### PR TITLE
Use zero-copy Arrays in `--release`

### DIFF
--- a/pgrx-tests/src/tests/array_tests.rs
+++ b/pgrx-tests/src/tests/array_tests.rs
@@ -253,15 +253,16 @@ mod tests {
 
     #[pg_test]
     fn test_serde_serialize_array_i32() -> Result<(), pgrx::spi::Error> {
-        let json = Spi::get_one::<Json>("SELECT serde_serialize_array_i32(ARRAY[1,2,3,null, 4])")?
-            .expect("returned json was null");
-        assert_eq!(json.0, json! {{"values": [1,2,3,null,4]}});
+        let json =
+            Spi::get_one::<Json>("SELECT serde_serialize_array_i32(ARRAY[1,null,2,3,null, 4, 5])")?
+                .expect("returned json was null");
+        assert_eq!(json.0, json! {{"values": [1,null,2,3,null,4, 5]}});
         Ok(())
     }
 
     #[pg_test(error = "array contains NULL")]
     fn test_serde_serialize_array_i32_deny_null() -> Result<Option<Json>, pgrx::spi::Error> {
-        Spi::get_one::<Json>("SELECT serde_serialize_array_i32_deny_null(ARRAY[1,2,3,null, 4])")
+        Spi::get_one::<Json>("SELECT serde_serialize_array_i32_deny_null(ARRAY[1,2,3,null, 4, 5])")
     }
 
     #[pg_test]
@@ -278,7 +279,7 @@ mod tests {
 
     #[pg_test]
     fn test_slice_to_array() -> Result<(), pgrx::spi::Error> {
-        let owned_vec = vec![Some(1), Some(2), Some(3), None, Some(4)];
+        let owned_vec = vec![Some(1), None, Some(2), Some(3), None, Some(4), Some(5)];
         let json = Spi::connect(|client| {
             client
                 .select(
@@ -293,7 +294,7 @@ mod tests {
                 .get_one::<Json>()
         })?
         .expect("Failed to return json even though it's right there ^^");
-        assert_eq!(json.0, json! {{"values": [1, 2, 3, null, 4]}});
+        assert_eq!(json.0, json! {{"values": [1, null, 2, 3, null, 4, 5]}});
         Ok(())
     }
 

--- a/pgrx-tests/src/tests/array_tests.rs
+++ b/pgrx-tests/src/tests/array_tests.rs
@@ -253,16 +253,19 @@ mod tests {
 
     #[pg_test]
     fn test_serde_serialize_array_i32() -> Result<(), pgrx::spi::Error> {
-        let json =
-            Spi::get_one::<Json>("SELECT serde_serialize_array_i32(ARRAY[1,null,2,3,null, 4, 5])")?
-                .expect("returned json was null");
+        let json = Spi::get_one::<Json>(
+            "SELECT serde_serialize_array_i32(ARRAY[1, null, 2, 3, null, 4, 5])",
+        )?
+        .expect("returned json was null");
         assert_eq!(json.0, json! {{"values": [1,null,2,3,null,4, 5]}});
         Ok(())
     }
 
     #[pg_test(error = "array contains NULL")]
     fn test_serde_serialize_array_i32_deny_null() -> Result<Option<Json>, pgrx::spi::Error> {
-        Spi::get_one::<Json>("SELECT serde_serialize_array_i32_deny_null(ARRAY[1,2,3,null, 4, 5])")
+        Spi::get_one::<Json>(
+            "SELECT serde_serialize_array_i32_deny_null(ARRAY[1, 2, 3, null, 4, 5])",
+        )
     }
 
     #[pg_test]

--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -239,6 +239,7 @@ impl RawArray {
     ) -> (*mut pg_sys::Datum, *mut bool) {
         let oid = self.oid();
         let array = self.ptr.as_ptr();
+
         // outvals for deconstruct_array
         let mut elements = core::ptr::null_mut();
         let mut nulls = core::ptr::null_mut();
@@ -490,7 +491,7 @@ impl RawArray {
         }
     }
 
-    pub(crate) fn data_ptr(&self) -> *mut u8 {
+    pub(crate) fn data_ptr(&self) -> *const u8 {
         unsafe { ARR_DATA_PTR(self.ptr.as_ptr()) }
     }
 
@@ -505,6 +506,12 @@ impl RawArray {
             ))
             .as_ptr()
         }
+    }
+
+    /// "one past the end" pointer for the entire array's bytes
+    pub(crate) fn end_ptr(&self) -> *const u8 {
+        let ptr = self.ptr.as_ptr().cast::<u8>();
+        ptr.wrapping_add(unsafe { crate::varlena::varsize_any(ptr.cast()) })
     }
 }
 

--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -1,6 +1,6 @@
 use crate::datum::{Array, FromDatum};
+use crate::layout::{Layout, PassBy, Size};
 use crate::pg_sys;
-use crate::layout::{Layout, PassBy};
 use crate::toast::{Toast, Toasty};
 use bitvec::prelude::*;
 use bitvec::ptr::{bitslice_from_raw_parts_mut, BitPtr, BitPtrError, Mut};
@@ -486,6 +486,10 @@ impl RawArray {
                 self.len,
             ))
         }
