### PR TITLE
Remove `Array::as_slice`

### DIFF
--- a/pgrx-tests/src/tests/array_tests.rs
+++ b/pgrx-tests/src/tests/array_tests.rs
@@ -131,7 +131,7 @@ fn arr_mapped_vec(arr: Array<i32>) -> Vec<i32> {
     arr.iter().filter_map(|x| x).collect()
 }
 
-/// Naive conversion. This causes errors if Array::as_slice doesn't handle differently sized slices well.
+/// Naive conversion.
 #[pg_extern]
 #[allow(deprecated)]
 fn arr_into_vec(arr: Array<i32>) -> Vec<i32> {
@@ -169,18 +169,6 @@ mod tests {
         assert_eq!(sum, Ok(Some(6)));
     }
 
-    #[pg_test]
-    fn test_sum_array_i32_sliced() {
-        let sum = Spi::get_one::<i32>("SELECT sum_array_sliced(ARRAY[1,2,3]::integer[])");
-        assert_eq!(sum, Ok(Some(6)));
-    }
-
-    #[pg_test]
-    fn test_sum_array_i64_sliced() {
-        let sum = Spi::get_one::<i64>("SELECT sum_array_sliced(ARRAY[1,2,3]::bigint[])");
-        assert_eq!(sum, Ok(Some(6)));
-    }
-
     #[pg_test(error = "attempt to add with overflow")]
     fn test_sum_array_i32_overflow() -> Result<Option<i64>, pgrx::spi::Error> {
         Spi::get_one::<i64>(
@@ -191,12 +179,6 @@ mod tests {
     #[pg_test]
     fn test_count_true() {
         let cnt = Spi::get_one::<i32>("SELECT count_true(ARRAY[true, true, false, true])");
-        assert_eq!(cnt, Ok(Some(3)));
-    }
-
-    #[pg_test]
-    fn test_count_true_sliced() {
-        let cnt = Spi::get_one::<i32>("SELECT count_true_sliced(ARRAY[true, true, false, true])");
         assert_eq!(cnt, Ok(Some(3)));
     }
 

--- a/pgrx-tests/src/tests/array_tests.rs
+++ b/pgrx-tests/src/tests/array_tests.rs
@@ -34,27 +34,9 @@ fn sum_array_i64(values: Array<i64>) -> i64 {
     values.iter().map(|v| v.unwrap_or(0i64)).sum()
 }
 
-#[pg_extern(name = "sum_array_sliced")]
-#[allow(deprecated)]
-fn sum_array_i32_sliced(values: Array<i32>) -> i32 {
-    unsafe { values.as_slice() }.iter().sum()
-}
-
-#[pg_extern(name = "sum_array_sliced")]
-#[allow(deprecated)]
-fn sum_array_i64_sliced(values: Array<i64>) -> i64 {
-    unsafe { values.as_slice() }.iter().sum()
-}
-
 #[pg_extern]
 fn count_true(values: Array<bool>) -> i32 {
     values.iter().filter(|b| b.unwrap_or(false)).count() as i32
-}
-
-#[pg_extern]
-#[allow(deprecated)]
-fn count_true_sliced(values: Array<bool>) -> i32 {
-    unsafe { values.as_slice() }.iter().filter(|b| **b).count() as i32
 }
 
 #[pg_extern]
@@ -153,13 +135,13 @@ fn arr_mapped_vec(arr: Array<i32>) -> Vec<i32> {
 #[pg_extern]
 #[allow(deprecated)]
 fn arr_into_vec(arr: Array<i32>) -> Vec<i32> {
-    unsafe { arr.as_slice() }.to_vec()
+    arr.iter_deny_null().collect()
 }
 
 #[pg_extern]
 #[allow(deprecated)]
 fn arr_sort_uniq(arr: Array<i32>) -> Vec<i32> {
-    let mut v: Vec<i32> = unsafe { arr.as_slice() }.into();
+    let mut v: Vec<i32> = arr.iter_deny_null().collect();
     v.sort();
     v.dedup();
     v

--- a/pgrx-tests/src/tests/heap_tuple.rs
+++ b/pgrx-tests/src/tests/heap_tuple.rs
@@ -118,22 +118,6 @@ mod arguments {
             }
             names
         }
-
-        #[pg_extern]
-        #[allow(deprecated)]
-        fn gets_name_field_as_slice(
-            dogs: VariadicArray<pgrx::composite_type!(DOG_COMPOSITE_TYPE)>,
-        ) -> Vec<String> {
-            // Gets resolved to:
-            let dogs: pgrx::VariadicArray<PgHeapTuple<AllocatedByRust>> = dogs;
-
-            let mut names = Vec::with_capacity(dogs.len());
-            for dog in unsafe { dogs.as_slice() } {
-                let name = dog.get_by_name("name").unwrap().unwrap();
-                names.push(name);
-            }
-            names
-        }
     }
 
     mod vec {
@@ -679,17 +663,6 @@ mod tests {
         let retval = Spi::get_one::<Vec<String>>(
             "
             SELECT gets_name_field_variadic(ROW('Nami', 1)::Dog, ROW('Brandy', 1)::Dog)
-        ",
-        );
-        assert_eq!(retval, Ok(Some(vec!["Nami".to_string(), "Brandy".to_string()])));
-    }
-
-    #[pg_test]
-    #[should_panic]
-    fn test_gets_name_field_as_slice() {
-        let retval = Spi::get_one::<Vec<String>>(
-            "
-            SELECT gets_name_field_as_slice(ROW('Nami', 1)::Dog, ROW('Brandy', 1)::Dog)
         ",
         );
         assert_eq!(retval, Ok(Some(vec!["Nami".to_string(), "Brandy".to_string()])));

--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -495,19 +495,6 @@ impl RawArray {
         unsafe { ARR_DATA_PTR(self.ptr.as_ptr()) }
     }
 
-    /// # Safety
-    /// See the entire thing just above. You're now instantly asserting validity for the slice.
-    pub(crate) unsafe fn assume_init_data_slice<T>(&self) -> &[T] {
-        // SAFETY: Assertion made by caller
-        unsafe {
-            &*NonNull::new_unchecked(slice_from_raw_parts_mut(
-                ARR_DATA_PTR(self.ptr.as_ptr()).cast(),
-                self.len,
-            ))
-            .as_ptr()
-        }
-    }
-
     /// "one past the end" pointer for the entire array's bytes
     pub(crate) fn end_ptr(&self) -> *const u8 {
         let ptr = self.ptr.as_ptr().cast::<u8>();

--- a/pgrx/src/datum/array.rs
+++ b/pgrx/src/datum/array.rs
@@ -23,7 +23,6 @@ use pgrx_sql_entity_graph::metadata::{
 };
 use serde::Serializer;
 use std::marker::PhantomData;
-use std::mem;
 
 /** An array of some type (eg. `TEXT[]`, `int[]`)
 
@@ -154,29 +153,6 @@ impl<'a, T: FromDatum> Array<'a, T> {
         let ptr = raw.deref_mut().deref_mut() as *mut RawArray;
         // SAFETY: Leaks are safe if they aren't use-after-frees!
         unsafe { ptr.read() }.into_ptr().as_ptr() as _
-    }
-
-    // # Panics
-    //
-    // Panics if it detects the slightest misalignment between types,
-    // or if a valid slice contains nulls, which may be uninit data.
-    #[deprecated(
-        since = "0.5.0",
-        note = "this function cannot be safe and is not generically sound\n\
-        even `unsafe fn as_slice(&self) -> &[T]` is not sound for all `&[T]`\n\
-        if you are sure your usage is sound, consider RawArray"
-    )]
-    pub unsafe fn as_slice(&self) -> &[T] {
-        const DATUM_SIZE: usize = mem::size_of::<pg_sys::Datum>();
-        if self.null_slice.any() {
-            panic!("null detected: can't expose potentially uninit data as a slice!")
-        }
-        match self.elem_layout.size_matches::<T>() {
-            // SAFETY: Rust slice layout matches Postgres data layout and this array is "owned"
-            #[allow(unreachable_patterns)] // happens on 32-bit when DATUM_SIZE = 4
-            Some(1 | 2 | 4 | DATUM_SIZE) => unsafe { self.raw.assume_init_data_slice::<T>() },
-            _ => panic!("no correctly-sized slice exists"),
-        }
     }
 
     /// Return an iterator of `Option<T>`.
@@ -333,21 +309,6 @@ impl<'a, T: FromDatum + serde::Serialize> serde::Serialize for VariadicArray<'a,
 impl<'a, T: FromDatum> VariadicArray<'a, T> {
     pub fn into_array_type(self) -> *const pg_sys::ArrayType {
         self.0.into_array_type()
-    }
-
-    // # Panics
-    //
-    // Panics if it detects the slightest misalignment between types,
-    // or if a valid slice contains nulls, which may be uninit data.
-    #[deprecated(
-        since = "0.5.0",
-        note = "this function cannot be safe and is not generically sound\n\
-        even `unsafe fn as_slice(&self) -> &[T]` is not sound for all `&[T]`\n\
-        if you are sure your usage is sound, consider RawArray"
-    )]
-    #[allow(deprecated)]
-    pub unsafe fn as_slice(&self) -> &[T] {
-        self.0.as_slice()
     }
 
     /// Return an Iterator of Option<T> over the contained Datums.

--- a/pgrx/src/layout.rs
+++ b/pgrx/src/layout.rs
@@ -49,20 +49,6 @@ impl Layout {
             pass: if passbyval { PassBy::Value } else { PassBy::Ref },
         }
     }
-
-    // Attempt to discern if a given Postgres and Rust layout are "matching" in some sense
-    // Some(usize) if they seem to agree on one, None if they do not
-    pub(crate) fn size_matches<T>(&self) -> Option<usize> {
-        const DATUM_SIZE: usize = mem::size_of::<pg_sys::Datum>();
-        match (self.pass, mem::size_of::<T>(), self.size.try_as_usize()) {
-            (PassBy::Value, rs @ (1 | 2 | 4 | 8), Some(pg @ (1 | 2 | 4 | 8))) if rs == pg => {
-                Some(rs)
-            }
-            (PassBy::Value, _, _) => None,
-            (PassBy::Ref, DATUM_SIZE, _) => Some(DATUM_SIZE),
-            (PassBy::Ref, _, _) => None,
-        }
-    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -134,14 +120,6 @@ impl Size {
             Self::CStr => -2,
             Self::Varlena => -1,
             Self::Fixed(v) => *v as _,
-        }
-    }
-
-    pub(crate) fn try_as_usize(&self) -> Option<usize> {
-        match self {
-            Self::CStr => None,
-            Self::Varlena => None,
-            Self::Fixed(v) => Some(*v as _),
         }
     }
 }


### PR DESCRIPTION
Remove this dubious function, without replacement. This has been deprecated for some time and my latest PR made it really obvious why this function was kinda always a questionable idea. This fixes https://github.com/tcdi/pgrx/issues/627.