### PR TITLE
Fix broken links to zombodb/pgrx

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > Build Postgres Extensions with Rust!
 
-![cargo test --all](https://github.com/zombodb/pgrx/workflows/cargo%20test%20--all/badge.svg)
+![cargo test --all](https://github.com/tcdi/pgrx/workflows/cargo%20test%20--all/badge.svg)
 [![crates.io badge](https://img.shields.io/crates/v/pgrx.svg)](https://crates.io/crates/pgrx)
 [![docs.rs badge](https://docs.rs/pgrx/badge.svg)](https://docs.rs/pgrx)
 [![Twitter Follow](https://img.shields.io/twitter/follow/zombodb.svg?style=flat)](https://twitter.com/zombodb)

--- a/articles/forging-sql-from-rust.md
+++ b/articles/forging-sql-from-rust.md
@@ -1,7 +1,7 @@
 # Forging SQL from Rust
 <!-- Written 2021-09-20 -->
 
-PostgreSQL offers an extension interface, and it's my belief that Rust is a fantastic language to write extensions for it. [Eric Ridge](https://twitter.com/zombodb) thought so too, and started [`pgrx`](https://github.com/zombodb/pgrx) awhile back. I've been working with him to improve the toolkit, and wanted to share about one of our latest hacks: improving the generation of extension SQL code to interface with Rust.
+PostgreSQL offers an extension interface, and it's my belief that Rust is a fantastic language to write extensions for it. [Eric Ridge](https://twitter.com/zombodb) thought so too, and started [`pgrx`](https://github.com/tcdi/pgrx) awhile back. I've been working with him to improve the toolkit, and wanted to share about one of our latest hacks: improving the generation of extension SQL code to interface with Rust.
 
 This post is more on the advanced side, as it assumes knowledge of both Rust and PostgreSQL. We'll approach topics like foreign functions, dynamic linking, procedural macros, and linkers.
 

--- a/articles/postgresql-aggregates-with-rust.md
+++ b/articles/postgresql-aggregates-with-rust.md
@@ -914,8 +914,8 @@ Moving-aggregate mode is pretty new to me, and I'm still learning about it! If y
 
 If you're looking for more materials about aggregates, the TimescaleDB folks wrote about aggregates and how they impacted their hyperfunctions in [this article][timescaledb-article-aggregation]. Also, My pal [Tim McNamara][timclicks] wrote about how to implement harmonic and geometric means as aggregates in [this article][timclicks-article-aggregates].
 
-[pgrx]: https://github.com/zombodb/pgrx
-[pgrx-issues]: https://github.com/zombodb/pgrx/issues
+[pgrx]: https://github.com/tcdi/pgrx
+[pgrx-issues]: https://github.com/tcdi/pgrx/issues
 [pgrx-aggregate-aggregate]: https://docs.rs/pgrx/0.3.0/pgrx/aggregate/trait.Aggregate.html
 [pgrx-aggregate-aggregate-finalize]: https://docs.rs/pgrx/0.3.0/pgrx/aggregate/trait.Aggregate.html#tymethod.finalize
 [pgrx-aggregate-aggregate-state]: https://docs.rs/pgrx/0.3.0/pgrx/aggregate/trait.Aggregate.html#associatedtype.State
@@ -930,7 +930,7 @@ If you're looking for more materials about aggregates, the TimescaleDB folks wro
 [pgrx::datum::Internal]: https://docs.rs/pgrx/0.3.0/pgrx/datum/struct.Internal.html
 [pgrx-pg_aggregate]: https://docs.rs/pgrx/0.3.0/pgrx/attr.pg_aggregate.html
 [pgrx-postgrestype]: https://docs.rs/pgrx/0.3.0/pgrx/derive.PostgresType.html
-[pgrx-system-requirements]: https://github.com/zombodb/pgrx#system-requirements
+[pgrx-system-requirements]: https://github.com/tcdi/pgrx#system-requirements
 [plrust]: https://github.com/zombodb/plrust
 [rustup-rs]: https://rustup.rs/
 [wsl]: https://docs.microsoft.com/en-us/windows/wsl/install

--- a/cargo-pgrx/src/command/init.rs
+++ b/cargo-pgrx/src/command/init.rs
@@ -37,7 +37,7 @@ static PROCESS_ENV_DENYLIST: &'static [&'static str] = &[
     "OUT_DIR",
     "HOST",
     "NUM_JOBS",
-    "LIBRARY_PATH", // see https://github.com/zombodb/pgrx/issues/16
+    "LIBRARY_PATH", // see https://github.com/tcdi/pgrx/issues/16
 ];
 
 /// Initialize pgrx development environment for the first time

--- a/cargo-pgrx/src/command/pgrx.rs
+++ b/cargo-pgrx/src/command/pgrx.rs
@@ -71,7 +71,7 @@ fn check_for_sql_generator_binary() -> eyre::Result<()> {
         println!("{}", "\
             Found `pgrx` 0.2-0.3 series SQL generation while using `cargo-pgrx` 0.4 series.
             
-We've updated our SQL generation method, it's much faster! Please follow the upgrading steps listed in https://github.com/zombodb/pgrx/releases/tag/v0.4.0.
+We've updated our SQL generation method, it's much faster! Please follow the upgrading steps listed in https://github.com/tcdi/pgrx/releases/tag/v0.4.0.
 
 Already done that? You didn't delete `src/bin/sql-generator.rs` yet, so you're still seeing this message.\
         ".red().bold());

--- a/pgrx-tests/src/tests/fcinfo_tests.rs
+++ b/pgrx-tests/src/tests/fcinfo_tests.rs
@@ -99,7 +99,7 @@ fn same_name(same_name: &str) -> &str {
     same_name
 }
 
-// Tests for regression of https://github.com/zombodb/pgrx/issues/432
+// Tests for regression of https://github.com/tcdi/pgrx/issues/432
 #[pg_extern]
 fn fcinfo_renamed_one_arg(
     _x: PgBox<pg_sys::IndexAmRoutine>,


### PR DESCRIPTION
Some links to zombodb/pgx got replaced with zombodb/pgrx, which GitHub doesn't redirect here. This fixes them by updating those links to tcdi/pgrx. 