+    }
+
+    pub(crate) fn byte_ptr(&self) -> *mut u8 {
+        unsafe { ARR_DATA_PTR(self.ptr.as_ptr()) }
     }
 
     /// # Safety

--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -520,7 +520,7 @@ impl Toasty for RawArray {
         unsafe { RawArray::detoast_from_varlena(self.into_ptr().cast()) }
     }
 
-    fn drop_toast(&mut self) {
+    unsafe fn drop_toast(&mut self) {
         unsafe { pg_sys::pfree(self.ptr.as_ptr().cast()) }
     }
 }

--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -233,10 +233,9 @@ impl RawArray {
         }
     }
 
-    pub(crate) unsafe fn deconstruct(&mut self) -> (Layout, *mut pg_sys::Datum, *mut bool, usize) {
+    pub(crate) unsafe fn deconstruct(&mut self, layout: Layout) -> (*mut pg_sys::Datum, *mut bool) {
         let oid = self.oid();
         let array = self.ptr.as_ptr();
-        let elem_layout = Layout::lookup_oid(oid);
         // outvals for deconstruct_array
         let mut elements = ptr::null_mut();
         let mut nulls = ptr::null_mut();
@@ -246,15 +245,15 @@ impl RawArray {
             pg_sys::deconstruct_array(
                 array,
                 oid,
-                elem_layout.size.as_typlen().into(),
-                matches!(elem_layout.pass, PassBy::Value),
-                elem_layout.align.as_typalign(),
+                layout.size.as_typlen().into(),
+                matches!(layout.pass, PassBy::Value),
+                layout.align.as_typalign(),
                 &mut elements,
                 &mut nulls,
                 &mut nelems,
             );
 
-            (elem_layout, elements, nulls, nelems as usize)
+            (elements, nulls)
         }
     }
 

--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -490,7 +490,7 @@ impl RawArray {
         }
     }
 
