### PR TITLE
Add `cargo pgrx info` command family

### DIFF
--- a/cargo-pgrx/README.md
+++ b/cargo-pgrx/README.md
@@ -20,33 +20,31 @@ As new versions of `pgrx` are released, you'll want to make sure you run this co
 
 ```shell script
 $ cargo pgrx --help
-cargo-pgrx 0.5.0
-ZomboDB, LLC <zombodb@gmail.com>
 Cargo subcommand for 'pgrx' to make Postgres extension development easy
 
-USAGE:
-    cargo pgrx [OPTIONS] <SUBCOMMAND>
+Usage: cargo pgrx [OPTIONS] <COMMAND>
 
-OPTIONS:
-    -h, --help       Print help information
-    -v, --verbose    Enable info logs, -vv for debug, -vvv for trace
-    -V, --version    Print version information
+Commands:
+  init     Initialize pgrx development environment for the first time
+  info     Provides information about pgrx-managed development environment
+  start    Start a pgrx-managed Postgres instance
+  stop     Stop a pgrx-managed Postgres instance
+  status   Is a pgrx-managed Postgres instance running?
+  new      Create a new extension crate
+  install  Install the extension from the current crate to the Postgres specified by whatever `pg_config` is currently on your $PATH
+  package  Create an installation package directory
+  schema   Generate extension schema files
+  run      Compile/install extension to a pgrx-managed Postgres instance and start psql
+  connect  Connect, via psql, to a Postgres instance
+  test     Run the test suite for this crate
+  get      Get a property from the extension control file
+  cross    Cargo subcommand for 'pgrx' to make Postgres extension development easy
+  help     Print this message or the help of the given subcommand(s)
 
-SUBCOMMANDS:
-    connect    Connect, via psql, to a Postgres instance
-    get        Get a property from the extension control file
-    help       Print this message or the help of the given subcommand(s)
-    init       Initialize pgrx development environment for the first time
-    install    Install the extension from the current crate to the Postgres specified by
-                   whatever `pg_config` is currently on your $PATH
-    new        Create a new extension crate
-    package    Create an installation package directory
-    run        Compile/install extension to a pgrx-managed Postgres instance and start psql
-    schema     Generate extension schema files
-    start      Start a pgrx-managed Postgres instance
-    status     Is a pgrx-managed Postgres instance running?
-    stop       Stop a pgrx-managed Postgres instance
-    test       Run the test suite for this crate
+Options:
+  -v, --verbose...  Enable info logs, -vv for debug, -vvv for trace
+  -h, --help        Print help
+  -V, --version     Print version
 ```
 
 ## Environment Variables
@@ -712,6 +710,29 @@ OPTIONS:
     -V, --version
             Print version information
 ```
+
+## Information about pgx-managed development environment
+
+```
+$ cargo pgx info --help
+Provides information about pgx-managed development environment
+
+Usage: cargo pgx info [OPTIONS] <COMMAND>
+
+Commands:
+  path       Print path to a base version of Postgres build
+  pg-config  Print path to pg_config for a base version of Postgres
+  version    Print specific version for a base Postgres version
+  help       Print this message or the help of the given subcommand(s)
+
+Options:
+  -v, --verbose...  Enable info logs, -vv for debug, -vvv for trace
+  -h, --help        Print help
+  -V, --version     Print version
+```
+
+`cargo pgx info` helps retrieving information about pgx-managed development
+environment (such as managed Postgres installations)
 
 ## EXPERIMENTAL: Versioned shared-object support
 

--- a/cargo-pgrx/src/command/info.rs
+++ b/cargo-pgrx/src/command/info.rs
@@ -1,0 +1,87 @@
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
+
+use crate::CommandExecute;
+use pgrx_pg_config::Pgrx;
+use std::borrow::Cow;
+
+/// Provides information about pgrx-managed development environment
+#[derive(clap::Args, Debug)]
+#[clap(author)]
+pub(crate) struct Info {
+    #[clap(subcommand)]
+    command: Subcommand,
+}
+
+#[derive(clap::Subcommand, Debug)]
+pub(crate) enum Subcommand {
+    /// Print path to a base version of Postgres build
+    ///
+    /// cargo pgrx info path 15 #=> ~/.pgrx/15.2/pgrx-install
+    Path {
+        /// Postgres version (12, 13, 14, 15...)
+        pg_ver: String,
+    },
+    /// Print path to pg_config for a base version of Postgres
+    ///
+    /// cargo pgrx info pg-config 15 #=> ~/.pgrx/15.2/pgrx-install/bin/pg_config
+    PgConfig {
+        /// Postgres version (12, 13, 14, 15...)
+        pg_ver: String,
+    },
+    /// Print specific version for a base Postgres version
+    ///
+    /// cargo pgrx info version 15 #=> 15.2
+    Version {
+        /// Postgres version (12, 13, 14, 15...)
+        pg_ver: String,
+    },
+}
+
+impl CommandExecute for Info {
+    #[tracing::instrument(level = "error", skip(self))]
+    fn execute(self) -> eyre::Result<()> {
+        let config = Pgrx::from_config()?;
+        match self.command {
+            Subcommand::Path { ref pg_ver } => {
+                println!(
+                    "{}",
+                    config
+                        .get(&version(pg_ver))?
+                        .parent_path()
+                        .parent()
+                        .ok_or(eyre::Error::msg("can't get path"))?
+                        .display()
+                );
+            }
+            Subcommand::PgConfig { ref pg_ver } => {
+                println!(
+                    "{}",
+                    config
+                        .get(&version(pg_ver))?
+                        .path()
+                        .ok_or(eyre::Error::msg("can't get path"))?
+                        .display()
+                );
+            }
+            Subcommand::Version { ref pg_ver } => {
+                println!("{}", config.get(&version(pg_ver))?.version()?);
+            }
+        }
+        Ok(())
+    }
+}
+
+fn version(ver: &str) -> Cow<str> {
+    if ver.starts_with("pg") {
+        Cow::Borrowed(ver)
+    } else {
+        Cow::Owned(format!("pg{}", ver))
+    }
+}

--- a/cargo-pgrx/src/command/mod.rs
+++ b/cargo-pgrx/src/command/mod.rs
@@ -13,6 +13,7 @@ use ureq::{Agent, AgentBuilder, Proxy};
 pub(crate) mod connect;
 pub(crate) mod cross;
 pub(crate) mod get;
+pub(crate) mod info;
 pub(crate) mod init;
 pub(crate) mod install;
 pub(crate) mod new;

--- a/cargo-pgrx/src/command/pgrx.rs
+++ b/cargo-pgrx/src/command/pgrx.rs
@@ -28,6 +28,7 @@ impl CommandExecute for Pgrx {
 #[derive(clap::Subcommand, Debug)]
 enum CargoPgrxSubCommands {
     Init(super::init::Init),
+    Info(super::info::Info),
     Start(super::start::Start),
     Stop(super::stop::Stop),
     Status(super::status::Status),
@@ -48,6 +49,7 @@ impl CommandExecute for CargoPgrxSubCommands {
         check_for_sql_generator_binary()?;
         match self {
             Init(c) => c.execute(),
+            Info(c) => c.execute(),
             Start(c) => c.execute(),
             Stop(c) => c.execute(),
             Status(c) => c.execute(),


### PR DESCRIPTION
At times it would have been very useful to be able to resolve version or path to pgx-managed Postgres installations.

Solution: add `cargo pgx info` command family