### PR TITLE
Blocklist c.h

### DIFF
--- a/pgx-pg-sys/build.rs
+++ b/pgx-pg-sys/build.rs
@@ -584,6 +584,7 @@ fn run_bindgen(pg_config: &PgConfig, include_h: &PathBuf) -> eyre::Result<syn::F
         .blocklist_function("(?:pg_|p)v(?:sn?|f)?printf")
         .blocklist_function("appendStringInfoVA")
         .blocklist_file("stdarg.h")
+        .blocklist_file("c.h")
         // these cause cause warnings, errors, or deprecations on some systems,
         // and are not useful for us.
         .blocklist_function("(?:sigstack|sigreturn|siggetmask|gets|vfork|te?mpnam(?:_r)?|mktemp)")


### PR DESCRIPTION
This header is used by Postgres, but is not of real use to PGX, as all it does is include various internally-used interfaces. This also reduces about 1MB from the generated symbols.

It seems to work on our tested Linux distros:
https://github.com/tcdi/pgx/actions/runs/3653997966/jobs/6174023739

@thomcc This affects the bindings significantly.