-    pub(crate) fn byte_ptr(&self) -> *mut u8 {
+    pub(crate) fn data_ptr(&self) -> *mut u8 {
         unsafe { ARR_DATA_PTR(self.ptr.as_ptr()) }
     }
 

--- a/pgrx/src/datum/array.rs
+++ b/pgrx/src/datum/array.rs
@@ -144,6 +144,9 @@ impl<'a, T: FromDatum> Array<'a, T> {
     /// Note that Array may have caused Postgres to allocate to unbox the datum,
     /// and this can hypothetically cause a memory leak if so.
     pub fn into_array_type(self) -> *const pg_sys::ArrayType {
+        // may be worth replacing this function when Toast<T> matures enough
+        // to be used as a public type with a fn(self) -> Toast<RawArray>
+
         let Array { raw, datum_slice, .. } = self;
         let _ = datum_slice;
         // Wrap the Toast<RawArray> to prevent it from deallocating itself

--- a/pgrx/src/datum/array.rs
+++ b/pgrx/src/datum/array.rs
@@ -200,7 +200,7 @@ impl<'a, T: FromDatum> Array<'a, T> {
     #[allow(clippy::option_option)]
     #[inline]
     pub fn get(&self, index: usize) -> Option<Option<T>> {
-        let is_null = self.null_slice.get(index)?;
+        let Some(is_null) = self.null_slice.get(index) else { return None };
         if is_null {
             return Some(None);
         }
@@ -410,7 +410,7 @@ impl<'a, T: FromDatum> Iterator for ArrayIterator<'a, T> {
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         let Self { array, curr, ptr } = self;
-        let is_null = array.null_slice.get(*curr)?;
+        let Some(is_null) = array.null_slice.get(*curr) else { return None };
         let element = unsafe { array.bring_it_back_now(*ptr, *curr, is_null) };
         *curr += 1;
         if let Some(false) = array.null_slice.get(*curr) {
@@ -452,7 +452,7 @@ impl<'a, T: FromDatum> Iterator for ArrayIntoIterator<'a, T> {
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         let Self { array, curr, ptr } = self;
-        let is_null = array.null_slice.get(*curr)?;
+        let Some(is_null) = array.null_slice.get(*curr) else { return None };
         let element = unsafe { array.bring_it_back_now(*ptr, *curr, is_null) };
         *curr += 1;
         if let Some(false) = array.null_slice.get(*curr) {
@@ -499,7 +499,7 @@ impl<'a, T: FromDatum> FromDatum for Array<'a, T> {
         if is_null {
             None
         } else {
-            let ptr = NonNull::new(datum.cast_mut_ptr())?;
+            let Some(ptr) = NonNull::new(datum.cast_mut_ptr()) else { return None };
             let raw = RawArray::detoast_from_varlena(ptr);
             Some(Array::deconstruct_from(raw))
         }

--- a/pgrx/src/datum/array.rs
+++ b/pgrx/src/datum/array.rs
@@ -129,6 +129,15 @@ impl<'a, T: FromDatum> Array<'a, T> {
             panic!("oh no, the debug code exploded!")
         };
 
+        // The array-walking code assumes this is always the case, is it?
+        if let Layout { size: Size::Fixed(n), align, .. } = elem_layout {
+            let n: usize = n.into();
+            assert!(
+                n % (align.as_usize()) == 0,
+                "typlen does NOT include padding for fixed-width layouts!"
+            );
+        }
+
         Array { raw, nelems, _datum_slice, null_slice, elem_layout, _marker: PhantomData }
     }
 

--- a/pgrx/src/datum/array.rs
+++ b/pgrx/src/datum/array.rs
@@ -207,6 +207,11 @@ impl<'a, T: FromDatum> Array<'a, T> {
             return Some(None);
         }
 
+        // This pointer is what's walked over the entire array's data buffer.
+        // If the array has varlena or cstr elements, we can't index into the array.
+        // If the elements are fixed size, we could, but we do not exploit that optimization yet
+        // as it would significantly complicate the code and impact debugging it.
+        // Such improvements should wait until a later version (today's: 0.7.4, preparing 0.8.0).
         let mut at_byte = self.raw.data_ptr();
         for i in 0..index {
             match self.null_slice.get(i) {

--- a/pgrx/src/datum/array.rs
+++ b/pgrx/src/datum/array.rs
@@ -292,6 +292,9 @@ impl<'a, T: FromDatum> Array<'a, T> {
                 unsafe {
                     for _ in 0..idx {
                         let varsize = varlena::varsize_any(at_byte.cast());
+                        // this DOES NOT match Postgres realignment code in form
+                        // I suspect it matches in function, but theirs is micro-optimized
+                        // so we probably need a battery of tests for this
                         let align_mask = varsize & (align - 1);
                         let align_offset = if align_mask != 0 { align - align_mask } else { 0 };
                         at_byte = at_byte.add(varsize + align_offset);

--- a/pgrx/src/datum/array.rs
+++ b/pgrx/src/datum/array.rs
@@ -9,9 +9,9 @@ Use of this source code is governed by the MIT license that can be found in the 
 
 use crate::array::RawArray;
 use crate::layout::*;
-use crate::varlena;
 use crate::slice::PallocSlice;
 use crate::toast::Toast;
+use crate::varlena;
 use crate::{pg_sys, FromDatum, IntoDatum, PgMemoryContexts};
 use bitvec::slice::BitSlice;
 use core::ops::DerefMut;
@@ -59,7 +59,7 @@ fn with_vec(elems: Array<String>) {
 pub struct Array<'a, T: FromDatum> {
     nelems: usize,
     // Remove this field if/when we figure out how to stop using pg_sys::deconstruct_array
-    datum_slice: Option<PallocSlice<pg_sys::Datum>>,
+    elem_slice: ElemSlice<T>,
     null_slice: NullKind<'a>,
     elem_layout: Layout,
     // Rust drops in FIFO order, drop this last
@@ -91,6 +91,20 @@ impl NullKind<'_> {
     }
 }
 
+enum ElemSlice<T: FromDatum> {
+    Datum(PallocSlice<pg_sys::Datum>),
+    Bare(NonNull<[mem::MaybeUninit<T>]>),
+}
+
+impl<T: FromDatum> ElemSlice<T> {
+    unsafe fn get(&self, idx: usize, is_null: bool, oid: pg_sys::Oid) -> Option<T> {
+        match self {
+            ElemSlice::Bare(slice) => (!is_null).then(|| slice.as_ref()[idx].assume_init_read()),
+            ElemSlice::Datum(slice) => T::from_polymorphic_datum(*(slice.get(idx)?), is_null, oid),
+        }
+    }
+}
+
 impl<'a, T: FromDatum + serde::Serialize> serde::Serialize for Array<'a, T> {
     fn serialize<S>(&self, serializer: S) -> Result<<S as Serializer>::Ok, <S as Serializer>::Error>
     where
@@ -107,38 +121,48 @@ impl<'a, T: FromDatum> Array<'a, T> {
     /// This function requires that the RawArray was obtained in a properly-constructed form
     /// (probably from Postgres).
     unsafe fn deconstruct_from(mut raw: Toast<RawArray>) -> Array<'a, T> {
-        /*
-        FIXME(jubilee): This way of getting array buffers causes problems for any Drop impl,
-        and clashes with assumptions of Array being a "zero-copy", lifetime-bound array,
-        some of which are implicitly embedded in other methods (e.g. Array::over).
-        It also risks leaking memory, as deconstruct_array calls palloc.
-
-        SAFETY: We have already asserted the validity of the RawArray, so
-        this only makes mistakes if we mix things up and pass Postgres the wrong data.
-        */
-        let (elem_layout, elements, nulls, nelems) = unsafe { raw.deconstruct() };
-
+        let oid = raw.oid();
+        let elem_layout = Layout::lookup_oid(oid);
+        let nelems = raw.len();
         let null_slice = raw
             .nulls_bitslice()
             .map(|nonnull| NullKind::Bits(unsafe { &*nonnull.as_ptr() }))
             .unwrap_or(NullKind::Strict(nelems));
+        if let (NullKind::Strict(_), Layout { size: Size::Fixed(_), pass: PassBy::Value, .. }) =
+            (&null_slice, elem_layout)
+        {
+            let elem_slice = ElemSlice::Bare(raw.data());
+            Array { raw, nelems, elem_slice, null_slice, elem_layout, _marker: PhantomData }
+        } else {
+            /*
+            FIXME(jubilee): This way of getting array buffers causes problems for any Drop impl,
+            and clashes with assumptions of Array being a "zero-copy", lifetime-bound array.
+            It also risks leaking memory, as deconstruct_array calls palloc.
 
-        // The array was just deconstructed, which allocates twice: effectively [Datum] and [bool].
-        // But pgrx doesn't actually need [bool] if NullKind's handling of BitSlices is correct.
-        // So, assert correctness of the NullKind implementation and cleanup.
-        // SAFETY: The pointer we got should be correctly constructed for slice validity.
-        let pallocd_null_slice =
-            unsafe { PallocSlice::from_raw_parts(NonNull::new(nulls).unwrap(), nelems) };
-        #[cfg(debug_assertions)]
-        for i in 0..nelems {
-            assert!(null_slice.get(i).unwrap().eq(unsafe { pallocd_null_slice.get_unchecked(i) }));
+            SAFETY: We have already asserted the validity of the RawArray, so
+            this only makes mistakes if we mix things up and pass Postgres the wrong data.
+            */
+            let (elements, nulls) = unsafe { raw.deconstruct(elem_layout) };
+            // The array was just deconstructed, which allocates twice: effectively [Datum] and [bool].
+            // But pgx doesn't actually need [bool] if NullKind's handling of BitSlices is correct.
+            // So, assert correctness of the NullKind implementation and cleanup.
+            // SAFETY: The pointer we got should be correctly constructed for slice validity.
+            let pallocd_null_slice =
+                unsafe { PallocSlice::from_raw_parts(NonNull::new(nulls).unwrap(), nelems) };
+            #[cfg(debug_assertions)]
+            for i in 0..nelems {
+                assert!(null_slice
+                    .get(i)
+                    .unwrap()
+                    .eq(unsafe { pallocd_null_slice.get_unchecked(i) }));
+            }
+
+            // SAFETY: This was just handed over as a palloc, so of course we can do this.
+            let elem_slice = ElemSlice::Datum(unsafe {
+                PallocSlice::from_raw_parts(NonNull::new(elements).unwrap(), nelems)
+            });
+            Array { raw, nelems, elem_slice, null_slice, elem_layout, _marker: PhantomData }
         }
-
-        // SAFETY: This was just handed over as a palloc, so of course we can do this.
-        let datum_slice =
-            Some(unsafe { PallocSlice::from_raw_parts(NonNull::new(elements).unwrap(), nelems) });
-
-        Array { raw, nelems, datum_slice, null_slice, elem_layout, _marker: PhantomData }
     }
 
     /// Rips out the underlying pg_sys::ArrayType pointer.
@@ -148,8 +172,8 @@ impl<'a, T: FromDatum> Array<'a, T> {
         // may be worth replacing this function when Toast<T> matures enough
         // to be used as a public type with a fn(self) -> Toast<RawArray>
 
-        let Array { raw, datum_slice, .. } = self;
-        let _ = datum_slice;
+        let Array { raw, elem_slice, .. } = self;
+        let _ = elem_slice;
         // Wrap the Toast<RawArray> to prevent it from deallocating itself
         let mut raw = core::mem::ManuallyDrop::new(raw);
         let ptr = raw.deref_mut().deref_mut() as *mut RawArray;
@@ -212,13 +236,7 @@ impl<'a, T: FromDatum> Array<'a, T> {
         if i >= self.nelems {
             None
         } else {
-            Some(unsafe {
-                T::from_polymorphic_datum(
-                    *(self.datum_slice.as_ref()?.get(i)?),
-                    self.null_slice.get(i)?,
-                    self.raw.oid(),
-                )
-            })
+            Some(unsafe { self.elem_slice.get(i, self.null_slice.get(i)?, self.raw.oid()) })
         }
     }
 
@@ -258,11 +276,15 @@ impl<'a, T: FromDatum> Array<'a, T> {
                 }
             }
             Size::Varlena => {
+                // In this branch, we have to be mindful of alignment.
+                let mut at_byte = at_byte;
+                let align = self.elem_layout.align.as_usize();
                 unsafe {
-                    let mut at_byte = at_byte;
                     for _ in 0..idx {
-                        let offset = varlena::varsize_any(at_byte.cast());
-                        at_byte = at_byte.add(offset);
+                        let varsize = varlena::varsize_any(at_byte.cast());
+                        let align_off = varsize & (align - 1);
+                        at_byte = at_byte
+                            .add(varsize + if align_off != 0 { align - align_off } else { 0 });
                     }
                     let datum = pg_sys::Datum::from(at_byte);
                     T::from_polymorphic_datum(datum, is_null, self.raw.oid())

--- a/pgrx/src/datum/array.rs
+++ b/pgrx/src/datum/array.rs
@@ -69,9 +69,6 @@ pub struct Array<'a, T: FromDatum> {
     _marker: PhantomData<T>,
 }
 
-// FIXME: When Array::over gets removed, this enum can probably be dropped
-// since we won't be entertaining ArrayTypes which don't use bitslices anymore.
-// However, we could also use a static resolution? Hard to say what's best.
 enum NullKind<'a> {
     Bits(&'a BitSlice<u8>),
     Strict(usize),
@@ -181,7 +178,7 @@ impl<'a, T: FromDatum> Array<'a, T> {
     ///
     /// This function will panic when called if the array contains any SQL NULL values.
     pub fn iter_deny_null(&self) -> ArrayTypedIterator<'_, T> {
-        if unsafe { self.raw.any_nulls() } {
+        if self.null_slice.any() {
             panic!("array contains NULL");
         }
 

--- a/pgrx/src/datum/array.rs
+++ b/pgrx/src/datum/array.rs
@@ -209,8 +209,7 @@ impl<'a, T: FromDatum> Array<'a, T> {
         let mut at_byte = self.raw.data_ptr();
         for i in 0..index {
             match self.null_slice.get(i) {
-                // SAFETY: Assured via earlier check that guarantees index is in-bounds
-                None => unsafe { core::hint::unreachable_unchecked() },
+                None => unreachable!("array was exceeded while walking to known non-null index???"),
                 // Skip nulls: the data buffer has no placeholders for them!
                 Some(true) => continue,
                 Some(false) => {

--- a/pgrx/src/datum/array.rs
+++ b/pgrx/src/datum/array.rs
@@ -121,7 +121,9 @@ impl<'a, T: FromDatum> Array<'a, T> {
 
         #[cfg(debug_assertions)]
         let Ok(()) = _datum_slice.set(unsafe {
-            let (datums, _bools) = raw.deconstruct(elem_layout);
+            let (datums, bools) = raw.deconstruct(elem_layout);
+            // Don't need this.
+            pg_sys::pfree(bools.cast());
             PallocSlice::from_raw_parts(NonNull::new(datums).unwrap(), nelems)
         }) else {
             panic!("oh no, the debug code exploded!")

--- a/pgrx/src/layout.rs
+++ b/pgrx/src/layout.rs
@@ -97,6 +97,7 @@ impl Align {
         }
     }
 
+    #[cfg(debug_assertions)]
     pub(crate) fn as_typalign(self) -> libc::c_char {
         (match self {
             Align::Byte => TYPALIGN_CHAR,
@@ -127,6 +128,7 @@ impl TryFrom<i16> for Size {
 }
 
 impl Size {
+    #[cfg(debug_assertions)]
     pub(crate) fn as_typlen(&self) -> i16 {
         match self {
             Self::CStr => -2,

--- a/pgrx/src/layout.rs
+++ b/pgrx/src/layout.rs
@@ -88,7 +88,16 @@ impl TryFrom<libc::c_char> for Align {
 }
 
 impl Align {
-    pub(crate) fn as_typalign(&self) -> libc::c_char {
+    pub(crate) fn as_usize(self) -> usize {
+        match self {
+            Align::Byte => mem::align_of::<libc::c_char>(),
+            Align::Short => mem::align_of::<libc::c_short>(),
+            Align::Int => mem::align_of::<libc::c_int>(),
+            Align::Double => mem::align_of::<libc::c_double>(),
+        }
+    }
+
+    pub(crate) fn as_typalign(self) -> libc::c_char {
         (match self {
             Align::Byte => TYPALIGN_CHAR,
             Align::Short => TYPALIGN_SHORT,

--- a/pgrx/src/lib.rs
+++ b/pgrx/src/lib.rs
@@ -81,6 +81,7 @@ pub use once_cell;
 /// Not ready for public exposure.
 mod layout;
 mod slice;
+mod toast;
 
 pub use aggregate::*;
 pub use atomics::*;

--- a/pgrx/src/slice.rs
+++ b/pgrx/src/slice.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 use core::marker::PhantomData;
-use core::ptr::{self, NonNull};
+use core::ptr;
 
 /// PallocSlice is between slice and Vec: PallocSlice does not assume the underlying T is valid for all indices
 /// and so does not implement the safe trait Index, but does let you call an `unsafe fn get` to do so,
@@ -9,14 +9,15 @@ use core::ptr::{self, NonNull};
 /// Note that while it's technically not lifetime-bound, it's still bound to the lifetime of the memory context.
 /// You should use this inside types that are themselves lifetime-bound to prevent inappropriate "escape".
 pub struct PallocSlice<T> {
-    pallocd: NonNull<[T]>,
+    pallocd: ptr::NonNull<[T]>,
     _phantom: PhantomData<Box<[T]>>,
 }
 
+#[cfg(debug_assertions)]
 impl<T> PallocSlice<T> {
-    pub unsafe fn from_raw_parts(ptr: NonNull<T>, len: usize) -> Self {
+    pub unsafe fn from_raw_parts(ptr: ptr::NonNull<T>, len: usize) -> Self {
         PallocSlice {
-            pallocd: NonNull::new_unchecked(ptr::slice_from_raw_parts_mut(ptr.as_ptr(), len)),
+            pallocd: ptr::NonNull::new_unchecked(ptr::slice_from_raw_parts_mut(ptr.as_ptr(), len)),
             _phantom: PhantomData,
         }
     }

--- a/pgrx/src/toast.rs
+++ b/pgrx/src/toast.rs
@@ -1,0 +1,44 @@
+use core::ops::{Deref, DerefMut};
+
+pub(crate) enum Toast<T>
+where
+    T: Toasty,
+{
+    Stale(T),
+    Fresh(T),
+}
+
+pub(crate) trait Toasty: Sized {
+    fn detoast(self) -> Toast<Self>;
+    /// Why does it always land butter-side down?
+    fn drop_toast(&mut self);
+}
+
+impl<T: Toasty> Drop for Toast<T> {
+    fn drop(&mut self) {
+        match self {
+            Toast::Stale(_) => {}
+            Toast::Fresh(t) => t.drop_toast(),
+        }
+    }
+}
+
+impl<T: Toasty> Deref for Toast<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Toast::Stale(t) => &t,
+            Toast::Fresh(t) => &t,
+        }
+    }
+}
+
+impl<T: Toasty> DerefMut for Toast<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        match self {
+            Toast::Stale(ref mut t) => t,
+            Toast::Fresh(ref mut t) => t,
+        }
+    }
+}

--- a/pgrx/src/toast.rs
+++ b/pgrx/src/toast.rs
@@ -11,14 +11,14 @@ where
 pub(crate) trait Toasty: Sized {
     fn detoast(self) -> Toast<Self>;
     /// Why does it always land butter-side down?
-    fn drop_toast(&mut self);
+    unsafe fn drop_toast(&mut self);
 }
 
 impl<T: Toasty> Drop for Toast<T> {
     fn drop(&mut self) {
         match self {
             Toast::Stale(_) => {}
-            Toast::Fresh(t) => t.drop_toast(),
+            Toast::Fresh(t) => unsafe { t.drop_toast() },
         }
     }
 }


### PR DESCRIPTION
This introduces a pile of "array-walking" code to implement truly "zero-copy" arrays... in release mode. It may make tests notably slower for a bit, because it includes a pile of assertions. Afterwards, a lot of the code, especially the assertion code, can be pared back, simplified, or changed into less high-overhead forms once this has been tested to our satisfaction. Ultimately, I prioritized correctness against the previous behavior of our library rather than validating against Postgres per se (because it's not as clear that our new behavior will correctly model Postgres).

There are no external, user-facing API changes required to take advantage of this. In the future we may wish to consider such, as there are further improvements atop this in terms of correctness and performance to be had.