### PR TITLE
Update version to 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
 dependencies = [
  "memchr",
 ]
@@ -269,9 +269,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.12.0"
+version = "3.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+checksum = "9b1ce199063694f33ffb7dd4e0ee620741495c32833cde5aa08f02a0bf96f0c8"
 
 [[package]]
 name = "bytea"
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-pgrx"
-version = "0.7.4"
+version = "0.8.0"
 dependencies = [
  "atty",
  "cargo_metadata",
@@ -534,9 +534,9 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280a9f2d8b3a38871a3c8a46fb80db65e5e5ed97da80c4d08bf27fb63e35e181"
+checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
 dependencies = [
  "libc",
 ]
@@ -1099,9 +1099,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.141"
+version = "0.2.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
+checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
 
 [[package]]
 name = "libflate"
@@ -1150,9 +1150,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b085a4f2cde5781fc4b1717f2e86c62f5cda49de7ba99a7c2eae02b61c9064c"
+checksum = "36eb31c1778188ae1e64398743890d0877fef36d11521ac60406b42016e8c2cf"
 
 [[package]]
 name = "lock_api"
@@ -1290,9 +1290,9 @@ dependencies = [
 
 [[package]]
 name = "ntapi"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc51db7b362b205941f71232e56c625156eb9a929f8cf74a428fd5bc094a4afc"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
 dependencies = [
  "winapi",
 ]
@@ -1344,9 +1344,9 @@ checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "openssl"
-version = "0.10.50"
+version = "0.10.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e30d8bc91859781f0a943411186324d580f2bbeb71b452fe91ae344806af3f1"
+checksum = "97ea2d98598bf9ada7ea6ee8a30fb74f9156b63bbe495d64ec2b87c269d2dda3"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1376,9 +1376,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.85"
+version = "0.9.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3d193fb1488ad46ffe3aaabc912cc931d02ee8518fe2959aea8ef52718b0c0"
+checksum = "992bac49bdbab4423199c654a5515bd2a6c6a23bf03f2dd3bdb7e5ae6259bc69"
 dependencies = [
  "cc",
  "libc",
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx"
-version = "0.7.4"
+version = "0.8.0"
 dependencies = [
  "atomic-traits",
  "bitflags",
@@ -1503,7 +1503,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-macros"
-version = "0.7.4"
+version = "0.8.0"
 dependencies = [
  "pgrx-sql-entity-graph",
  "proc-macro2",
@@ -1514,7 +1514,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-config"
-version = "0.7.4"
+version = "0.8.0"
 dependencies = [
  "cargo_toml",
  "dirs",
@@ -1530,7 +1530,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-sys"
-version = "0.7.4"
+version = "0.8.0"
 dependencies = [
  "bindgen",
  "eyre",
@@ -1550,7 +1550,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-sql-entity-graph"
-version = "0.7.4"
+version = "0.8.0"
 dependencies = [
  "atty",
  "convert_case",
@@ -1566,7 +1566,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-tests"
-version = "0.7.4"
+version = "0.8.0"
 dependencies = [
  "clap-cargo",
  "eyre",
@@ -1836,13 +1836,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.3"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
+checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.7.1",
 ]
 
 [[package]]
@@ -1851,7 +1851,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 dependencies = [
- "regex-syntax",
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -1859,6 +1859,12 @@ name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
 
 [[package]]
 name = "ring"
@@ -1913,9 +1919,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.12"
+version = "0.37.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "722529a737f5a942fdbac3a46cee213053196737c5eaa3386d52e85b786f2659"
+checksum = "d9b864d3c18a5785a05953adeed93e2dca37ed30f18e69bba9f30079d51f363f"
 dependencies = [
  "bitflags",
  "errno",
@@ -2327,7 +2333,7 @@ dependencies = [
  "lazy_static",
  "once_cell",
  "plist",
- "regex-syntax",
+ "regex-syntax 0.6.29",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2605,9 +2611,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
 dependencies = [
  "matchers",
  "nu-ansi-term",

--- a/cargo-pgrx/Cargo.toml
+++ b/cargo-pgrx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pgrx"
-version = "0.7.4"
+version = "0.8.0"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Cargo subcommand for 'pgrx' to make Postgres extension development easy"
@@ -23,13 +23,13 @@ semver = "1.0.17"
 owo-colors = { version = "3.5.0", features = [ "supports-colors" ] }
 env_proxy = "0.4.1"
 num_cpus = "1.15.0"
-pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.7.4" }
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.7.4" }
+pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.8.0" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.8.0" }
 prettyplease = "0.1.25"
 proc-macro2 = { version = "1.0.56", features = [ "span-locations" ] }
 quote = "1.0.26"
 rayon = "1.7.0"
-regex = "1.7.3"
+regex = "1.8.1"
 ureq = "2.6.2"
 url = "2.3.1"
 serde = { version = "1.0.160", features = [ "derive" ] }
@@ -45,7 +45,7 @@ eyre = "0.6.8"
 color-eyre = "0.6.2"
 tracing = "0.1.37"
 tracing-error = "0.2.0"
-tracing-subscriber = { version = "0.3.16", features = [ "env-filter" ] }
+tracing-subscriber = { version = "0.3.17", features = [ "env-filter" ] }
 flate2 = { version = "1.0.25", default-features = false, features = ["rust_backend"] }
 tar = { version = "0.4.38", default-features = false }
 tempfile = "3.5.0"

--- a/cargo-pgrx/src/templates/cargo_toml
+++ b/cargo-pgrx/src/templates/cargo_toml
@@ -16,10 +16,10 @@ pg15 = ["pgrx/pg15", "pgrx-tests/pg15" ]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.7.4"
+pgrx = "=0.8.0"
 
 [dev-dependencies]
-pgrx-tests = "=0.7.4"
+pgrx-tests = "=0.8.0"
 
 [profile.dev]
 panic = "unwind"

--- a/nix/templates/default/Cargo.toml
+++ b/nix/templates/default/Cargo.toml
@@ -16,10 +16,10 @@ pg15 = ["pgrx/pg15", "pgrx-tests/pg15" ]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.7.4"
+pgrx = "=0.8.0"
 
 [dev-dependencies]
-pgrx-tests = "=0.7.4"
+pgrx-tests = "=0.8.0"
 tempfile = "3.2.0"
 once_cell = "1.7.2"
 

--- a/pgrx-macros/Cargo.toml
+++ b/pgrx-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx-macros"
-version = "0.7.4"
+version = "0.8.0"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Proc Macros for 'pgrx'"
@@ -21,7 +21,7 @@ rustc-args = ["--cfg", "docsrs"]
 no-schema-generation = ["pgrx-sql-entity-graph/no-schema-generation"]
 
 [dependencies]
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.7.4" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.8.0" }
 proc-macro2 = "1.0.56"
 quote = "1.0.26"
 syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsing" ] }

--- a/pgrx-pg-config/Cargo.toml
+++ b/pgrx-pg-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx-pg-config"
-version = "0.7.4"
+version = "0.8.0"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "A Postgres pg_config wrapper for 'pgrx'"

--- a/pgrx-pg-sys/Cargo.toml
+++ b/pgrx-pg-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx-pg-sys"
-version = "0.7.4"
+version = "0.8.0"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Generated Rust bindings for Postgres internals, for use with 'pgrx'"
@@ -29,8 +29,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 memoffset = "0.8.0"
-pgrx-macros = { path = "../pgrx-macros/", version = "=0.7.4" }
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph/", version = "=0.7.4" }
+pgrx-macros = { path = "../pgrx-macros/", version = "=0.8.0" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph/", version = "=0.8.0" }
 serde = { version = "1.0.160", features = [ "derive" ] } # impls on pub types
 # polyfill until #![feature(strict_provenance)] stabilizes
 sptr = "0.3"
@@ -38,7 +38,7 @@ libc = "0.2"
 
 [build-dependencies]
 bindgen = { version = "0.60.1", default-features = false, features = ["runtime"] }
-pgrx-pg-config= { path = "../pgrx-pg-config/", version = "=0.7.4" }
+pgrx-pg-config= { path = "../pgrx-pg-config/", version = "=0.8.0" }
 proc-macro2 = "1.0.56"
 quote = "1.0.26"
 syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsing" ] }

--- a/pgrx-pg-sys/src/pg11.rs
+++ b/pgrx-pg-sys/src/pg11.rs
@@ -3035,6 +3035,34 @@ pub const DEFAULT_PARALLEL_TUPLE_COST: f64 = 0.1;
 pub const DEFAULT_PARALLEL_SETUP_COST: f64 = 1000.0;
 pub const DEFAULT_EFFECTIVE_CACHE_SIZE: u32 = 524288;
 pub const DEFAULT_CURSOR_TUPLE_FRACTION: f64 = 0.1;
+pub const ER_MAGIC: u32 = 1384727874;
+pub const ER_FLAG_FVALUE_VALID: u32 = 1;
+pub const ER_FLAG_FVALUE_ALLOCED: u32 = 2;
+pub const ER_FLAG_DVALUES_VALID: u32 = 4;
+pub const ER_FLAG_DVALUES_ALLOCED: u32 = 8;
+pub const ER_FLAG_HAVE_EXTERNAL: u32 = 16;
+pub const ER_FLAG_TUPDESC_ALLOCED: u32 = 32;
+pub const ER_FLAG_IS_DOMAIN: u32 = 64;
+pub const ER_FLAG_IS_DUMMY: u32 = 128;
+pub const ER_FLAGS_NON_DATA: u32 = 224;
+pub const TYPECACHE_EQ_OPR: u32 = 1;
+pub const TYPECACHE_LT_OPR: u32 = 2;
+pub const TYPECACHE_GT_OPR: u32 = 4;
+pub const TYPECACHE_CMP_PROC: u32 = 8;
+pub const TYPECACHE_HASH_PROC: u32 = 16;
+pub const TYPECACHE_EQ_OPR_FINFO: u32 = 32;
+pub const TYPECACHE_CMP_PROC_FINFO: u32 = 64;
+pub const TYPECACHE_HASH_PROC_FINFO: u32 = 128;
+pub const TYPECACHE_TUPDESC: u32 = 256;
+pub const TYPECACHE_BTREE_OPFAMILY: u32 = 512;
+pub const TYPECACHE_HASH_OPFAMILY: u32 = 1024;
+pub const TYPECACHE_RANGE_INFO: u32 = 2048;
+pub const TYPECACHE_DOMAIN_BASE_INFO: u32 = 4096;
+pub const TYPECACHE_DOMAIN_CONSTR_INFO: u32 = 8192;
+pub const TYPECACHE_HASH_EXTENDED_PROC: u32 = 16384;
+pub const TYPECACHE_HASH_EXTENDED_PROC_FINFO: u32 = 32768;
+pub const PLPGSQL_XCHECK_NONE: u32 = 0;
+pub const PLPGSQL_XCHECK_SHADOWVAR: u32 = 1;
 pub const OLD_SNAPSHOT_PADDING_ENTRIES: u32 = 10;
 pub const MAX_IO_CONCURRENCY: u32 = 1000;
 pub const BUFFER_LOCK_UNLOCK: u32 = 0;
@@ -3184,22 +3212,6 @@ pub const DEFAULT_MATCH_SEL: f64 = 0.005;
 pub const DEFAULT_NUM_DISTINCT: u32 = 200;
 pub const DEFAULT_UNK_SEL: f64 = 0.005;
 pub const DEFAULT_NOT_UNK_SEL: f64 = 0.995;
-pub const TYPECACHE_EQ_OPR: u32 = 1;
-pub const TYPECACHE_LT_OPR: u32 = 2;
-pub const TYPECACHE_GT_OPR: u32 = 4;
-pub const TYPECACHE_CMP_PROC: u32 = 8;
-pub const TYPECACHE_HASH_PROC: u32 = 16;
-pub const TYPECACHE_EQ_OPR_FINFO: u32 = 32;
-pub const TYPECACHE_CMP_PROC_FINFO: u32 = 64;
-pub const TYPECACHE_HASH_PROC_FINFO: u32 = 128;
-pub const TYPECACHE_TUPDESC: u32 = 256;
-pub const TYPECACHE_BTREE_OPFAMILY: u32 = 512;
-pub const TYPECACHE_HASH_OPFAMILY: u32 = 1024;
-pub const TYPECACHE_RANGE_INFO: u32 = 2048;
-pub const TYPECACHE_DOMAIN_BASE_INFO: u32 = 4096;
-pub const TYPECACHE_DOMAIN_CONSTR_INFO: u32 = 8192;
-pub const TYPECACHE_HASH_EXTENDED_PROC: u32 = 16384;
-pub const TYPECACHE_HASH_EXTENDED_PROC_FINFO: u32 = 32768;
 pub const RANGE_EMPTY: u32 = 1;
 pub const RANGE_LB_INC: u32 = 2;
 pub const RANGE_UB_INC: u32 = 4;
@@ -30644,6 +30656,91 @@ extern "C" {
         sarray_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
+pub const ObjectAccessType_OAT_POST_CREATE: ObjectAccessType = 0;
+pub const ObjectAccessType_OAT_DROP: ObjectAccessType = 1;
+pub const ObjectAccessType_OAT_POST_ALTER: ObjectAccessType = 2;
+pub const ObjectAccessType_OAT_NAMESPACE_SEARCH: ObjectAccessType = 3;
+pub const ObjectAccessType_OAT_FUNCTION_EXECUTE: ObjectAccessType = 4;
+pub type ObjectAccessType = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ObjectAccessPostCreate {
+    pub is_internal: bool,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ObjectAccessDrop {
+    pub dropflags: ::std::os::raw::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ObjectAccessPostAlter {
+    pub auxiliary_id: Oid,
+    pub is_internal: bool,
+}
+impl Default for ObjectAccessPostAlter {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ObjectAccessNamespaceSearch {
+    pub ereport_on_violation: bool,
+    pub result: bool,
+}
+pub type object_access_hook_type = ::std::option::Option<
+    unsafe extern "C" fn(
+        access: ObjectAccessType,
+        classId: Oid,
+        objectId: Oid,
+        subId: ::std::os::raw::c_int,
+        arg: *mut ::std::os::raw::c_void,
+    ),
+>;
+extern "C" {
+    pub static mut object_access_hook: object_access_hook_type;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RunObjectPostCreateHook(
+        classId: Oid,
+        objectId: Oid,
+        subId: ::std::os::raw::c_int,
+        is_internal: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RunObjectDropHook(
+        classId: Oid,
+        objectId: Oid,
+        subId: ::std::os::raw::c_int,
+        dropflags: ::std::os::raw::c_int,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RunObjectPostAlterHook(
+        classId: Oid,
+        objectId: Oid,
+        subId: ::std::os::raw::c_int,
+        auxiliaryId: Oid,
+        is_internal: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RunNamespaceSearchHook(objectId: Oid, ereport_on_violation: bool) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RunFunctionExecuteHook(objectId: Oid);
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct FormData_pg_authid {
@@ -32846,6 +32943,103 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn RI_FKey_trigger_type(tgfoid: Oid) -> ::std::os::raw::c_int;
+}
+pub const PasswordType_PASSWORD_TYPE_PLAINTEXT: PasswordType = 0;
+pub const PasswordType_PASSWORD_TYPE_MD5: PasswordType = 1;
+pub const PasswordType_PASSWORD_TYPE_SCRAM_SHA_256: PasswordType = 2;
+pub type PasswordType = ::std::os::raw::c_uint;
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_password_type(shadow_pass: *const ::std::os::raw::c_char) -> PasswordType;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn encrypt_password(
+        target_type: PasswordType,
+        role: *const ::std::os::raw::c_char,
+        password: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_role_password(
+        role: *const ::std::os::raw::c_char,
+        logdetail: *mut *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn md5_crypt_verify(
+        role: *const ::std::os::raw::c_char,
+        shadow_pass: *const ::std::os::raw::c_char,
+        client_pass: *const ::std::os::raw::c_char,
+        md5_salt: *const ::std::os::raw::c_char,
+        md5_salt_len: ::std::os::raw::c_int,
+        logdetail: *mut *mut ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plain_crypt_verify(
+        role: *const ::std::os::raw::c_char,
+        shadow_pass: *const ::std::os::raw::c_char,
+        client_pass: *const ::std::os::raw::c_char,
+        logdetail: *mut *mut ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut Password_encryption: ::std::os::raw::c_int;
+}
+pub type check_password_hook_type = ::std::option::Option<
+    unsafe extern "C" fn(
+        username: *const ::std::os::raw::c_char,
+        shadow_pass: *const ::std::os::raw::c_char,
+        password_type: PasswordType,
+        validuntil_time: Datum,
+        validuntil_null: bool,
+    ),
+>;
+extern "C" {
+    pub static mut check_password_hook: check_password_hook_type;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn CreateRole(pstate: *mut ParseState, stmt: *mut CreateRoleStmt) -> Oid;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn AlterRole(stmt: *mut AlterRoleStmt) -> Oid;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn AlterRoleSet(stmt: *mut AlterRoleSetStmt) -> Oid;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DropRole(stmt: *mut DropRoleStmt);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GrantRole(stmt: *mut GrantRoleStmt);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RenameRole(
+        oldname: *const ::std::os::raw::c_char,
+        newname: *const ::std::os::raw::c_char,
+    ) -> ObjectAddress;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DropOwnedObjects(stmt: *mut DropOwnedStmt);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ReassignOwnedObjects(stmt: *mut ReassignOwnedStmt);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn roleSpecsToIds(memberNames: *mut List) -> *mut List;
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -37753,6 +37947,85 @@ extern "C" {
         live_childrels: *mut List,
     );
 }
+pub type get_relation_info_hook_type = ::std::option::Option<
+    unsafe extern "C" fn(
+        root: *mut PlannerInfo,
+        relationObjectId: Oid,
+        inhparent: bool,
+        rel: *mut RelOptInfo,
+    ),
+>;
+extern "C" {
+    pub static mut get_relation_info_hook: get_relation_info_hook_type;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_relation_info(
+        root: *mut PlannerInfo,
+        relationObjectId: Oid,
+        inhparent: bool,
+        rel: *mut RelOptInfo,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn infer_arbiter_indexes(root: *mut PlannerInfo) -> *mut List;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn estimate_rel_size(
+        rel: Relation,
+        attr_widths: *mut int32,
+        pages: *mut BlockNumber,
+        tuples: *mut f64,
+        allvisfrac: *mut f64,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_relation_data_width(relid: Oid, attr_widths: *mut int32) -> int32;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn relation_excluded_by_constraints(
+        root: *mut PlannerInfo,
+        rel: *mut RelOptInfo,
+        rte: *mut RangeTblEntry,
+    ) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn build_physical_tlist(root: *mut PlannerInfo, rel: *mut RelOptInfo) -> *mut List;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn has_unique_index(rel: *mut RelOptInfo, attno: AttrNumber) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn restriction_selectivity(
+        root: *mut PlannerInfo,
+        operatorid: Oid,
+        args: *mut List,
+        inputcollid: Oid,
+        varRelid: ::std::os::raw::c_int,
+    ) -> Selectivity;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn join_selectivity(
+        root: *mut PlannerInfo,
+        operatorid: Oid,
+        args: *mut List,
+        inputcollid: Oid,
+        jointype: JoinType,
+        sjinfo: *mut SpecialJoinInfo,
+    ) -> Selectivity;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn has_row_triggers(root: *mut PlannerInfo, rti: Index, event: CmdType) -> bool;
+}
 pub const ForceParallelMode_FORCE_PARALLEL_OFF: ForceParallelMode = 0;
 pub const ForceParallelMode_FORCE_PARALLEL_ON: ForceParallelMode = 1;
 pub const ForceParallelMode_FORCE_PARALLEL_REGRESS: ForceParallelMode = 2;
@@ -38851,6 +39124,1819 @@ extern "C" {
 extern "C" {
     pub fn get_parse_rowmark(qry: *mut Query, rtindex: Index) -> *mut RowMarkClause;
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ExpandedRecordHeader {
+    pub hdr: ExpandedObjectHeader,
+    pub er_magic: ::std::os::raw::c_int,
+    pub flags: ::std::os::raw::c_int,
+    pub er_decltypeid: Oid,
+    pub er_typeid: Oid,
+    pub er_typmod: int32,
+    pub er_tupdesc: TupleDesc,
+    pub er_tupdesc_id: uint64,
+    pub dvalues: *mut Datum,
+    pub dnulls: *mut bool,
+    pub nfields: ::std::os::raw::c_int,
+    pub flat_size: Size,
+    pub data_len: Size,
+    pub hoff: ::std::os::raw::c_int,
+    pub hasnull: bool,
+    pub fvalue: HeapTuple,
+    pub fstartptr: *mut ::std::os::raw::c_char,
+    pub fendptr: *mut ::std::os::raw::c_char,
+    pub er_short_term_cxt: MemoryContext,
+    pub er_dummy_header: *mut ExpandedRecordHeader,
+    pub er_domaininfo: *mut ::std::os::raw::c_void,
+    pub er_mcb: MemoryContextCallback,
+}
+impl Default for ExpandedRecordHeader {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ExpandedRecordFieldInfo {
+    pub fnumber: ::std::os::raw::c_int,
+    pub ftypeid: Oid,
+    pub ftypmod: int32,
+    pub fcollation: Oid,
+}
+impl Default for ExpandedRecordFieldInfo {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn make_expanded_record_from_typeid(
+        type_id: Oid,
+        typmod: int32,
+        parentcontext: MemoryContext,
+    ) -> *mut ExpandedRecordHeader;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn make_expanded_record_from_tupdesc(
+        tupdesc: TupleDesc,
+        parentcontext: MemoryContext,
+    ) -> *mut ExpandedRecordHeader;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn make_expanded_record_from_exprecord(
+        olderh: *mut ExpandedRecordHeader,
+        parentcontext: MemoryContext,
+    ) -> *mut ExpandedRecordHeader;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn expanded_record_set_tuple(
+        erh: *mut ExpandedRecordHeader,
+        tuple: HeapTuple,
+        copy: bool,
+        expand_external: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn make_expanded_record_from_datum(
+        recorddatum: Datum,
+        parentcontext: MemoryContext,
+    ) -> Datum;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn expanded_record_fetch_tupdesc(erh: *mut ExpandedRecordHeader) -> TupleDesc;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn expanded_record_get_tuple(erh: *mut ExpandedRecordHeader) -> HeapTuple;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DatumGetExpandedRecord(d: Datum) -> *mut ExpandedRecordHeader;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn deconstruct_expanded_record(erh: *mut ExpandedRecordHeader);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn expanded_record_lookup_field(
+        erh: *mut ExpandedRecordHeader,
+        fieldname: *const ::std::os::raw::c_char,
+        finfo: *mut ExpandedRecordFieldInfo,
+    ) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn expanded_record_fetch_field(
+        erh: *mut ExpandedRecordHeader,
+        fnumber: ::std::os::raw::c_int,
+        isnull: *mut bool,
+    ) -> Datum;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn expanded_record_set_field_internal(
+        erh: *mut ExpandedRecordHeader,
+        fnumber: ::std::os::raw::c_int,
+        newValue: Datum,
+        isnull: bool,
+        expand_external: bool,
+        check_constraints: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn expanded_record_set_fields(
+        erh: *mut ExpandedRecordHeader,
+        newValues: *const Datum,
+        isnulls: *const bool,
+        expand_external: bool,
+    );
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct DomainConstraintCache {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct TypeCacheEnumData {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct TypeCacheEntry {
+    pub type_id: Oid,
+    pub typlen: int16,
+    pub typbyval: bool,
+    pub typalign: ::std::os::raw::c_char,
+    pub typstorage: ::std::os::raw::c_char,
+    pub typtype: ::std::os::raw::c_char,
+    pub typrelid: Oid,
+    pub typelem: Oid,
+    pub btree_opf: Oid,
+    pub btree_opintype: Oid,
+    pub hash_opf: Oid,
+    pub hash_opintype: Oid,
+    pub eq_opr: Oid,
+    pub lt_opr: Oid,
+    pub gt_opr: Oid,
+    pub cmp_proc: Oid,
+    pub hash_proc: Oid,
+    pub hash_extended_proc: Oid,
+    pub eq_opr_finfo: FmgrInfo,
+    pub cmp_proc_finfo: FmgrInfo,
+    pub hash_proc_finfo: FmgrInfo,
+    pub hash_extended_proc_finfo: FmgrInfo,
+    pub tupDesc: TupleDesc,
+    pub tupDesc_identifier: uint64,
+    pub rngelemtype: *mut TypeCacheEntry,
+    pub rng_collation: Oid,
+    pub rng_cmp_proc_finfo: FmgrInfo,
+    pub rng_canonical_finfo: FmgrInfo,
+    pub rng_subdiff_finfo: FmgrInfo,
+    pub domainBaseType: Oid,
+    pub domainBaseTypmod: int32,
+    pub domainData: *mut DomainConstraintCache,
+    pub flags: ::std::os::raw::c_int,
+    pub enumData: *mut TypeCacheEnumData,
+    pub nextDomain: *mut TypeCacheEntry,
+}
+impl Default for TypeCacheEntry {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct DomainConstraintRef {
+    pub constraints: *mut List,
+    pub refctx: MemoryContext,
+    pub tcache: *mut TypeCacheEntry,
+    pub need_exprstate: bool,
+    pub dcc: *mut DomainConstraintCache,
+    pub callback: MemoryContextCallback,
+}
+impl Default for DomainConstraintRef {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct SharedRecordTypmodRegistry {
+    _unused: [u8; 0],
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn lookup_type_cache(type_id: Oid, flags: ::std::os::raw::c_int) -> *mut TypeCacheEntry;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn InitDomainConstraintRef(
+        type_id: Oid,
+        ref_: *mut DomainConstraintRef,
+        refctx: MemoryContext,
+        need_exprstate: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UpdateDomainConstraintRef(ref_: *mut DomainConstraintRef);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DomainHasConstraints(type_id: Oid) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn lookup_rowtype_tupdesc(type_id: Oid, typmod: int32) -> TupleDesc;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn lookup_rowtype_tupdesc_noerror(type_id: Oid, typmod: int32, noError: bool) -> TupleDesc;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn lookup_rowtype_tupdesc_copy(type_id: Oid, typmod: int32) -> TupleDesc;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn lookup_rowtype_tupdesc_domain(type_id: Oid, typmod: int32, noError: bool) -> TupleDesc;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn assign_record_type_typmod(tupDesc: TupleDesc);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn assign_record_type_identifier(type_id: Oid, typmod: int32) -> uint64;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn compare_values_of_enum(
+        tcache: *mut TypeCacheEntry,
+        arg1: Oid,
+        arg2: Oid,
+    ) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SharedRecordTypmodRegistryEstimate() -> usize;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SharedRecordTypmodRegistryInit(
+        arg1: *mut SharedRecordTypmodRegistry,
+        segment: *mut dsm_segment,
+        area: *mut dsa_area,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SharedRecordTypmodRegistryAttach(arg1: *mut SharedRecordTypmodRegistry);
+}
+pub const PLpgSQL_nsitem_type_PLPGSQL_NSTYPE_LABEL: PLpgSQL_nsitem_type = 0;
+pub const PLpgSQL_nsitem_type_PLPGSQL_NSTYPE_VAR: PLpgSQL_nsitem_type = 1;
+pub const PLpgSQL_nsitem_type_PLPGSQL_NSTYPE_REC: PLpgSQL_nsitem_type = 2;
+pub type PLpgSQL_nsitem_type = ::std::os::raw::c_uint;
+pub const PLpgSQL_label_type_PLPGSQL_LABEL_BLOCK: PLpgSQL_label_type = 0;
+pub const PLpgSQL_label_type_PLPGSQL_LABEL_LOOP: PLpgSQL_label_type = 1;
+pub const PLpgSQL_label_type_PLPGSQL_LABEL_OTHER: PLpgSQL_label_type = 2;
+pub type PLpgSQL_label_type = ::std::os::raw::c_uint;
+pub const PLpgSQL_datum_type_PLPGSQL_DTYPE_VAR: PLpgSQL_datum_type = 0;
+pub const PLpgSQL_datum_type_PLPGSQL_DTYPE_ROW: PLpgSQL_datum_type = 1;
+pub const PLpgSQL_datum_type_PLPGSQL_DTYPE_REC: PLpgSQL_datum_type = 2;
+pub const PLpgSQL_datum_type_PLPGSQL_DTYPE_RECFIELD: PLpgSQL_datum_type = 3;
+pub const PLpgSQL_datum_type_PLPGSQL_DTYPE_ARRAYELEM: PLpgSQL_datum_type = 4;
+pub const PLpgSQL_datum_type_PLPGSQL_DTYPE_PROMISE: PLpgSQL_datum_type = 5;
+pub type PLpgSQL_datum_type = ::std::os::raw::c_uint;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_NONE: PLpgSQL_promise_type = 0;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_NAME: PLpgSQL_promise_type = 1;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_WHEN: PLpgSQL_promise_type = 2;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_LEVEL: PLpgSQL_promise_type = 3;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_OP: PLpgSQL_promise_type = 4;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_RELID: PLpgSQL_promise_type = 5;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_TABLE_NAME: PLpgSQL_promise_type = 6;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_TABLE_SCHEMA: PLpgSQL_promise_type = 7;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_NARGS: PLpgSQL_promise_type = 8;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_ARGV: PLpgSQL_promise_type = 9;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_EVENT: PLpgSQL_promise_type = 10;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_TAG: PLpgSQL_promise_type = 11;
+pub type PLpgSQL_promise_type = ::std::os::raw::c_uint;
+pub const PLpgSQL_type_type_PLPGSQL_TTYPE_SCALAR: PLpgSQL_type_type = 0;
+pub const PLpgSQL_type_type_PLPGSQL_TTYPE_REC: PLpgSQL_type_type = 1;
+pub const PLpgSQL_type_type_PLPGSQL_TTYPE_PSEUDO: PLpgSQL_type_type = 2;
+pub type PLpgSQL_type_type = ::std::os::raw::c_uint;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_BLOCK: PLpgSQL_stmt_type = 0;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_ASSIGN: PLpgSQL_stmt_type = 1;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_IF: PLpgSQL_stmt_type = 2;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_CASE: PLpgSQL_stmt_type = 3;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_LOOP: PLpgSQL_stmt_type = 4;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_WHILE: PLpgSQL_stmt_type = 5;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_FORI: PLpgSQL_stmt_type = 6;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_FORS: PLpgSQL_stmt_type = 7;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_FORC: PLpgSQL_stmt_type = 8;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_FOREACH_A: PLpgSQL_stmt_type = 9;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_EXIT: PLpgSQL_stmt_type = 10;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_RETURN: PLpgSQL_stmt_type = 11;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_RETURN_NEXT: PLpgSQL_stmt_type = 12;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_RETURN_QUERY: PLpgSQL_stmt_type = 13;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_RAISE: PLpgSQL_stmt_type = 14;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_ASSERT: PLpgSQL_stmt_type = 15;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_EXECSQL: PLpgSQL_stmt_type = 16;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_DYNEXECUTE: PLpgSQL_stmt_type = 17;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_DYNFORS: PLpgSQL_stmt_type = 18;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_GETDIAG: PLpgSQL_stmt_type = 19;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_OPEN: PLpgSQL_stmt_type = 20;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_FETCH: PLpgSQL_stmt_type = 21;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_CLOSE: PLpgSQL_stmt_type = 22;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_PERFORM: PLpgSQL_stmt_type = 23;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_CALL: PLpgSQL_stmt_type = 24;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_COMMIT: PLpgSQL_stmt_type = 25;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_ROLLBACK: PLpgSQL_stmt_type = 26;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_SET: PLpgSQL_stmt_type = 27;
+pub type PLpgSQL_stmt_type = ::std::os::raw::c_uint;
+pub const PLPGSQL_RC_OK: _bindgen_ty_19 = 0;
+pub const PLPGSQL_RC_EXIT: _bindgen_ty_19 = 1;
+pub const PLPGSQL_RC_RETURN: _bindgen_ty_19 = 2;
+pub const PLPGSQL_RC_CONTINUE: _bindgen_ty_19 = 3;
+pub type _bindgen_ty_19 = ::std::os::raw::c_uint;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_ROW_COUNT: PLpgSQL_getdiag_kind = 0;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_RESULT_OID: PLpgSQL_getdiag_kind = 1;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_CONTEXT: PLpgSQL_getdiag_kind = 2;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_ERROR_CONTEXT: PLpgSQL_getdiag_kind = 3;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_ERROR_DETAIL: PLpgSQL_getdiag_kind = 4;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_ERROR_HINT: PLpgSQL_getdiag_kind = 5;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_RETURNED_SQLSTATE: PLpgSQL_getdiag_kind = 6;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_COLUMN_NAME: PLpgSQL_getdiag_kind = 7;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_CONSTRAINT_NAME: PLpgSQL_getdiag_kind = 8;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_DATATYPE_NAME: PLpgSQL_getdiag_kind = 9;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_MESSAGE_TEXT: PLpgSQL_getdiag_kind = 10;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_TABLE_NAME: PLpgSQL_getdiag_kind = 11;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_SCHEMA_NAME: PLpgSQL_getdiag_kind = 12;
+pub type PLpgSQL_getdiag_kind = ::std::os::raw::c_uint;
+pub const PLpgSQL_raise_option_type_PLPGSQL_RAISEOPTION_ERRCODE: PLpgSQL_raise_option_type = 0;
+pub const PLpgSQL_raise_option_type_PLPGSQL_RAISEOPTION_MESSAGE: PLpgSQL_raise_option_type = 1;
+pub const PLpgSQL_raise_option_type_PLPGSQL_RAISEOPTION_DETAIL: PLpgSQL_raise_option_type = 2;
+pub const PLpgSQL_raise_option_type_PLPGSQL_RAISEOPTION_HINT: PLpgSQL_raise_option_type = 3;
+pub const PLpgSQL_raise_option_type_PLPGSQL_RAISEOPTION_COLUMN: PLpgSQL_raise_option_type = 4;
+pub const PLpgSQL_raise_option_type_PLPGSQL_RAISEOPTION_CONSTRAINT: PLpgSQL_raise_option_type = 5;
+pub const PLpgSQL_raise_option_type_PLPGSQL_RAISEOPTION_DATATYPE: PLpgSQL_raise_option_type = 6;
+pub const PLpgSQL_raise_option_type_PLPGSQL_RAISEOPTION_TABLE: PLpgSQL_raise_option_type = 7;
+pub const PLpgSQL_raise_option_type_PLPGSQL_RAISEOPTION_SCHEMA: PLpgSQL_raise_option_type = 8;
+pub type PLpgSQL_raise_option_type = ::std::os::raw::c_uint;
+pub const PLpgSQL_resolve_option_PLPGSQL_RESOLVE_ERROR: PLpgSQL_resolve_option = 0;
+pub const PLpgSQL_resolve_option_PLPGSQL_RESOLVE_VARIABLE: PLpgSQL_resolve_option = 1;
+pub const PLpgSQL_resolve_option_PLPGSQL_RESOLVE_COLUMN: PLpgSQL_resolve_option = 2;
+pub type PLpgSQL_resolve_option = ::std::os::raw::c_uint;
+#[doc = " Node and structure definitions"]
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_type {
+    pub typname: *mut ::std::os::raw::c_char,
+    pub typoid: Oid,
+    pub ttype: PLpgSQL_type_type,
+    pub typlen: int16,
+    pub typbyval: bool,
+    pub typtype: ::std::os::raw::c_char,
+    pub collation: Oid,
+    pub typisarray: bool,
+    pub atttypmod: int32,
+    pub origtypname: *mut TypeName,
+    pub tcache: *mut TypeCacheEntry,
+    pub tupdesc_id: uint64,
+}
+impl Default for PLpgSQL_type {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_expr {
+    pub query: *mut ::std::os::raw::c_char,
+    pub plan: SPIPlanPtr,
+    pub paramnos: *mut Bitmapset,
+    pub rwparam: ::std::os::raw::c_int,
+    pub func: *mut PLpgSQL_function,
+    pub ns: *mut PLpgSQL_nsitem,
+    pub expr_simple_expr: *mut Expr,
+    pub expr_simple_generation: ::std::os::raw::c_int,
+    pub expr_simple_type: Oid,
+    pub expr_simple_typmod: int32,
+    pub expr_simple_state: *mut ExprState,
+    pub expr_simple_in_use: bool,
+    pub expr_simple_lxid: LocalTransactionId,
+}
+impl Default for PLpgSQL_expr {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_datum {
+    pub dtype: PLpgSQL_datum_type,
+    pub dno: ::std::os::raw::c_int,
+}
+impl Default for PLpgSQL_datum {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_variable {
+    pub dtype: PLpgSQL_datum_type,
+    pub dno: ::std::os::raw::c_int,
+    pub refname: *mut ::std::os::raw::c_char,
+    pub lineno: ::std::os::raw::c_int,
+    pub isconst: bool,
+    pub notnull: bool,
+    pub default_val: *mut PLpgSQL_expr,
+}
+impl Default for PLpgSQL_variable {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_var {
+    pub dtype: PLpgSQL_datum_type,
+    pub dno: ::std::os::raw::c_int,
+    pub refname: *mut ::std::os::raw::c_char,
+    pub lineno: ::std::os::raw::c_int,
+    pub isconst: bool,
+    pub notnull: bool,
+    pub default_val: *mut PLpgSQL_expr,
+    pub datatype: *mut PLpgSQL_type,
+    pub cursor_explicit_expr: *mut PLpgSQL_expr,
+    pub cursor_explicit_argrow: ::std::os::raw::c_int,
+    pub cursor_options: ::std::os::raw::c_int,
+    pub value: Datum,
+    pub isnull: bool,
+    pub freeval: bool,
+    pub promise: PLpgSQL_promise_type,
+}
+impl Default for PLpgSQL_var {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_row {
+    pub dtype: PLpgSQL_datum_type,
+    pub dno: ::std::os::raw::c_int,
+    pub refname: *mut ::std::os::raw::c_char,
+    pub lineno: ::std::os::raw::c_int,
+    pub isconst: bool,
+    pub notnull: bool,
+    pub default_val: *mut PLpgSQL_expr,
+    pub rowtupdesc: TupleDesc,
+    pub nfields: ::std::os::raw::c_int,
+    pub fieldnames: *mut *mut ::std::os::raw::c_char,
+    pub varnos: *mut ::std::os::raw::c_int,
+}
+impl Default for PLpgSQL_row {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_rec {
+    pub dtype: PLpgSQL_datum_type,
+    pub dno: ::std::os::raw::c_int,
+    pub refname: *mut ::std::os::raw::c_char,
+    pub lineno: ::std::os::raw::c_int,
+    pub isconst: bool,
+    pub notnull: bool,
+    pub default_val: *mut PLpgSQL_expr,
+    pub datatype: *mut PLpgSQL_type,
+    pub rectypeid: Oid,
+    pub firstfield: ::std::os::raw::c_int,
+    pub erh: *mut ExpandedRecordHeader,
+}
+impl Default for PLpgSQL_rec {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_recfield {
+    pub dtype: PLpgSQL_datum_type,
+    pub dno: ::std::os::raw::c_int,
+    pub fieldname: *mut ::std::os::raw::c_char,
+    pub recparentno: ::std::os::raw::c_int,
+    pub nextfield: ::std::os::raw::c_int,
+    pub rectupledescid: uint64,
+    pub finfo: ExpandedRecordFieldInfo,
+}
+impl Default for PLpgSQL_recfield {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_arrayelem {
+    pub dtype: PLpgSQL_datum_type,
+    pub dno: ::std::os::raw::c_int,
+    pub subscript: *mut PLpgSQL_expr,
+    pub arrayparentno: ::std::os::raw::c_int,
+    pub parenttypoid: Oid,
+    pub parenttypmod: int32,
+    pub arraytypoid: Oid,
+    pub arraytypmod: int32,
+    pub arraytyplen: int16,
+    pub elemtypoid: Oid,
+    pub elemtyplen: int16,
+    pub elemtypbyval: bool,
+    pub elemtypalign: ::std::os::raw::c_char,
+}
+impl Default for PLpgSQL_arrayelem {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct PLpgSQL_nsitem {
+    pub itemtype: PLpgSQL_nsitem_type,
+    pub itemno: ::std::os::raw::c_int,
+    pub prev: *mut PLpgSQL_nsitem,
+    pub name: __IncompleteArrayField<::std::os::raw::c_char>,
+}
+impl Default for PLpgSQL_nsitem {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+}
+impl Default for PLpgSQL_stmt {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_condition {
+    pub sqlerrstate: ::std::os::raw::c_int,
+    pub condname: *mut ::std::os::raw::c_char,
+    pub next: *mut PLpgSQL_condition,
+}
+impl Default for PLpgSQL_condition {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_exception_block {
+    pub sqlstate_varno: ::std::os::raw::c_int,
+    pub sqlerrm_varno: ::std::os::raw::c_int,
+    pub exc_list: *mut List,
+}
+impl Default for PLpgSQL_exception_block {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_exception {
+    pub lineno: ::std::os::raw::c_int,
+    pub conditions: *mut PLpgSQL_condition,
+    pub action: *mut List,
+}
+impl Default for PLpgSQL_exception {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_block {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub label: *mut ::std::os::raw::c_char,
+    pub body: *mut List,
+    pub n_initvars: ::std::os::raw::c_int,
+    pub initvarnos: *mut ::std::os::raw::c_int,
+    pub exceptions: *mut PLpgSQL_exception_block,
+}
+impl Default for PLpgSQL_stmt_block {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_assign {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub varno: ::std::os::raw::c_int,
+    pub expr: *mut PLpgSQL_expr,
+}
+impl Default for PLpgSQL_stmt_assign {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_perform {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub expr: *mut PLpgSQL_expr,
+}
+impl Default for PLpgSQL_stmt_perform {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_call {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub expr: *mut PLpgSQL_expr,
+    pub is_call: bool,
+    pub target: *mut PLpgSQL_variable,
+}
+impl Default for PLpgSQL_stmt_call {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_commit {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+}
+impl Default for PLpgSQL_stmt_commit {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_rollback {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+}
+impl Default for PLpgSQL_stmt_rollback {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_set {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub expr: *mut PLpgSQL_expr,
+}
+impl Default for PLpgSQL_stmt_set {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_diag_item {
+    pub kind: PLpgSQL_getdiag_kind,
+    pub target: ::std::os::raw::c_int,
+}
+impl Default for PLpgSQL_diag_item {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_getdiag {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub is_stacked: bool,
+    pub diag_items: *mut List,
+}
+impl Default for PLpgSQL_stmt_getdiag {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_if {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub cond: *mut PLpgSQL_expr,
+    pub then_body: *mut List,
+    pub elsif_list: *mut List,
+    pub else_body: *mut List,
+}
+impl Default for PLpgSQL_stmt_if {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_if_elsif {
+    pub lineno: ::std::os::raw::c_int,
+    pub cond: *mut PLpgSQL_expr,
+    pub stmts: *mut List,
+}
+impl Default for PLpgSQL_if_elsif {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_case {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub t_expr: *mut PLpgSQL_expr,
+    pub t_varno: ::std::os::raw::c_int,
+    pub case_when_list: *mut List,
+    pub have_else: bool,
+    pub else_stmts: *mut List,
+}
+impl Default for PLpgSQL_stmt_case {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_case_when {
+    pub lineno: ::std::os::raw::c_int,
+    pub expr: *mut PLpgSQL_expr,
+    pub stmts: *mut List,
+}
+impl Default for PLpgSQL_case_when {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_loop {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub label: *mut ::std::os::raw::c_char,
+    pub body: *mut List,
+}
+impl Default for PLpgSQL_stmt_loop {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_while {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub label: *mut ::std::os::raw::c_char,
+    pub cond: *mut PLpgSQL_expr,
+    pub body: *mut List,
+}
+impl Default for PLpgSQL_stmt_while {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_fori {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub label: *mut ::std::os::raw::c_char,
+    pub var: *mut PLpgSQL_var,
+    pub lower: *mut PLpgSQL_expr,
+    pub upper: *mut PLpgSQL_expr,
+    pub step: *mut PLpgSQL_expr,
+    pub reverse: ::std::os::raw::c_int,
+    pub body: *mut List,
+}
+impl Default for PLpgSQL_stmt_fori {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_forq {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub label: *mut ::std::os::raw::c_char,
+    pub var: *mut PLpgSQL_variable,
+    pub body: *mut List,
+}
+impl Default for PLpgSQL_stmt_forq {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_fors {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub label: *mut ::std::os::raw::c_char,
+    pub var: *mut PLpgSQL_variable,
+    pub body: *mut List,
+    pub query: *mut PLpgSQL_expr,
+}
+impl Default for PLpgSQL_stmt_fors {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_forc {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub label: *mut ::std::os::raw::c_char,
+    pub var: *mut PLpgSQL_variable,
+    pub body: *mut List,
+    pub curvar: ::std::os::raw::c_int,
+    pub argquery: *mut PLpgSQL_expr,
+}
+impl Default for PLpgSQL_stmt_forc {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_dynfors {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub label: *mut ::std::os::raw::c_char,
+    pub var: *mut PLpgSQL_variable,
+    pub body: *mut List,
+    pub query: *mut PLpgSQL_expr,
+    pub params: *mut List,
+}
+impl Default for PLpgSQL_stmt_dynfors {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_foreach_a {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub label: *mut ::std::os::raw::c_char,
+    pub varno: ::std::os::raw::c_int,
+    pub slice: ::std::os::raw::c_int,
+    pub expr: *mut PLpgSQL_expr,
+    pub body: *mut List,
+}
+impl Default for PLpgSQL_stmt_foreach_a {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_open {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub curvar: ::std::os::raw::c_int,
+    pub cursor_options: ::std::os::raw::c_int,
+    pub argquery: *mut PLpgSQL_expr,
+    pub query: *mut PLpgSQL_expr,
+    pub dynquery: *mut PLpgSQL_expr,
+    pub params: *mut List,
+}
+impl Default for PLpgSQL_stmt_open {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_fetch {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub target: *mut PLpgSQL_variable,
+    pub curvar: ::std::os::raw::c_int,
+    pub direction: FetchDirection,
+    pub how_many: ::std::os::raw::c_long,
+    pub expr: *mut PLpgSQL_expr,
+    pub is_move: bool,
+    pub returns_multiple_rows: bool,
+}
+impl Default for PLpgSQL_stmt_fetch {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_close {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub curvar: ::std::os::raw::c_int,
+}
+impl Default for PLpgSQL_stmt_close {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_exit {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub is_exit: bool,
+    pub label: *mut ::std::os::raw::c_char,
+    pub cond: *mut PLpgSQL_expr,
+}
+impl Default for PLpgSQL_stmt_exit {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_return {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub expr: *mut PLpgSQL_expr,
+    pub retvarno: ::std::os::raw::c_int,
+}
+impl Default for PLpgSQL_stmt_return {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_return_next {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub expr: *mut PLpgSQL_expr,
+    pub retvarno: ::std::os::raw::c_int,
+}
+impl Default for PLpgSQL_stmt_return_next {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_return_query {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub query: *mut PLpgSQL_expr,
+    pub dynquery: *mut PLpgSQL_expr,
+    pub params: *mut List,
+}
+impl Default for PLpgSQL_stmt_return_query {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_raise {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub elog_level: ::std::os::raw::c_int,
+    pub condname: *mut ::std::os::raw::c_char,
+    pub message: *mut ::std::os::raw::c_char,
+    pub params: *mut List,
+    pub options: *mut List,
+}
+impl Default for PLpgSQL_stmt_raise {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_raise_option {
+    pub opt_type: PLpgSQL_raise_option_type,
+    pub expr: *mut PLpgSQL_expr,
+}
+impl Default for PLpgSQL_raise_option {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_assert {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub cond: *mut PLpgSQL_expr,
+    pub message: *mut PLpgSQL_expr,
+}
+impl Default for PLpgSQL_stmt_assert {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_execsql {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub sqlstmt: *mut PLpgSQL_expr,
+    pub mod_stmt: bool,
+    pub into: bool,
+    pub strict: bool,
+    pub mod_stmt_set: bool,
+    pub target: *mut PLpgSQL_variable,
+}
+impl Default for PLpgSQL_stmt_execsql {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_dynexecute {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub query: *mut PLpgSQL_expr,
+    pub into: bool,
+    pub strict: bool,
+    pub target: *mut PLpgSQL_variable,
+    pub params: *mut List,
+}
+impl Default for PLpgSQL_stmt_dynexecute {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_func_hashkey {
+    pub funcOid: Oid,
+    pub isTrigger: bool,
+    pub isEventTrigger: bool,
+    pub trigOid: Oid,
+    pub inputCollation: Oid,
+    pub argtypes: [Oid; 100usize],
+}
+impl Default for PLpgSQL_func_hashkey {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub const PLpgSQL_trigtype_PLPGSQL_DML_TRIGGER: PLpgSQL_trigtype = 0;
+pub const PLpgSQL_trigtype_PLPGSQL_EVENT_TRIGGER: PLpgSQL_trigtype = 1;
+pub const PLpgSQL_trigtype_PLPGSQL_NOT_TRIGGER: PLpgSQL_trigtype = 2;
+pub type PLpgSQL_trigtype = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_function {
+    pub fn_signature: *mut ::std::os::raw::c_char,
+    pub fn_oid: Oid,
+    pub fn_xmin: TransactionId,
+    pub fn_tid: ItemPointerData,
+    pub fn_is_trigger: PLpgSQL_trigtype,
+    pub fn_input_collation: Oid,
+    pub fn_hashkey: *mut PLpgSQL_func_hashkey,
+    pub fn_cxt: MemoryContext,
+    pub fn_rettype: Oid,
+    pub fn_rettyplen: ::std::os::raw::c_int,
+    pub fn_retbyval: bool,
+    pub fn_retistuple: bool,
+    pub fn_retisdomain: bool,
+    pub fn_retset: bool,
+    pub fn_readonly: bool,
+    pub fn_prokind: ::std::os::raw::c_char,
+    pub fn_nargs: ::std::os::raw::c_int,
+    pub fn_argvarnos: [::std::os::raw::c_int; 100usize],
+    pub out_param_varno: ::std::os::raw::c_int,
+    pub found_varno: ::std::os::raw::c_int,
+    pub new_varno: ::std::os::raw::c_int,
+    pub old_varno: ::std::os::raw::c_int,
+    pub resolve_option: PLpgSQL_resolve_option,
+    pub print_strict_params: bool,
+    pub extra_warnings: ::std::os::raw::c_int,
+    pub extra_errors: ::std::os::raw::c_int,
+    pub ndatums: ::std::os::raw::c_int,
+    pub datums: *mut *mut PLpgSQL_datum,
+    pub copiable_size: Size,
+    pub action: *mut PLpgSQL_stmt_block,
+    pub cur_estate: *mut PLpgSQL_execstate,
+    pub use_count: ::std::os::raw::c_ulong,
+}
+impl Default for PLpgSQL_function {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_execstate {
+    pub func: *mut PLpgSQL_function,
+    pub trigdata: *mut TriggerData,
+    pub evtrigdata: *mut EventTriggerData,
+    pub retval: Datum,
+    pub retisnull: bool,
+    pub rettype: Oid,
+    pub fn_rettype: Oid,
+    pub retistuple: bool,
+    pub retisset: bool,
+    pub readonly_func: bool,
+    pub atomic: bool,
+    pub exitlabel: *mut ::std::os::raw::c_char,
+    pub cur_error: *mut ErrorData,
+    pub tuple_store: *mut Tuplestorestate,
+    pub tuple_store_desc: TupleDesc,
+    pub tuple_store_cxt: MemoryContext,
+    pub tuple_store_owner: ResourceOwner,
+    pub rsi: *mut ReturnSetInfo,
+    pub found_varno: ::std::os::raw::c_int,
+    pub ndatums: ::std::os::raw::c_int,
+    pub datums: *mut *mut PLpgSQL_datum,
+    pub datum_context: MemoryContext,
+    pub paramLI: ParamListInfo,
+    pub simple_eval_estate: *mut EState,
+    pub cast_hash: *mut HTAB,
+    pub cast_hash_context: MemoryContext,
+    pub stmt_mcontext: MemoryContext,
+    pub stmt_mcontext_parent: MemoryContext,
+    pub eval_tuptable: *mut SPITupleTable,
+    pub eval_processed: uint64,
+    pub eval_lastoid: Oid,
+    pub eval_econtext: *mut ExprContext,
+    pub err_stmt: *mut PLpgSQL_stmt,
+    pub err_text: *const ::std::os::raw::c_char,
+    pub plugin_info: *mut ::std::os::raw::c_void,
+}
+impl Default for PLpgSQL_execstate {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct PLpgSQL_plugin {
+    pub func_setup: ::std::option::Option<
+        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, func: *mut PLpgSQL_function),
+    >,
+    pub func_beg: ::std::option::Option<
+        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, func: *mut PLpgSQL_function),
+    >,
+    pub func_end: ::std::option::Option<
+        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, func: *mut PLpgSQL_function),
+    >,
+    pub stmt_beg: ::std::option::Option<
+        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, stmt: *mut PLpgSQL_stmt),
+    >,
+    pub stmt_end: ::std::option::Option<
+        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, stmt: *mut PLpgSQL_stmt),
+    >,
+    pub error_callback:
+        ::std::option::Option<unsafe extern "C" fn(arg: *mut ::std::os::raw::c_void)>,
+    pub assign_expr: ::std::option::Option<
+        unsafe extern "C" fn(
+            estate: *mut PLpgSQL_execstate,
+            target: *mut PLpgSQL_datum,
+            expr: *mut PLpgSQL_expr,
+        ),
+    >,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLword {
+    pub ident: *mut ::std::os::raw::c_char,
+    pub quoted: bool,
+}
+impl Default for PLword {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLcword {
+    pub idents: *mut List,
+}
+impl Default for PLcword {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLwdatum {
+    pub datum: *mut PLpgSQL_datum,
+    pub ident: *mut ::std::os::raw::c_char,
+    pub quoted: bool,
+    pub idents: *mut List,
+}
+impl Default for PLwdatum {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub const IdentifierLookup_IDENTIFIER_LOOKUP_NORMAL: IdentifierLookup = 0;
+pub const IdentifierLookup_IDENTIFIER_LOOKUP_DECLARE: IdentifierLookup = 1;
+pub const IdentifierLookup_IDENTIFIER_LOOKUP_EXPR: IdentifierLookup = 2;
+#[doc = " Global variable declarations"]
+pub type IdentifierLookup = ::std::os::raw::c_uint;
+extern "C" {
+    pub static mut plpgsql_IdentifierLookup: IdentifierLookup;
+}
+extern "C" {
+    pub static mut plpgsql_variable_conflict: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut plpgsql_print_strict_params: bool;
+}
+extern "C" {
+    pub static mut plpgsql_check_asserts: bool;
+}
+extern "C" {
+    pub static mut plpgsql_extra_warnings: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut plpgsql_extra_errors: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut plpgsql_check_syntax: bool;
+}
+extern "C" {
+    pub static mut plpgsql_DumpExecTree: bool;
+}
+extern "C" {
+    pub static mut plpgsql_parse_result: *mut PLpgSQL_stmt_block;
+}
+extern "C" {
+    pub static mut plpgsql_nDatums: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut plpgsql_Datums: *mut *mut PLpgSQL_datum;
+}
+extern "C" {
+    pub static mut plpgsql_error_funcname: *mut ::std::os::raw::c_char;
+}
+extern "C" {
+    pub static mut plpgsql_curr_compile: *mut PLpgSQL_function;
+}
+extern "C" {
+    pub static mut plpgsql_compile_tmp_cxt: MemoryContext;
+}
+extern "C" {
+    pub static mut plpgsql_plugin_ptr: *mut *mut PLpgSQL_plugin;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    #[doc = " Function declarations"]
+    pub fn plpgsql_compile(fcinfo: FunctionCallInfo, forValidator: bool) -> *mut PLpgSQL_function;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_compile_inline(
+        proc_source: *mut ::std::os::raw::c_char,
+    ) -> *mut PLpgSQL_function;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_parser_setup(pstate: *mut ParseState, expr: *mut PLpgSQL_expr);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_parse_word(
+        word1: *mut ::std::os::raw::c_char,
+        yytxt: *const ::std::os::raw::c_char,
+        wdatum: *mut PLwdatum,
+        word: *mut PLword,
+    ) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_parse_dblword(
+        word1: *mut ::std::os::raw::c_char,
+        word2: *mut ::std::os::raw::c_char,
+        wdatum: *mut PLwdatum,
+        cword: *mut PLcword,
+    ) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_parse_tripword(
+        word1: *mut ::std::os::raw::c_char,
+        word2: *mut ::std::os::raw::c_char,
+        word3: *mut ::std::os::raw::c_char,
+        wdatum: *mut PLwdatum,
+        cword: *mut PLcword,
+    ) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_parse_wordtype(ident: *mut ::std::os::raw::c_char) -> *mut PLpgSQL_type;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_parse_cwordtype(idents: *mut List) -> *mut PLpgSQL_type;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_parse_wordrowtype(ident: *mut ::std::os::raw::c_char) -> *mut PLpgSQL_type;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_parse_cwordrowtype(idents: *mut List) -> *mut PLpgSQL_type;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_build_datatype(
+        typeOid: Oid,
+        typmod: int32,
+        collation: Oid,
+        origtypname: *mut TypeName,
+    ) -> *mut PLpgSQL_type;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_build_variable(
+        refname: *const ::std::os::raw::c_char,
+        lineno: ::std::os::raw::c_int,
+        dtype: *mut PLpgSQL_type,
+        add2namespace: bool,
+    ) -> *mut PLpgSQL_variable;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_build_record(
+        refname: *const ::std::os::raw::c_char,
+        lineno: ::std::os::raw::c_int,
+        dtype: *mut PLpgSQL_type,
+        rectypeid: Oid,
+        add2namespace: bool,
+    ) -> *mut PLpgSQL_rec;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_build_recfield(
+        rec: *mut PLpgSQL_rec,
+        fldname: *const ::std::os::raw::c_char,
+    ) -> *mut PLpgSQL_recfield;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_recognize_err_condition(
+        condname: *const ::std::os::raw::c_char,
+        allow_sqlstate: bool,
+    ) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_parse_err_condition(
+        condname: *mut ::std::os::raw::c_char,
+    ) -> *mut PLpgSQL_condition;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_adddatum(newdatum: *mut PLpgSQL_datum);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_add_initdatums(varnos: *mut *mut ::std::os::raw::c_int)
+        -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_HashTableInit();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn _PG_init();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_exec_function(
+        func: *mut PLpgSQL_function,
+        fcinfo: FunctionCallInfo,
+        simple_eval_estate: *mut EState,
+        atomic: bool,
+    ) -> Datum;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_exec_trigger(
+        func: *mut PLpgSQL_function,
+        trigdata: *mut TriggerData,
+    ) -> HeapTuple;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_exec_event_trigger(func: *mut PLpgSQL_function, trigdata: *mut EventTriggerData);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_xact_cb(event: XactEvent, arg: *mut ::std::os::raw::c_void);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_subxact_cb(
+        event: SubXactEvent,
+        mySubid: SubTransactionId,
+        parentSubid: SubTransactionId,
+        arg: *mut ::std::os::raw::c_void,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_exec_get_datum_type(
+        estate: *mut PLpgSQL_execstate,
+        datum: *mut PLpgSQL_datum,
+    ) -> Oid;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_exec_get_datum_type_info(
+        estate: *mut PLpgSQL_execstate,
+        datum: *mut PLpgSQL_datum,
+        typeId: *mut Oid,
+        typMod: *mut int32,
+        collation: *mut Oid,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_ns_init();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_ns_push(label: *const ::std::os::raw::c_char, label_type: PLpgSQL_label_type);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_ns_pop();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_ns_top() -> *mut PLpgSQL_nsitem;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_ns_additem(
+        itemtype: PLpgSQL_nsitem_type,
+        itemno: ::std::os::raw::c_int,
+        name: *const ::std::os::raw::c_char,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_ns_lookup(
+        ns_cur: *mut PLpgSQL_nsitem,
+        localmode: bool,
+        name1: *const ::std::os::raw::c_char,
+        name2: *const ::std::os::raw::c_char,
+        name3: *const ::std::os::raw::c_char,
+        names_used: *mut ::std::os::raw::c_int,
+    ) -> *mut PLpgSQL_nsitem;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_ns_lookup_label(
+        ns_cur: *mut PLpgSQL_nsitem,
+        name: *const ::std::os::raw::c_char,
+    ) -> *mut PLpgSQL_nsitem;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_ns_find_nearest_loop(ns_cur: *mut PLpgSQL_nsitem) -> *mut PLpgSQL_nsitem;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_stmt_typename(stmt: *mut PLpgSQL_stmt) -> *const ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_getdiag_kindname(kind: PLpgSQL_getdiag_kind) -> *const ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_free_function_memory(func: *mut PLpgSQL_function);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_dumptree(func: *mut PLpgSQL_function);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_base_yylex() -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_yylex() -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_push_back_token(token: ::std::os::raw::c_int);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_token_is_unreserved_keyword(token: ::std::os::raw::c_int) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_append_source_text(
+        buf: StringInfo,
+        startlocation: ::std::os::raw::c_int,
+        endlocation: ::std::os::raw::c_int,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_peek() -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_peek2(
+        tok1_p: *mut ::std::os::raw::c_int,
+        tok2_p: *mut ::std::os::raw::c_int,
+        tok1_loc: *mut ::std::os::raw::c_int,
+        tok2_loc: *mut ::std::os::raw::c_int,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_scanner_errposition(location: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_yyerror(message: *const ::std::os::raw::c_char);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_location_to_lineno(location: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_latest_lineno() -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_scanner_init(str_: *const ::std::os::raw::c_char);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_scanner_finish();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_yyparse() -> ::std::os::raw::c_int;
+}
 pub const ReplicationSlotPersistency_RS_PERSISTENT: ReplicationSlotPersistency = 0;
 pub const ReplicationSlotPersistency_RS_EPHEMERAL: ReplicationSlotPersistency = 1;
 pub const ReplicationSlotPersistency_RS_TEMPORARY: ReplicationSlotPersistency = 2;
@@ -39699,6 +41785,61 @@ extern "C" {
         include_triggers: bool,
         include_cols: *mut Bitmapset,
     ) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct RowSecurityPolicy {
+    pub policy_name: *mut ::std::os::raw::c_char,
+    pub polcmd: ::std::os::raw::c_char,
+    pub roles: *mut ArrayType,
+    pub permissive: bool,
+    pub qual: *mut Expr,
+    pub with_check_qual: *mut Expr,
+    pub hassublinks: bool,
+}
+impl Default for RowSecurityPolicy {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct RowSecurityDesc {
+    pub rscxt: MemoryContext,
+    pub policies: *mut List,
+}
+impl Default for RowSecurityDesc {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type row_security_policy_hook_type =
+    ::std::option::Option<unsafe extern "C" fn(cmdtype: CmdType, relation: Relation) -> *mut List>;
+extern "C" {
+    pub static mut row_security_policy_hook_permissive: row_security_policy_hook_type;
+}
+extern "C" {
+    pub static mut row_security_policy_hook_restrictive: row_security_policy_hook_type;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_row_security_policies(
+        root: *mut Query,
+        rte: *mut RangeTblEntry,
+        rt_index: ::std::os::raw::c_int,
+        securityQuals: *mut *mut List,
+        withCheckOptions: *mut *mut List,
+        hasRowSecurity: *mut bool,
+        hasSubLinks: *mut bool,
+    );
 }
 extern "C" {
     pub static mut old_snapshot_threshold: ::std::os::raw::c_int;
@@ -54934,157 +57075,6 @@ extern "C" {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct DomainConstraintCache {
-    _unused: [u8; 0],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct TypeCacheEnumData {
-    _unused: [u8; 0],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct TypeCacheEntry {
-    pub type_id: Oid,
-    pub typlen: int16,
-    pub typbyval: bool,
-    pub typalign: ::std::os::raw::c_char,
-    pub typstorage: ::std::os::raw::c_char,
-    pub typtype: ::std::os::raw::c_char,
-    pub typrelid: Oid,
-    pub typelem: Oid,
-    pub btree_opf: Oid,
-    pub btree_opintype: Oid,
-    pub hash_opf: Oid,
-    pub hash_opintype: Oid,
-    pub eq_opr: Oid,
-    pub lt_opr: Oid,
-    pub gt_opr: Oid,
-    pub cmp_proc: Oid,
-    pub hash_proc: Oid,
-    pub hash_extended_proc: Oid,
-    pub eq_opr_finfo: FmgrInfo,
-    pub cmp_proc_finfo: FmgrInfo,
-    pub hash_proc_finfo: FmgrInfo,
-    pub hash_extended_proc_finfo: FmgrInfo,
-    pub tupDesc: TupleDesc,
-    pub tupDesc_identifier: uint64,
-    pub rngelemtype: *mut TypeCacheEntry,
-    pub rng_collation: Oid,
-    pub rng_cmp_proc_finfo: FmgrInfo,
-    pub rng_canonical_finfo: FmgrInfo,
-    pub rng_subdiff_finfo: FmgrInfo,
-    pub domainBaseType: Oid,
-    pub domainBaseTypmod: int32,
-    pub domainData: *mut DomainConstraintCache,
-    pub flags: ::std::os::raw::c_int,
-    pub enumData: *mut TypeCacheEnumData,
-    pub nextDomain: *mut TypeCacheEntry,
-}
-impl Default for TypeCacheEntry {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct DomainConstraintRef {
-    pub constraints: *mut List,
-    pub refctx: MemoryContext,
-    pub tcache: *mut TypeCacheEntry,
-    pub need_exprstate: bool,
-    pub dcc: *mut DomainConstraintCache,
-    pub callback: MemoryContextCallback,
-}
-impl Default for DomainConstraintRef {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct SharedRecordTypmodRegistry {
-    _unused: [u8; 0],
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn lookup_type_cache(type_id: Oid, flags: ::std::os::raw::c_int) -> *mut TypeCacheEntry;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn InitDomainConstraintRef(
-        type_id: Oid,
-        ref_: *mut DomainConstraintRef,
-        refctx: MemoryContext,
-        need_exprstate: bool,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn UpdateDomainConstraintRef(ref_: *mut DomainConstraintRef);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn DomainHasConstraints(type_id: Oid) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn lookup_rowtype_tupdesc(type_id: Oid, typmod: int32) -> TupleDesc;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn lookup_rowtype_tupdesc_noerror(type_id: Oid, typmod: int32, noError: bool) -> TupleDesc;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn lookup_rowtype_tupdesc_copy(type_id: Oid, typmod: int32) -> TupleDesc;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn lookup_rowtype_tupdesc_domain(type_id: Oid, typmod: int32, noError: bool) -> TupleDesc;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn assign_record_type_typmod(tupDesc: TupleDesc);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn assign_record_type_identifier(type_id: Oid, typmod: int32) -> uint64;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn compare_values_of_enum(
-        tcache: *mut TypeCacheEntry,
-        arg1: Oid,
-        arg2: Oid,
-    ) -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn SharedRecordTypmodRegistryEstimate() -> usize;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn SharedRecordTypmodRegistryInit(
-        arg1: *mut SharedRecordTypmodRegistry,
-        segment: *mut dsm_segment,
-        area: *mut dsa_area,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn SharedRecordTypmodRegistryAttach(arg1: *mut SharedRecordTypmodRegistry);
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
 pub struct RangeType {
     pub vl_len_: int32,
     pub rangetypid: Oid,
@@ -55352,11 +57342,6 @@ pub struct SnapBuild {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct _MdfdVec {
-    pub _address: u8,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct RowSecurityDesc {
     pub _address: u8,
 }
 impl pg_sys::seal::Sealed for A_ArrayExpr {}

--- a/pgrx-pg-sys/src/pg12.rs
+++ b/pgrx-pg-sys/src/pg12.rs
@@ -3154,6 +3154,36 @@ pub const PVC_RECURSE_WINDOWFUNCS: u32 = 8;
 pub const PVC_INCLUDE_PLACEHOLDERS: u32 = 16;
 pub const PVC_RECURSE_PLACEHOLDERS: u32 = 32;
 pub const DEFAULT_CURSOR_TUPLE_FRACTION: f64 = 0.1;
+pub const ER_MAGIC: u32 = 1384727874;
+pub const ER_FLAG_FVALUE_VALID: u32 = 1;
+pub const ER_FLAG_FVALUE_ALLOCED: u32 = 2;
+pub const ER_FLAG_DVALUES_VALID: u32 = 4;
+pub const ER_FLAG_DVALUES_ALLOCED: u32 = 8;
+pub const ER_FLAG_HAVE_EXTERNAL: u32 = 16;
+pub const ER_FLAG_TUPDESC_ALLOCED: u32 = 32;
+pub const ER_FLAG_IS_DOMAIN: u32 = 64;
+pub const ER_FLAG_IS_DUMMY: u32 = 128;
+pub const ER_FLAGS_NON_DATA: u32 = 224;
+pub const TYPECACHE_EQ_OPR: u32 = 1;
+pub const TYPECACHE_LT_OPR: u32 = 2;
+pub const TYPECACHE_GT_OPR: u32 = 4;
+pub const TYPECACHE_CMP_PROC: u32 = 8;
+pub const TYPECACHE_HASH_PROC: u32 = 16;
+pub const TYPECACHE_EQ_OPR_FINFO: u32 = 32;
+pub const TYPECACHE_CMP_PROC_FINFO: u32 = 64;
+pub const TYPECACHE_HASH_PROC_FINFO: u32 = 128;
+pub const TYPECACHE_TUPDESC: u32 = 256;
+pub const TYPECACHE_BTREE_OPFAMILY: u32 = 512;
+pub const TYPECACHE_HASH_OPFAMILY: u32 = 1024;
+pub const TYPECACHE_RANGE_INFO: u32 = 2048;
+pub const TYPECACHE_DOMAIN_BASE_INFO: u32 = 4096;
+pub const TYPECACHE_DOMAIN_CONSTR_INFO: u32 = 8192;
+pub const TYPECACHE_HASH_EXTENDED_PROC: u32 = 16384;
+pub const TYPECACHE_HASH_EXTENDED_PROC_FINFO: u32 = 32768;
+pub const PLPGSQL_XCHECK_NONE: u32 = 0;
+pub const PLPGSQL_XCHECK_SHADOWVAR: u32 = 2;
+pub const PLPGSQL_XCHECK_TOOMANYROWS: u32 = 4;
+pub const PLPGSQL_XCHECK_STRICTMULTIASSIGNMENT: u32 = 8;
 pub const OLD_SNAPSHOT_PADDING_ENTRIES: u32 = 10;
 pub const MAX_IO_CONCURRENCY: u32 = 1000;
 pub const BUFFER_LOCK_UNLOCK: u32 = 0;
@@ -3171,6 +3201,7 @@ pub const PROCARRAY_FLAGS_DEFAULT: u32 = 16;
 pub const PROCARRAY_FLAGS_VACUUM: u32 = 18;
 pub const PROCARRAY_FLAGS_ANALYZE: u32 = 20;
 pub const PROCARRAY_FLAGS_VACUUM_ANALYZE: u32 = 22;
+pub const STACK_DEPTH_SLOP: u32 = 524288;
 pub const MAXSTRLEN: u32 = 2047;
 pub const MAXSTRPOS: u32 = 1048575;
 pub const MAXENTRYPOS: u32 = 16384;
@@ -3199,7 +3230,6 @@ pub const TSearchWithClassStrategyNumber: u32 = 2;
 pub const QTN_NEEDFREE: u32 = 1;
 pub const QTN_NOCHANGE: u32 = 2;
 pub const QTN_WORDFREE: u32 = 4;
-pub const STACK_DEPTH_SLOP: u32 = 524288;
 pub const FORMAT_TYPE_TYPEMOD_GIVEN: u32 = 1;
 pub const FORMAT_TYPE_ALLOW_INVALID: u32 = 2;
 pub const FORMAT_TYPE_FORCE_QUALIFY: u32 = 4;
@@ -3246,22 +3276,6 @@ pub const DEFAULT_MATCH_SEL: f64 = 0.005;
 pub const DEFAULT_NUM_DISTINCT: u32 = 200;
 pub const DEFAULT_UNK_SEL: f64 = 0.005;
 pub const DEFAULT_NOT_UNK_SEL: f64 = 0.995;
-pub const TYPECACHE_EQ_OPR: u32 = 1;
-pub const TYPECACHE_LT_OPR: u32 = 2;
-pub const TYPECACHE_GT_OPR: u32 = 4;
-pub const TYPECACHE_CMP_PROC: u32 = 8;
-pub const TYPECACHE_HASH_PROC: u32 = 16;
-pub const TYPECACHE_EQ_OPR_FINFO: u32 = 32;
-pub const TYPECACHE_CMP_PROC_FINFO: u32 = 64;
-pub const TYPECACHE_HASH_PROC_FINFO: u32 = 128;
-pub const TYPECACHE_TUPDESC: u32 = 256;
-pub const TYPECACHE_BTREE_OPFAMILY: u32 = 512;
-pub const TYPECACHE_HASH_OPFAMILY: u32 = 1024;
-pub const TYPECACHE_RANGE_INFO: u32 = 2048;
-pub const TYPECACHE_DOMAIN_BASE_INFO: u32 = 4096;
-pub const TYPECACHE_DOMAIN_CONSTR_INFO: u32 = 8192;
-pub const TYPECACHE_HASH_EXTENDED_PROC: u32 = 16384;
-pub const TYPECACHE_HASH_EXTENDED_PROC_FINFO: u32 = 32768;
 pub const RANGE_EMPTY: u32 = 1;
 pub const RANGE_LB_INC: u32 = 2;
 pub const RANGE_UB_INC: u32 = 4;
@@ -31281,6 +31295,91 @@ extern "C" {
         sarray_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
+pub const ObjectAccessType_OAT_POST_CREATE: ObjectAccessType = 0;
+pub const ObjectAccessType_OAT_DROP: ObjectAccessType = 1;
+pub const ObjectAccessType_OAT_POST_ALTER: ObjectAccessType = 2;
+pub const ObjectAccessType_OAT_NAMESPACE_SEARCH: ObjectAccessType = 3;
+pub const ObjectAccessType_OAT_FUNCTION_EXECUTE: ObjectAccessType = 4;
+pub type ObjectAccessType = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ObjectAccessPostCreate {
+    pub is_internal: bool,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ObjectAccessDrop {
+    pub dropflags: ::std::os::raw::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ObjectAccessPostAlter {
+    pub auxiliary_id: Oid,
+    pub is_internal: bool,
+}
+impl Default for ObjectAccessPostAlter {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ObjectAccessNamespaceSearch {
+    pub ereport_on_violation: bool,
+    pub result: bool,
+}
+pub type object_access_hook_type = ::std::option::Option<
+    unsafe extern "C" fn(
+        access: ObjectAccessType,
+        classId: Oid,
+        objectId: Oid,
+        subId: ::std::os::raw::c_int,
+        arg: *mut ::std::os::raw::c_void,
+    ),
+>;
+extern "C" {
+    pub static mut object_access_hook: object_access_hook_type;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RunObjectPostCreateHook(
+        classId: Oid,
+        objectId: Oid,
+        subId: ::std::os::raw::c_int,
+        is_internal: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RunObjectDropHook(
+        classId: Oid,
+        objectId: Oid,
+        subId: ::std::os::raw::c_int,
+        dropflags: ::std::os::raw::c_int,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RunObjectPostAlterHook(
+        classId: Oid,
+        objectId: Oid,
+        subId: ::std::os::raw::c_int,
+        auxiliaryId: Oid,
+        is_internal: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RunNamespaceSearchHook(objectId: Oid, ereport_on_violation: bool) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RunFunctionExecuteHook(objectId: Oid);
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct FormData_pg_authid {
@@ -33476,6 +33575,103 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn RI_FKey_trigger_type(tgfoid: Oid) -> ::std::os::raw::c_int;
+}
+pub const PasswordType_PASSWORD_TYPE_PLAINTEXT: PasswordType = 0;
+pub const PasswordType_PASSWORD_TYPE_MD5: PasswordType = 1;
+pub const PasswordType_PASSWORD_TYPE_SCRAM_SHA_256: PasswordType = 2;
+pub type PasswordType = ::std::os::raw::c_uint;
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_password_type(shadow_pass: *const ::std::os::raw::c_char) -> PasswordType;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn encrypt_password(
+        target_type: PasswordType,
+        role: *const ::std::os::raw::c_char,
+        password: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_role_password(
+        role: *const ::std::os::raw::c_char,
+        logdetail: *mut *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn md5_crypt_verify(
+        role: *const ::std::os::raw::c_char,
+        shadow_pass: *const ::std::os::raw::c_char,
+        client_pass: *const ::std::os::raw::c_char,
+        md5_salt: *const ::std::os::raw::c_char,
+        md5_salt_len: ::std::os::raw::c_int,
+        logdetail: *mut *mut ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plain_crypt_verify(
+        role: *const ::std::os::raw::c_char,
+        shadow_pass: *const ::std::os::raw::c_char,
+        client_pass: *const ::std::os::raw::c_char,
+        logdetail: *mut *mut ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut Password_encryption: ::std::os::raw::c_int;
+}
+pub type check_password_hook_type = ::std::option::Option<
+    unsafe extern "C" fn(
+        username: *const ::std::os::raw::c_char,
+        shadow_pass: *const ::std::os::raw::c_char,
+        password_type: PasswordType,
+        validuntil_time: Datum,
+        validuntil_null: bool,
+    ),
+>;
+extern "C" {
+    pub static mut check_password_hook: check_password_hook_type;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn CreateRole(pstate: *mut ParseState, stmt: *mut CreateRoleStmt) -> Oid;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn AlterRole(stmt: *mut AlterRoleStmt) -> Oid;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn AlterRoleSet(stmt: *mut AlterRoleSetStmt) -> Oid;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DropRole(stmt: *mut DropRoleStmt);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GrantRole(stmt: *mut GrantRoleStmt);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RenameRole(
+        oldname: *const ::std::os::raw::c_char,
+        newname: *const ::std::os::raw::c_char,
+    ) -> ObjectAddress;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DropOwnedObjects(stmt: *mut DropOwnedStmt);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ReassignOwnedObjects(stmt: *mut ReassignOwnedStmt);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn roleSpecsToIds(memberNames: *mut List) -> *mut List;
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -40211,6 +40407,119 @@ extern "C" {
         live_childrels: *mut List,
     );
 }
+pub type get_relation_info_hook_type = ::std::option::Option<
+    unsafe extern "C" fn(
+        root: *mut PlannerInfo,
+        relationObjectId: Oid,
+        inhparent: bool,
+        rel: *mut RelOptInfo,
+    ),
+>;
+extern "C" {
+    pub static mut get_relation_info_hook: get_relation_info_hook_type;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_relation_info(
+        root: *mut PlannerInfo,
+        relationObjectId: Oid,
+        inhparent: bool,
+        rel: *mut RelOptInfo,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn infer_arbiter_indexes(root: *mut PlannerInfo) -> *mut List;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn estimate_rel_size(
+        rel: Relation,
+        attr_widths: *mut int32,
+        pages: *mut BlockNumber,
+        tuples: *mut f64,
+        allvisfrac: *mut f64,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_rel_data_width(rel: Relation, attr_widths: *mut int32) -> int32;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_relation_data_width(relid: Oid, attr_widths: *mut int32) -> int32;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn relation_excluded_by_constraints(
+        root: *mut PlannerInfo,
+        rel: *mut RelOptInfo,
+        rte: *mut RangeTblEntry,
+    ) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn build_physical_tlist(root: *mut PlannerInfo, rel: *mut RelOptInfo) -> *mut List;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn has_unique_index(rel: *mut RelOptInfo, attno: AttrNumber) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn restriction_selectivity(
+        root: *mut PlannerInfo,
+        operatorid: Oid,
+        args: *mut List,
+        inputcollid: Oid,
+        varRelid: ::std::os::raw::c_int,
+    ) -> Selectivity;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn join_selectivity(
+        root: *mut PlannerInfo,
+        operatorid: Oid,
+        args: *mut List,
+        inputcollid: Oid,
+        jointype: JoinType,
+        sjinfo: *mut SpecialJoinInfo,
+    ) -> Selectivity;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn function_selectivity(
+        root: *mut PlannerInfo,
+        funcid: Oid,
+        args: *mut List,
+        inputcollid: Oid,
+        is_join: bool,
+        varRelid: ::std::os::raw::c_int,
+        jointype: JoinType,
+        sjinfo: *mut SpecialJoinInfo,
+    ) -> Selectivity;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn add_function_cost(
+        root: *mut PlannerInfo,
+        funcid: Oid,
+        node: *mut Node,
+        cost: *mut QualCost,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_function_rows(root: *mut PlannerInfo, funcid: Oid, node: *mut Node) -> f64;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn has_row_triggers(root: *mut PlannerInfo, rti: Index, event: CmdType) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn has_stored_generated_columns(root: *mut PlannerInfo, rti: Index) -> bool;
+}
 extern "C" {
     pub static mut cursor_tuple_fraction: f64;
 }
@@ -41267,6 +41576,1852 @@ extern "C" {
 extern "C" {
     pub fn get_parse_rowmark(qry: *mut Query, rtindex: Index) -> *mut RowMarkClause;
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ExpandedRecordHeader {
+    pub hdr: ExpandedObjectHeader,
+    pub er_magic: ::std::os::raw::c_int,
+    pub flags: ::std::os::raw::c_int,
+    pub er_decltypeid: Oid,
+    pub er_typeid: Oid,
+    pub er_typmod: int32,
+    pub er_tupdesc: TupleDesc,
+    pub er_tupdesc_id: uint64,
+    pub dvalues: *mut Datum,
+    pub dnulls: *mut bool,
+    pub nfields: ::std::os::raw::c_int,
+    pub flat_size: Size,
+    pub data_len: Size,
+    pub hoff: ::std::os::raw::c_int,
+    pub hasnull: bool,
+    pub fvalue: HeapTuple,
+    pub fstartptr: *mut ::std::os::raw::c_char,
+    pub fendptr: *mut ::std::os::raw::c_char,
+    pub er_short_term_cxt: MemoryContext,
+    pub er_dummy_header: *mut ExpandedRecordHeader,
+    pub er_domaininfo: *mut ::std::os::raw::c_void,
+    pub er_mcb: MemoryContextCallback,
+}
+impl Default for ExpandedRecordHeader {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ExpandedRecordFieldInfo {
+    pub fnumber: ::std::os::raw::c_int,
+    pub ftypeid: Oid,
+    pub ftypmod: int32,
+    pub fcollation: Oid,
+}
+impl Default for ExpandedRecordFieldInfo {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn make_expanded_record_from_typeid(
+        type_id: Oid,
+        typmod: int32,
+        parentcontext: MemoryContext,
+    ) -> *mut ExpandedRecordHeader;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn make_expanded_record_from_tupdesc(
+        tupdesc: TupleDesc,
+        parentcontext: MemoryContext,
+    ) -> *mut ExpandedRecordHeader;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn make_expanded_record_from_exprecord(
+        olderh: *mut ExpandedRecordHeader,
+        parentcontext: MemoryContext,
+    ) -> *mut ExpandedRecordHeader;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn expanded_record_set_tuple(
+        erh: *mut ExpandedRecordHeader,
+        tuple: HeapTuple,
+        copy: bool,
+        expand_external: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn make_expanded_record_from_datum(
+        recorddatum: Datum,
+        parentcontext: MemoryContext,
+    ) -> Datum;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn expanded_record_fetch_tupdesc(erh: *mut ExpandedRecordHeader) -> TupleDesc;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn expanded_record_get_tuple(erh: *mut ExpandedRecordHeader) -> HeapTuple;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DatumGetExpandedRecord(d: Datum) -> *mut ExpandedRecordHeader;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn deconstruct_expanded_record(erh: *mut ExpandedRecordHeader);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn expanded_record_lookup_field(
+        erh: *mut ExpandedRecordHeader,
+        fieldname: *const ::std::os::raw::c_char,
+        finfo: *mut ExpandedRecordFieldInfo,
+    ) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn expanded_record_fetch_field(
+        erh: *mut ExpandedRecordHeader,
+        fnumber: ::std::os::raw::c_int,
+        isnull: *mut bool,
+    ) -> Datum;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn expanded_record_set_field_internal(
+        erh: *mut ExpandedRecordHeader,
+        fnumber: ::std::os::raw::c_int,
+        newValue: Datum,
+        isnull: bool,
+        expand_external: bool,
+        check_constraints: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn expanded_record_set_fields(
+        erh: *mut ExpandedRecordHeader,
+        newValues: *const Datum,
+        isnulls: *const bool,
+        expand_external: bool,
+    );
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct DomainConstraintCache {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct TypeCacheEnumData {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct TypeCacheEntry {
+    pub type_id: Oid,
+    pub typlen: int16,
+    pub typbyval: bool,
+    pub typalign: ::std::os::raw::c_char,
+    pub typstorage: ::std::os::raw::c_char,
+    pub typtype: ::std::os::raw::c_char,
+    pub typrelid: Oid,
+    pub typelem: Oid,
+    pub typcollation: Oid,
+    pub btree_opf: Oid,
+    pub btree_opintype: Oid,
+    pub hash_opf: Oid,
+    pub hash_opintype: Oid,
+    pub eq_opr: Oid,
+    pub lt_opr: Oid,
+    pub gt_opr: Oid,
+    pub cmp_proc: Oid,
+    pub hash_proc: Oid,
+    pub hash_extended_proc: Oid,
+    pub eq_opr_finfo: FmgrInfo,
+    pub cmp_proc_finfo: FmgrInfo,
+    pub hash_proc_finfo: FmgrInfo,
+    pub hash_extended_proc_finfo: FmgrInfo,
+    pub tupDesc: TupleDesc,
+    pub tupDesc_identifier: uint64,
+    pub rngelemtype: *mut TypeCacheEntry,
+    pub rng_collation: Oid,
+    pub rng_cmp_proc_finfo: FmgrInfo,
+    pub rng_canonical_finfo: FmgrInfo,
+    pub rng_subdiff_finfo: FmgrInfo,
+    pub domainBaseType: Oid,
+    pub domainBaseTypmod: int32,
+    pub domainData: *mut DomainConstraintCache,
+    pub flags: ::std::os::raw::c_int,
+    pub enumData: *mut TypeCacheEnumData,
+    pub nextDomain: *mut TypeCacheEntry,
+}
+impl Default for TypeCacheEntry {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct DomainConstraintRef {
+    pub constraints: *mut List,
+    pub refctx: MemoryContext,
+    pub tcache: *mut TypeCacheEntry,
+    pub need_exprstate: bool,
+    pub dcc: *mut DomainConstraintCache,
+    pub callback: MemoryContextCallback,
+}
+impl Default for DomainConstraintRef {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct SharedRecordTypmodRegistry {
+    _unused: [u8; 0],
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn lookup_type_cache(type_id: Oid, flags: ::std::os::raw::c_int) -> *mut TypeCacheEntry;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn InitDomainConstraintRef(
+        type_id: Oid,
+        ref_: *mut DomainConstraintRef,
+        refctx: MemoryContext,
+        need_exprstate: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UpdateDomainConstraintRef(ref_: *mut DomainConstraintRef);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DomainHasConstraints(type_id: Oid) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn lookup_rowtype_tupdesc(type_id: Oid, typmod: int32) -> TupleDesc;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn lookup_rowtype_tupdesc_noerror(type_id: Oid, typmod: int32, noError: bool) -> TupleDesc;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn lookup_rowtype_tupdesc_copy(type_id: Oid, typmod: int32) -> TupleDesc;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn lookup_rowtype_tupdesc_domain(type_id: Oid, typmod: int32, noError: bool) -> TupleDesc;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn assign_record_type_typmod(tupDesc: TupleDesc);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn assign_record_type_identifier(type_id: Oid, typmod: int32) -> uint64;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn compare_values_of_enum(
+        tcache: *mut TypeCacheEntry,
+        arg1: Oid,
+        arg2: Oid,
+    ) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SharedRecordTypmodRegistryEstimate() -> usize;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SharedRecordTypmodRegistryInit(
+        arg1: *mut SharedRecordTypmodRegistry,
+        segment: *mut dsm_segment,
+        area: *mut dsa_area,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SharedRecordTypmodRegistryAttach(arg1: *mut SharedRecordTypmodRegistry);
+}
+pub const PLpgSQL_nsitem_type_PLPGSQL_NSTYPE_LABEL: PLpgSQL_nsitem_type = 0;
+pub const PLpgSQL_nsitem_type_PLPGSQL_NSTYPE_VAR: PLpgSQL_nsitem_type = 1;
+pub const PLpgSQL_nsitem_type_PLPGSQL_NSTYPE_REC: PLpgSQL_nsitem_type = 2;
+pub type PLpgSQL_nsitem_type = ::std::os::raw::c_uint;
+pub const PLpgSQL_label_type_PLPGSQL_LABEL_BLOCK: PLpgSQL_label_type = 0;
+pub const PLpgSQL_label_type_PLPGSQL_LABEL_LOOP: PLpgSQL_label_type = 1;
+pub const PLpgSQL_label_type_PLPGSQL_LABEL_OTHER: PLpgSQL_label_type = 2;
+pub type PLpgSQL_label_type = ::std::os::raw::c_uint;
+pub const PLpgSQL_datum_type_PLPGSQL_DTYPE_VAR: PLpgSQL_datum_type = 0;
+pub const PLpgSQL_datum_type_PLPGSQL_DTYPE_ROW: PLpgSQL_datum_type = 1;
+pub const PLpgSQL_datum_type_PLPGSQL_DTYPE_REC: PLpgSQL_datum_type = 2;
+pub const PLpgSQL_datum_type_PLPGSQL_DTYPE_RECFIELD: PLpgSQL_datum_type = 3;
+pub const PLpgSQL_datum_type_PLPGSQL_DTYPE_ARRAYELEM: PLpgSQL_datum_type = 4;
+pub const PLpgSQL_datum_type_PLPGSQL_DTYPE_PROMISE: PLpgSQL_datum_type = 5;
+pub type PLpgSQL_datum_type = ::std::os::raw::c_uint;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_NONE: PLpgSQL_promise_type = 0;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_NAME: PLpgSQL_promise_type = 1;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_WHEN: PLpgSQL_promise_type = 2;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_LEVEL: PLpgSQL_promise_type = 3;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_OP: PLpgSQL_promise_type = 4;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_RELID: PLpgSQL_promise_type = 5;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_TABLE_NAME: PLpgSQL_promise_type = 6;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_TABLE_SCHEMA: PLpgSQL_promise_type = 7;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_NARGS: PLpgSQL_promise_type = 8;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_ARGV: PLpgSQL_promise_type = 9;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_EVENT: PLpgSQL_promise_type = 10;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_TAG: PLpgSQL_promise_type = 11;
+pub type PLpgSQL_promise_type = ::std::os::raw::c_uint;
+pub const PLpgSQL_type_type_PLPGSQL_TTYPE_SCALAR: PLpgSQL_type_type = 0;
+pub const PLpgSQL_type_type_PLPGSQL_TTYPE_REC: PLpgSQL_type_type = 1;
+pub const PLpgSQL_type_type_PLPGSQL_TTYPE_PSEUDO: PLpgSQL_type_type = 2;
+pub type PLpgSQL_type_type = ::std::os::raw::c_uint;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_BLOCK: PLpgSQL_stmt_type = 0;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_ASSIGN: PLpgSQL_stmt_type = 1;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_IF: PLpgSQL_stmt_type = 2;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_CASE: PLpgSQL_stmt_type = 3;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_LOOP: PLpgSQL_stmt_type = 4;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_WHILE: PLpgSQL_stmt_type = 5;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_FORI: PLpgSQL_stmt_type = 6;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_FORS: PLpgSQL_stmt_type = 7;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_FORC: PLpgSQL_stmt_type = 8;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_FOREACH_A: PLpgSQL_stmt_type = 9;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_EXIT: PLpgSQL_stmt_type = 10;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_RETURN: PLpgSQL_stmt_type = 11;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_RETURN_NEXT: PLpgSQL_stmt_type = 12;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_RETURN_QUERY: PLpgSQL_stmt_type = 13;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_RAISE: PLpgSQL_stmt_type = 14;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_ASSERT: PLpgSQL_stmt_type = 15;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_EXECSQL: PLpgSQL_stmt_type = 16;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_DYNEXECUTE: PLpgSQL_stmt_type = 17;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_DYNFORS: PLpgSQL_stmt_type = 18;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_GETDIAG: PLpgSQL_stmt_type = 19;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_OPEN: PLpgSQL_stmt_type = 20;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_FETCH: PLpgSQL_stmt_type = 21;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_CLOSE: PLpgSQL_stmt_type = 22;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_PERFORM: PLpgSQL_stmt_type = 23;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_CALL: PLpgSQL_stmt_type = 24;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_COMMIT: PLpgSQL_stmt_type = 25;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_ROLLBACK: PLpgSQL_stmt_type = 26;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_SET: PLpgSQL_stmt_type = 27;
+pub type PLpgSQL_stmt_type = ::std::os::raw::c_uint;
+pub const PLPGSQL_RC_OK: _bindgen_ty_19 = 0;
+pub const PLPGSQL_RC_EXIT: _bindgen_ty_19 = 1;
+pub const PLPGSQL_RC_RETURN: _bindgen_ty_19 = 2;
+pub const PLPGSQL_RC_CONTINUE: _bindgen_ty_19 = 3;
+pub type _bindgen_ty_19 = ::std::os::raw::c_uint;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_ROW_COUNT: PLpgSQL_getdiag_kind = 0;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_CONTEXT: PLpgSQL_getdiag_kind = 1;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_ERROR_CONTEXT: PLpgSQL_getdiag_kind = 2;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_ERROR_DETAIL: PLpgSQL_getdiag_kind = 3;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_ERROR_HINT: PLpgSQL_getdiag_kind = 4;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_RETURNED_SQLSTATE: PLpgSQL_getdiag_kind = 5;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_COLUMN_NAME: PLpgSQL_getdiag_kind = 6;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_CONSTRAINT_NAME: PLpgSQL_getdiag_kind = 7;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_DATATYPE_NAME: PLpgSQL_getdiag_kind = 8;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_MESSAGE_TEXT: PLpgSQL_getdiag_kind = 9;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_TABLE_NAME: PLpgSQL_getdiag_kind = 10;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_SCHEMA_NAME: PLpgSQL_getdiag_kind = 11;
+pub type PLpgSQL_getdiag_kind = ::std::os::raw::c_uint;
+pub const PLpgSQL_raise_option_type_PLPGSQL_RAISEOPTION_ERRCODE: PLpgSQL_raise_option_type = 0;
+pub const PLpgSQL_raise_option_type_PLPGSQL_RAISEOPTION_MESSAGE: PLpgSQL_raise_option_type = 1;
+pub const PLpgSQL_raise_option_type_PLPGSQL_RAISEOPTION_DETAIL: PLpgSQL_raise_option_type = 2;
+pub const PLpgSQL_raise_option_type_PLPGSQL_RAISEOPTION_HINT: PLpgSQL_raise_option_type = 3;
+pub const PLpgSQL_raise_option_type_PLPGSQL_RAISEOPTION_COLUMN: PLpgSQL_raise_option_type = 4;
+pub const PLpgSQL_raise_option_type_PLPGSQL_RAISEOPTION_CONSTRAINT: PLpgSQL_raise_option_type = 5;
+pub const PLpgSQL_raise_option_type_PLPGSQL_RAISEOPTION_DATATYPE: PLpgSQL_raise_option_type = 6;
+pub const PLpgSQL_raise_option_type_PLPGSQL_RAISEOPTION_TABLE: PLpgSQL_raise_option_type = 7;
+pub const PLpgSQL_raise_option_type_PLPGSQL_RAISEOPTION_SCHEMA: PLpgSQL_raise_option_type = 8;
+pub type PLpgSQL_raise_option_type = ::std::os::raw::c_uint;
+pub const PLpgSQL_resolve_option_PLPGSQL_RESOLVE_ERROR: PLpgSQL_resolve_option = 0;
+pub const PLpgSQL_resolve_option_PLPGSQL_RESOLVE_VARIABLE: PLpgSQL_resolve_option = 1;
+pub const PLpgSQL_resolve_option_PLPGSQL_RESOLVE_COLUMN: PLpgSQL_resolve_option = 2;
+pub type PLpgSQL_resolve_option = ::std::os::raw::c_uint;
+#[doc = " Node and structure definitions"]
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_type {
+    pub typname: *mut ::std::os::raw::c_char,
+    pub typoid: Oid,
+    pub ttype: PLpgSQL_type_type,
+    pub typlen: int16,
+    pub typbyval: bool,
+    pub typtype: ::std::os::raw::c_char,
+    pub collation: Oid,
+    pub typisarray: bool,
+    pub atttypmod: int32,
+    pub origtypname: *mut TypeName,
+    pub tcache: *mut TypeCacheEntry,
+    pub tupdesc_id: uint64,
+}
+impl Default for PLpgSQL_type {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_expr {
+    pub query: *mut ::std::os::raw::c_char,
+    pub plan: SPIPlanPtr,
+    pub paramnos: *mut Bitmapset,
+    pub rwparam: ::std::os::raw::c_int,
+    pub func: *mut PLpgSQL_function,
+    pub ns: *mut PLpgSQL_nsitem,
+    pub expr_simple_expr: *mut Expr,
+    pub expr_simple_generation: ::std::os::raw::c_int,
+    pub expr_simple_type: Oid,
+    pub expr_simple_typmod: int32,
+    pub expr_simple_state: *mut ExprState,
+    pub expr_simple_in_use: bool,
+    pub expr_simple_lxid: LocalTransactionId,
+}
+impl Default for PLpgSQL_expr {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_datum {
+    pub dtype: PLpgSQL_datum_type,
+    pub dno: ::std::os::raw::c_int,
+}
+impl Default for PLpgSQL_datum {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_variable {
+    pub dtype: PLpgSQL_datum_type,
+    pub dno: ::std::os::raw::c_int,
+    pub refname: *mut ::std::os::raw::c_char,
+    pub lineno: ::std::os::raw::c_int,
+    pub isconst: bool,
+    pub notnull: bool,
+    pub default_val: *mut PLpgSQL_expr,
+}
+impl Default for PLpgSQL_variable {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_var {
+    pub dtype: PLpgSQL_datum_type,
+    pub dno: ::std::os::raw::c_int,
+    pub refname: *mut ::std::os::raw::c_char,
+    pub lineno: ::std::os::raw::c_int,
+    pub isconst: bool,
+    pub notnull: bool,
+    pub default_val: *mut PLpgSQL_expr,
+    pub datatype: *mut PLpgSQL_type,
+    pub cursor_explicit_expr: *mut PLpgSQL_expr,
+    pub cursor_explicit_argrow: ::std::os::raw::c_int,
+    pub cursor_options: ::std::os::raw::c_int,
+    pub value: Datum,
+    pub isnull: bool,
+    pub freeval: bool,
+    pub promise: PLpgSQL_promise_type,
+}
+impl Default for PLpgSQL_var {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_row {
+    pub dtype: PLpgSQL_datum_type,
+    pub dno: ::std::os::raw::c_int,
+    pub refname: *mut ::std::os::raw::c_char,
+    pub lineno: ::std::os::raw::c_int,
+    pub isconst: bool,
+    pub notnull: bool,
+    pub default_val: *mut PLpgSQL_expr,
+    pub rowtupdesc: TupleDesc,
+    pub nfields: ::std::os::raw::c_int,
+    pub fieldnames: *mut *mut ::std::os::raw::c_char,
+    pub varnos: *mut ::std::os::raw::c_int,
+}
+impl Default for PLpgSQL_row {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_rec {
+    pub dtype: PLpgSQL_datum_type,
+    pub dno: ::std::os::raw::c_int,
+    pub refname: *mut ::std::os::raw::c_char,
+    pub lineno: ::std::os::raw::c_int,
+    pub isconst: bool,
+    pub notnull: bool,
+    pub default_val: *mut PLpgSQL_expr,
+    pub datatype: *mut PLpgSQL_type,
+    pub rectypeid: Oid,
+    pub firstfield: ::std::os::raw::c_int,
+    pub erh: *mut ExpandedRecordHeader,
+}
+impl Default for PLpgSQL_rec {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_recfield {
+    pub dtype: PLpgSQL_datum_type,
+    pub dno: ::std::os::raw::c_int,
+    pub fieldname: *mut ::std::os::raw::c_char,
+    pub recparentno: ::std::os::raw::c_int,
+    pub nextfield: ::std::os::raw::c_int,
+    pub rectupledescid: uint64,
+    pub finfo: ExpandedRecordFieldInfo,
+}
+impl Default for PLpgSQL_recfield {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_arrayelem {
+    pub dtype: PLpgSQL_datum_type,
+    pub dno: ::std::os::raw::c_int,
+    pub subscript: *mut PLpgSQL_expr,
+    pub arrayparentno: ::std::os::raw::c_int,
+    pub parenttypoid: Oid,
+    pub parenttypmod: int32,
+    pub arraytypoid: Oid,
+    pub arraytypmod: int32,
+    pub arraytyplen: int16,
+    pub elemtypoid: Oid,
+    pub elemtyplen: int16,
+    pub elemtypbyval: bool,
+    pub elemtypalign: ::std::os::raw::c_char,
+}
+impl Default for PLpgSQL_arrayelem {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct PLpgSQL_nsitem {
+    pub itemtype: PLpgSQL_nsitem_type,
+    pub itemno: ::std::os::raw::c_int,
+    pub prev: *mut PLpgSQL_nsitem,
+    pub name: __IncompleteArrayField<::std::os::raw::c_char>,
+}
+impl Default for PLpgSQL_nsitem {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+}
+impl Default for PLpgSQL_stmt {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_condition {
+    pub sqlerrstate: ::std::os::raw::c_int,
+    pub condname: *mut ::std::os::raw::c_char,
+    pub next: *mut PLpgSQL_condition,
+}
+impl Default for PLpgSQL_condition {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_exception_block {
+    pub sqlstate_varno: ::std::os::raw::c_int,
+    pub sqlerrm_varno: ::std::os::raw::c_int,
+    pub exc_list: *mut List,
+}
+impl Default for PLpgSQL_exception_block {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_exception {
+    pub lineno: ::std::os::raw::c_int,
+    pub conditions: *mut PLpgSQL_condition,
+    pub action: *mut List,
+}
+impl Default for PLpgSQL_exception {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_block {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub label: *mut ::std::os::raw::c_char,
+    pub body: *mut List,
+    pub n_initvars: ::std::os::raw::c_int,
+    pub initvarnos: *mut ::std::os::raw::c_int,
+    pub exceptions: *mut PLpgSQL_exception_block,
+}
+impl Default for PLpgSQL_stmt_block {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_assign {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub varno: ::std::os::raw::c_int,
+    pub expr: *mut PLpgSQL_expr,
+}
+impl Default for PLpgSQL_stmt_assign {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_perform {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub expr: *mut PLpgSQL_expr,
+}
+impl Default for PLpgSQL_stmt_perform {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_call {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub expr: *mut PLpgSQL_expr,
+    pub is_call: bool,
+    pub target: *mut PLpgSQL_variable,
+}
+impl Default for PLpgSQL_stmt_call {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_commit {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub chain: bool,
+}
+impl Default for PLpgSQL_stmt_commit {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_rollback {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub chain: bool,
+}
+impl Default for PLpgSQL_stmt_rollback {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_set {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub expr: *mut PLpgSQL_expr,
+}
+impl Default for PLpgSQL_stmt_set {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_diag_item {
+    pub kind: PLpgSQL_getdiag_kind,
+    pub target: ::std::os::raw::c_int,
+}
+impl Default for PLpgSQL_diag_item {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_getdiag {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub is_stacked: bool,
+    pub diag_items: *mut List,
+}
+impl Default for PLpgSQL_stmt_getdiag {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_if {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub cond: *mut PLpgSQL_expr,
+    pub then_body: *mut List,
+    pub elsif_list: *mut List,
+    pub else_body: *mut List,
+}
+impl Default for PLpgSQL_stmt_if {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_if_elsif {
+    pub lineno: ::std::os::raw::c_int,
+    pub cond: *mut PLpgSQL_expr,
+    pub stmts: *mut List,
+}
+impl Default for PLpgSQL_if_elsif {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_case {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub t_expr: *mut PLpgSQL_expr,
+    pub t_varno: ::std::os::raw::c_int,
+    pub case_when_list: *mut List,
+    pub have_else: bool,
+    pub else_stmts: *mut List,
+}
+impl Default for PLpgSQL_stmt_case {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_case_when {
+    pub lineno: ::std::os::raw::c_int,
+    pub expr: *mut PLpgSQL_expr,
+    pub stmts: *mut List,
+}
+impl Default for PLpgSQL_case_when {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_loop {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub label: *mut ::std::os::raw::c_char,
+    pub body: *mut List,
+}
+impl Default for PLpgSQL_stmt_loop {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_while {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub label: *mut ::std::os::raw::c_char,
+    pub cond: *mut PLpgSQL_expr,
+    pub body: *mut List,
+}
+impl Default for PLpgSQL_stmt_while {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_fori {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub label: *mut ::std::os::raw::c_char,
+    pub var: *mut PLpgSQL_var,
+    pub lower: *mut PLpgSQL_expr,
+    pub upper: *mut PLpgSQL_expr,
+    pub step: *mut PLpgSQL_expr,
+    pub reverse: ::std::os::raw::c_int,
+    pub body: *mut List,
+}
+impl Default for PLpgSQL_stmt_fori {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_forq {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub label: *mut ::std::os::raw::c_char,
+    pub var: *mut PLpgSQL_variable,
+    pub body: *mut List,
+}
+impl Default for PLpgSQL_stmt_forq {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_fors {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub label: *mut ::std::os::raw::c_char,
+    pub var: *mut PLpgSQL_variable,
+    pub body: *mut List,
+    pub query: *mut PLpgSQL_expr,
+}
+impl Default for PLpgSQL_stmt_fors {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_forc {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub label: *mut ::std::os::raw::c_char,
+    pub var: *mut PLpgSQL_variable,
+    pub body: *mut List,
+    pub curvar: ::std::os::raw::c_int,
+    pub argquery: *mut PLpgSQL_expr,
+}
+impl Default for PLpgSQL_stmt_forc {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_dynfors {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub label: *mut ::std::os::raw::c_char,
+    pub var: *mut PLpgSQL_variable,
+    pub body: *mut List,
+    pub query: *mut PLpgSQL_expr,
+    pub params: *mut List,
+}
+impl Default for PLpgSQL_stmt_dynfors {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_foreach_a {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub label: *mut ::std::os::raw::c_char,
+    pub varno: ::std::os::raw::c_int,
+    pub slice: ::std::os::raw::c_int,
+    pub expr: *mut PLpgSQL_expr,
+    pub body: *mut List,
+}
+impl Default for PLpgSQL_stmt_foreach_a {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_open {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub curvar: ::std::os::raw::c_int,
+    pub cursor_options: ::std::os::raw::c_int,
+    pub argquery: *mut PLpgSQL_expr,
+    pub query: *mut PLpgSQL_expr,
+    pub dynquery: *mut PLpgSQL_expr,
+    pub params: *mut List,
+}
+impl Default for PLpgSQL_stmt_open {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_fetch {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub target: *mut PLpgSQL_variable,
+    pub curvar: ::std::os::raw::c_int,
+    pub direction: FetchDirection,
+    pub how_many: ::std::os::raw::c_long,
+    pub expr: *mut PLpgSQL_expr,
+    pub is_move: bool,
+    pub returns_multiple_rows: bool,
+}
+impl Default for PLpgSQL_stmt_fetch {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_close {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub curvar: ::std::os::raw::c_int,
+}
+impl Default for PLpgSQL_stmt_close {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_exit {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub is_exit: bool,
+    pub label: *mut ::std::os::raw::c_char,
+    pub cond: *mut PLpgSQL_expr,
+}
+impl Default for PLpgSQL_stmt_exit {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_return {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub expr: *mut PLpgSQL_expr,
+    pub retvarno: ::std::os::raw::c_int,
+}
+impl Default for PLpgSQL_stmt_return {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_return_next {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub expr: *mut PLpgSQL_expr,
+    pub retvarno: ::std::os::raw::c_int,
+}
+impl Default for PLpgSQL_stmt_return_next {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_return_query {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub query: *mut PLpgSQL_expr,
+    pub dynquery: *mut PLpgSQL_expr,
+    pub params: *mut List,
+}
+impl Default for PLpgSQL_stmt_return_query {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_raise {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub elog_level: ::std::os::raw::c_int,
+    pub condname: *mut ::std::os::raw::c_char,
+    pub message: *mut ::std::os::raw::c_char,
+    pub params: *mut List,
+    pub options: *mut List,
+}
+impl Default for PLpgSQL_stmt_raise {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_raise_option {
+    pub opt_type: PLpgSQL_raise_option_type,
+    pub expr: *mut PLpgSQL_expr,
+}
+impl Default for PLpgSQL_raise_option {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_assert {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub cond: *mut PLpgSQL_expr,
+    pub message: *mut PLpgSQL_expr,
+}
+impl Default for PLpgSQL_stmt_assert {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_execsql {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub sqlstmt: *mut PLpgSQL_expr,
+    pub mod_stmt: bool,
+    pub into: bool,
+    pub strict: bool,
+    pub mod_stmt_set: bool,
+    pub target: *mut PLpgSQL_variable,
+}
+impl Default for PLpgSQL_stmt_execsql {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_dynexecute {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub query: *mut PLpgSQL_expr,
+    pub into: bool,
+    pub strict: bool,
+    pub target: *mut PLpgSQL_variable,
+    pub params: *mut List,
+}
+impl Default for PLpgSQL_stmt_dynexecute {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_func_hashkey {
+    pub funcOid: Oid,
+    pub isTrigger: bool,
+    pub isEventTrigger: bool,
+    pub trigOid: Oid,
+    pub inputCollation: Oid,
+    pub argtypes: [Oid; 100usize],
+}
+impl Default for PLpgSQL_func_hashkey {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub const PLpgSQL_trigtype_PLPGSQL_DML_TRIGGER: PLpgSQL_trigtype = 0;
+pub const PLpgSQL_trigtype_PLPGSQL_EVENT_TRIGGER: PLpgSQL_trigtype = 1;
+pub const PLpgSQL_trigtype_PLPGSQL_NOT_TRIGGER: PLpgSQL_trigtype = 2;
+pub type PLpgSQL_trigtype = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_function {
+    pub fn_signature: *mut ::std::os::raw::c_char,
+    pub fn_oid: Oid,
+    pub fn_xmin: TransactionId,
+    pub fn_tid: ItemPointerData,
+    pub fn_is_trigger: PLpgSQL_trigtype,
+    pub fn_input_collation: Oid,
+    pub fn_hashkey: *mut PLpgSQL_func_hashkey,
+    pub fn_cxt: MemoryContext,
+    pub fn_rettype: Oid,
+    pub fn_rettyplen: ::std::os::raw::c_int,
+    pub fn_retbyval: bool,
+    pub fn_retistuple: bool,
+    pub fn_retisdomain: bool,
+    pub fn_retset: bool,
+    pub fn_readonly: bool,
+    pub fn_prokind: ::std::os::raw::c_char,
+    pub fn_nargs: ::std::os::raw::c_int,
+    pub fn_argvarnos: [::std::os::raw::c_int; 100usize],
+    pub out_param_varno: ::std::os::raw::c_int,
+    pub found_varno: ::std::os::raw::c_int,
+    pub new_varno: ::std::os::raw::c_int,
+    pub old_varno: ::std::os::raw::c_int,
+    pub resolve_option: PLpgSQL_resolve_option,
+    pub print_strict_params: bool,
+    pub extra_warnings: ::std::os::raw::c_int,
+    pub extra_errors: ::std::os::raw::c_int,
+    pub nstatements: ::std::os::raw::c_uint,
+    pub ndatums: ::std::os::raw::c_int,
+    pub datums: *mut *mut PLpgSQL_datum,
+    pub copiable_size: Size,
+    pub action: *mut PLpgSQL_stmt_block,
+    pub cur_estate: *mut PLpgSQL_execstate,
+    pub use_count: ::std::os::raw::c_ulong,
+}
+impl Default for PLpgSQL_function {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_execstate {
+    pub func: *mut PLpgSQL_function,
+    pub trigdata: *mut TriggerData,
+    pub evtrigdata: *mut EventTriggerData,
+    pub retval: Datum,
+    pub retisnull: bool,
+    pub rettype: Oid,
+    pub fn_rettype: Oid,
+    pub retistuple: bool,
+    pub retisset: bool,
+    pub readonly_func: bool,
+    pub atomic: bool,
+    pub exitlabel: *mut ::std::os::raw::c_char,
+    pub cur_error: *mut ErrorData,
+    pub tuple_store: *mut Tuplestorestate,
+    pub tuple_store_desc: TupleDesc,
+    pub tuple_store_cxt: MemoryContext,
+    pub tuple_store_owner: ResourceOwner,
+    pub rsi: *mut ReturnSetInfo,
+    pub found_varno: ::std::os::raw::c_int,
+    pub ndatums: ::std::os::raw::c_int,
+    pub datums: *mut *mut PLpgSQL_datum,
+    pub datum_context: MemoryContext,
+    pub paramLI: ParamListInfo,
+    pub simple_eval_estate: *mut EState,
+    pub cast_hash: *mut HTAB,
+    pub cast_hash_context: MemoryContext,
+    pub stmt_mcontext: MemoryContext,
+    pub stmt_mcontext_parent: MemoryContext,
+    pub eval_tuptable: *mut SPITupleTable,
+    pub eval_processed: uint64,
+    pub eval_econtext: *mut ExprContext,
+    pub err_stmt: *mut PLpgSQL_stmt,
+    pub err_text: *const ::std::os::raw::c_char,
+    pub plugin_info: *mut ::std::os::raw::c_void,
+}
+impl Default for PLpgSQL_execstate {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct PLpgSQL_plugin {
+    pub func_setup: ::std::option::Option<
+        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, func: *mut PLpgSQL_function),
+    >,
+    pub func_beg: ::std::option::Option<
+        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, func: *mut PLpgSQL_function),
+    >,
+    pub func_end: ::std::option::Option<
+        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, func: *mut PLpgSQL_function),
+    >,
+    pub stmt_beg: ::std::option::Option<
+        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, stmt: *mut PLpgSQL_stmt),
+    >,
+    pub stmt_end: ::std::option::Option<
+        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, stmt: *mut PLpgSQL_stmt),
+    >,
+    pub error_callback:
+        ::std::option::Option<unsafe extern "C" fn(arg: *mut ::std::os::raw::c_void)>,
+    pub assign_expr: ::std::option::Option<
+        unsafe extern "C" fn(
+            estate: *mut PLpgSQL_execstate,
+            target: *mut PLpgSQL_datum,
+            expr: *mut PLpgSQL_expr,
+        ),
+    >,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLword {
+    pub ident: *mut ::std::os::raw::c_char,
+    pub quoted: bool,
+}
+impl Default for PLword {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLcword {
+    pub idents: *mut List,
+}
+impl Default for PLcword {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLwdatum {
+    pub datum: *mut PLpgSQL_datum,
+    pub ident: *mut ::std::os::raw::c_char,
+    pub quoted: bool,
+    pub idents: *mut List,
+}
+impl Default for PLwdatum {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub const IdentifierLookup_IDENTIFIER_LOOKUP_NORMAL: IdentifierLookup = 0;
+pub const IdentifierLookup_IDENTIFIER_LOOKUP_DECLARE: IdentifierLookup = 1;
+pub const IdentifierLookup_IDENTIFIER_LOOKUP_EXPR: IdentifierLookup = 2;
+#[doc = " Global variable declarations"]
+pub type IdentifierLookup = ::std::os::raw::c_uint;
+extern "C" {
+    pub static mut plpgsql_IdentifierLookup: IdentifierLookup;
+}
+extern "C" {
+    pub static mut plpgsql_variable_conflict: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut plpgsql_print_strict_params: bool;
+}
+extern "C" {
+    pub static mut plpgsql_check_asserts: bool;
+}
+extern "C" {
+    pub static mut plpgsql_extra_warnings: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut plpgsql_extra_errors: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut plpgsql_check_syntax: bool;
+}
+extern "C" {
+    pub static mut plpgsql_DumpExecTree: bool;
+}
+extern "C" {
+    pub static mut plpgsql_parse_result: *mut PLpgSQL_stmt_block;
+}
+extern "C" {
+    pub static mut plpgsql_nDatums: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut plpgsql_Datums: *mut *mut PLpgSQL_datum;
+}
+extern "C" {
+    pub static mut plpgsql_error_funcname: *mut ::std::os::raw::c_char;
+}
+extern "C" {
+    pub static mut plpgsql_curr_compile: *mut PLpgSQL_function;
+}
+extern "C" {
+    pub static mut plpgsql_compile_tmp_cxt: MemoryContext;
+}
+extern "C" {
+    pub static mut plpgsql_plugin_ptr: *mut *mut PLpgSQL_plugin;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    #[doc = " Function declarations"]
+    pub fn plpgsql_compile(fcinfo: FunctionCallInfo, forValidator: bool) -> *mut PLpgSQL_function;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_compile_inline(
+        proc_source: *mut ::std::os::raw::c_char,
+    ) -> *mut PLpgSQL_function;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_parser_setup(pstate: *mut ParseState, expr: *mut PLpgSQL_expr);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_parse_word(
+        word1: *mut ::std::os::raw::c_char,
+        yytxt: *const ::std::os::raw::c_char,
+        lookup: bool,
+        wdatum: *mut PLwdatum,
+        word: *mut PLword,
+    ) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_parse_dblword(
+        word1: *mut ::std::os::raw::c_char,
+        word2: *mut ::std::os::raw::c_char,
+        wdatum: *mut PLwdatum,
+        cword: *mut PLcword,
+    ) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_parse_tripword(
+        word1: *mut ::std::os::raw::c_char,
+        word2: *mut ::std::os::raw::c_char,
+        word3: *mut ::std::os::raw::c_char,
+        wdatum: *mut PLwdatum,
+        cword: *mut PLcword,
+    ) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_parse_wordtype(ident: *mut ::std::os::raw::c_char) -> *mut PLpgSQL_type;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_parse_cwordtype(idents: *mut List) -> *mut PLpgSQL_type;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_parse_wordrowtype(ident: *mut ::std::os::raw::c_char) -> *mut PLpgSQL_type;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_parse_cwordrowtype(idents: *mut List) -> *mut PLpgSQL_type;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_build_datatype(
+        typeOid: Oid,
+        typmod: int32,
+        collation: Oid,
+        origtypname: *mut TypeName,
+    ) -> *mut PLpgSQL_type;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_build_variable(
+        refname: *const ::std::os::raw::c_char,
+        lineno: ::std::os::raw::c_int,
+        dtype: *mut PLpgSQL_type,
+        add2namespace: bool,
+    ) -> *mut PLpgSQL_variable;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_build_record(
+        refname: *const ::std::os::raw::c_char,
+        lineno: ::std::os::raw::c_int,
+        dtype: *mut PLpgSQL_type,
+        rectypeid: Oid,
+        add2namespace: bool,
+    ) -> *mut PLpgSQL_rec;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_build_recfield(
+        rec: *mut PLpgSQL_rec,
+        fldname: *const ::std::os::raw::c_char,
+    ) -> *mut PLpgSQL_recfield;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_recognize_err_condition(
+        condname: *const ::std::os::raw::c_char,
+        allow_sqlstate: bool,
+    ) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_parse_err_condition(
+        condname: *mut ::std::os::raw::c_char,
+    ) -> *mut PLpgSQL_condition;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_adddatum(newdatum: *mut PLpgSQL_datum);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_add_initdatums(varnos: *mut *mut ::std::os::raw::c_int)
+        -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_HashTableInit();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn _PG_init();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_exec_function(
+        func: *mut PLpgSQL_function,
+        fcinfo: FunctionCallInfo,
+        simple_eval_estate: *mut EState,
+        atomic: bool,
+    ) -> Datum;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_exec_trigger(
+        func: *mut PLpgSQL_function,
+        trigdata: *mut TriggerData,
+    ) -> HeapTuple;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_exec_event_trigger(func: *mut PLpgSQL_function, trigdata: *mut EventTriggerData);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_xact_cb(event: XactEvent, arg: *mut ::std::os::raw::c_void);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_subxact_cb(
+        event: SubXactEvent,
+        mySubid: SubTransactionId,
+        parentSubid: SubTransactionId,
+        arg: *mut ::std::os::raw::c_void,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_exec_get_datum_type(
+        estate: *mut PLpgSQL_execstate,
+        datum: *mut PLpgSQL_datum,
+    ) -> Oid;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_exec_get_datum_type_info(
+        estate: *mut PLpgSQL_execstate,
+        datum: *mut PLpgSQL_datum,
+        typeId: *mut Oid,
+        typMod: *mut int32,
+        collation: *mut Oid,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_ns_init();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_ns_push(label: *const ::std::os::raw::c_char, label_type: PLpgSQL_label_type);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_ns_pop();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_ns_top() -> *mut PLpgSQL_nsitem;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_ns_additem(
+        itemtype: PLpgSQL_nsitem_type,
+        itemno: ::std::os::raw::c_int,
+        name: *const ::std::os::raw::c_char,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_ns_lookup(
+        ns_cur: *mut PLpgSQL_nsitem,
+        localmode: bool,
+        name1: *const ::std::os::raw::c_char,
+        name2: *const ::std::os::raw::c_char,
+        name3: *const ::std::os::raw::c_char,
+        names_used: *mut ::std::os::raw::c_int,
+    ) -> *mut PLpgSQL_nsitem;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_ns_lookup_label(
+        ns_cur: *mut PLpgSQL_nsitem,
+        name: *const ::std::os::raw::c_char,
+    ) -> *mut PLpgSQL_nsitem;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_ns_find_nearest_loop(ns_cur: *mut PLpgSQL_nsitem) -> *mut PLpgSQL_nsitem;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_stmt_typename(stmt: *mut PLpgSQL_stmt) -> *const ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_getdiag_kindname(kind: PLpgSQL_getdiag_kind) -> *const ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_free_function_memory(func: *mut PLpgSQL_function);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_dumptree(func: *mut PLpgSQL_function);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_base_yylex() -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_yylex() -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_push_back_token(token: ::std::os::raw::c_int);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_token_is_unreserved_keyword(token: ::std::os::raw::c_int) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_append_source_text(
+        buf: StringInfo,
+        startlocation: ::std::os::raw::c_int,
+        endlocation: ::std::os::raw::c_int,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_peek() -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_peek2(
+        tok1_p: *mut ::std::os::raw::c_int,
+        tok2_p: *mut ::std::os::raw::c_int,
+        tok1_loc: *mut ::std::os::raw::c_int,
+        tok2_loc: *mut ::std::os::raw::c_int,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_scanner_errposition(location: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_yyerror(message: *const ::std::os::raw::c_char);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_location_to_lineno(location: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_latest_lineno() -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_scanner_init(str_: *const ::std::os::raw::c_char);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_scanner_finish();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_yyparse() -> ::std::os::raw::c_int;
+}
 pub const ReplicationSlotPersistency_RS_PERSISTENT: ReplicationSlotPersistency = 0;
 pub const ReplicationSlotPersistency_RS_EPHEMERAL: ReplicationSlotPersistency = 1;
 pub const ReplicationSlotPersistency_RS_TEMPORARY: ReplicationSlotPersistency = 2;
@@ -42120,6 +44275,61 @@ extern "C" {
         include_triggers: bool,
         include_cols: *mut Bitmapset,
     ) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct RowSecurityPolicy {
+    pub policy_name: *mut ::std::os::raw::c_char,
+    pub polcmd: ::std::os::raw::c_char,
+    pub roles: *mut ArrayType,
+    pub permissive: bool,
+    pub qual: *mut Expr,
+    pub with_check_qual: *mut Expr,
+    pub hassublinks: bool,
+}
+impl Default for RowSecurityPolicy {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct RowSecurityDesc {
+    pub rscxt: MemoryContext,
+    pub policies: *mut List,
+}
+impl Default for RowSecurityDesc {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type row_security_policy_hook_type =
+    ::std::option::Option<unsafe extern "C" fn(cmdtype: CmdType, relation: Relation) -> *mut List>;
+extern "C" {
+    pub static mut row_security_policy_hook_permissive: row_security_policy_hook_type;
+}
+extern "C" {
+    pub static mut row_security_policy_hook_restrictive: row_security_policy_hook_type;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_row_security_policies(
+        root: *mut Query,
+        rte: *mut RangeTblEntry,
+        rt_index: ::std::os::raw::c_int,
+        securityQuals: *mut *mut List,
+        withCheckOptions: *mut *mut List,
+        hasRowSecurity: *mut bool,
+        hasSubLinks: *mut bool,
+    );
 }
 extern "C" {
     pub static mut old_snapshot_threshold: ::std::os::raw::c_int;
@@ -43146,6 +45356,235 @@ extern "C" {
         catalog_xmin: *mut TransactionId,
     );
 }
+extern "C" {
+    pub static mut whereToSendOutput: CommandDest;
+}
+extern "C" {
+    pub static mut debug_query_string: *const ::std::os::raw::c_char;
+}
+extern "C" {
+    pub static mut max_stack_depth: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut PostAuthDelay: ::std::os::raw::c_int;
+}
+pub const LogStmtLevel_LOGSTMT_NONE: LogStmtLevel = 0;
+pub const LogStmtLevel_LOGSTMT_DDL: LogStmtLevel = 1;
+pub const LogStmtLevel_LOGSTMT_MOD: LogStmtLevel = 2;
+pub const LogStmtLevel_LOGSTMT_ALL: LogStmtLevel = 3;
+pub type LogStmtLevel = ::std::os::raw::c_uint;
+extern "C" {
+    pub static mut log_statement: ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn pg_parse_query(query_string: *const ::std::os::raw::c_char) -> *mut List;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn pg_analyze_and_rewrite(
+        parsetree: *mut RawStmt,
+        query_string: *const ::std::os::raw::c_char,
+        paramTypes: *mut Oid,
+        numParams: ::std::os::raw::c_int,
+        queryEnv: *mut QueryEnvironment,
+    ) -> *mut List;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn pg_analyze_and_rewrite_params(
+        parsetree: *mut RawStmt,
+        query_string: *const ::std::os::raw::c_char,
+        parserSetup: ParserSetupHook,
+        parserSetupArg: *mut ::std::os::raw::c_void,
+        queryEnv: *mut QueryEnvironment,
+    ) -> *mut List;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn pg_plan_query(
+        querytree: *mut Query,
+        cursorOptions: ::std::os::raw::c_int,
+        boundParams: ParamListInfo,
+    ) -> *mut PlannedStmt;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn pg_plan_queries(
+        querytrees: *mut List,
+        cursorOptions: ::std::os::raw::c_int,
+        boundParams: ParamListInfo,
+    ) -> *mut List;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn check_max_stack_depth(
+        newval: *mut ::std::os::raw::c_int,
+        extra: *mut *mut ::std::os::raw::c_void,
+        source: GucSource,
+    ) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn assign_max_stack_depth(
+        newval: ::std::os::raw::c_int,
+        extra: *mut ::std::os::raw::c_void,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn die(postgres_signal_arg: ::std::os::raw::c_int);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn quickdie(postgres_signal_arg: ::std::os::raw::c_int);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn StatementCancelHandler(postgres_signal_arg: ::std::os::raw::c_int);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn FloatExceptionHandler(postgres_signal_arg: ::std::os::raw::c_int);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RecoveryConflictInterrupt(reason: ProcSignalReason);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ProcessClientReadInterrupt(blocked: bool);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ProcessClientWriteInterrupt(blocked: bool);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn process_postgres_switches(
+        argc: ::std::os::raw::c_int,
+        argv: *mut *mut ::std::os::raw::c_char,
+        ctx: GucContext,
+        dbname: *mut *const ::std::os::raw::c_char,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn PostgresMain(
+        argc: ::std::os::raw::c_int,
+        argv: *mut *mut ::std::os::raw::c_char,
+        dbname: *const ::std::os::raw::c_char,
+        username: *const ::std::os::raw::c_char,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_stack_depth_rlimit() -> ::std::os::raw::c_long;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ResetUsage();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ShowUsage(title: *const ::std::os::raw::c_char);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn check_log_duration(
+        msec_str: *mut ::std::os::raw::c_char,
+        was_logged: bool,
+    ) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn set_debug_options(
+        debug_flag: ::std::os::raw::c_int,
+        context: GucContext,
+        source: GucSource,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn set_plan_disabling_options(
+        arg: *const ::std::os::raw::c_char,
+        context: GucContext,
+        source: GucSource,
+    ) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_stats_option_name(
+        arg: *const ::std::os::raw::c_char,
+    ) -> *const ::std::os::raw::c_char;
+}
+pub const ProcessUtilityContext_PROCESS_UTILITY_TOPLEVEL: ProcessUtilityContext = 0;
+pub const ProcessUtilityContext_PROCESS_UTILITY_QUERY: ProcessUtilityContext = 1;
+pub const ProcessUtilityContext_PROCESS_UTILITY_QUERY_NONATOMIC: ProcessUtilityContext = 2;
+pub const ProcessUtilityContext_PROCESS_UTILITY_SUBCOMMAND: ProcessUtilityContext = 3;
+pub type ProcessUtilityContext = ::std::os::raw::c_uint;
+pub type ProcessUtility_hook_type = ::std::option::Option<
+    unsafe extern "C" fn(
+        pstmt: *mut PlannedStmt,
+        queryString: *const ::std::os::raw::c_char,
+        context: ProcessUtilityContext,
+        params: ParamListInfo,
+        queryEnv: *mut QueryEnvironment,
+        dest: *mut DestReceiver,
+        completionTag: *mut ::std::os::raw::c_char,
+    ),
+>;
+extern "C" {
+    pub static mut ProcessUtility_hook: ProcessUtility_hook_type;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ProcessUtility(
+        pstmt: *mut PlannedStmt,
+        queryString: *const ::std::os::raw::c_char,
+        context: ProcessUtilityContext,
+        params: ParamListInfo,
+        queryEnv: *mut QueryEnvironment,
+        dest: *mut DestReceiver,
+        completionTag: *mut ::std::os::raw::c_char,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn standard_ProcessUtility(
+        pstmt: *mut PlannedStmt,
+        queryString: *const ::std::os::raw::c_char,
+        context: ProcessUtilityContext,
+        params: ParamListInfo,
+        queryEnv: *mut QueryEnvironment,
+        dest: *mut DestReceiver,
+        completionTag: *mut ::std::os::raw::c_char,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UtilityReturnsTuples(parsetree: *mut Node) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UtilityTupleDescriptor(parsetree: *mut Node) -> TupleDesc;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UtilityContainsQuery(parsetree: *mut Node) -> *mut Query;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn CreateCommandTag(parsetree: *mut Node) -> *const ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetCommandLogLevel(parsetree: *mut Node) -> LogStmtLevel;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn CommandIsReadOnly(pstmt: *mut PlannedStmt) -> bool;
+}
 #[repr(C)]
 #[repr(align(4))]
 #[derive(Debug, Default, Copy, Clone)]
@@ -43864,235 +46303,6 @@ extern "C" {
         subs: *mut QTNode,
         isfind: *mut bool,
     ) -> *mut QTNode;
-}
-extern "C" {
-    pub static mut whereToSendOutput: CommandDest;
-}
-extern "C" {
-    pub static mut debug_query_string: *const ::std::os::raw::c_char;
-}
-extern "C" {
-    pub static mut max_stack_depth: ::std::os::raw::c_int;
-}
-extern "C" {
-    pub static mut PostAuthDelay: ::std::os::raw::c_int;
-}
-pub const LogStmtLevel_LOGSTMT_NONE: LogStmtLevel = 0;
-pub const LogStmtLevel_LOGSTMT_DDL: LogStmtLevel = 1;
-pub const LogStmtLevel_LOGSTMT_MOD: LogStmtLevel = 2;
-pub const LogStmtLevel_LOGSTMT_ALL: LogStmtLevel = 3;
-pub type LogStmtLevel = ::std::os::raw::c_uint;
-extern "C" {
-    pub static mut log_statement: ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn pg_parse_query(query_string: *const ::std::os::raw::c_char) -> *mut List;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn pg_analyze_and_rewrite(
-        parsetree: *mut RawStmt,
-        query_string: *const ::std::os::raw::c_char,
-        paramTypes: *mut Oid,
-        numParams: ::std::os::raw::c_int,
-        queryEnv: *mut QueryEnvironment,
-    ) -> *mut List;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn pg_analyze_and_rewrite_params(
-        parsetree: *mut RawStmt,
-        query_string: *const ::std::os::raw::c_char,
-        parserSetup: ParserSetupHook,
-        parserSetupArg: *mut ::std::os::raw::c_void,
-        queryEnv: *mut QueryEnvironment,
-    ) -> *mut List;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn pg_plan_query(
-        querytree: *mut Query,
-        cursorOptions: ::std::os::raw::c_int,
-        boundParams: ParamListInfo,
-    ) -> *mut PlannedStmt;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn pg_plan_queries(
-        querytrees: *mut List,
-        cursorOptions: ::std::os::raw::c_int,
-        boundParams: ParamListInfo,
-    ) -> *mut List;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn check_max_stack_depth(
-        newval: *mut ::std::os::raw::c_int,
-        extra: *mut *mut ::std::os::raw::c_void,
-        source: GucSource,
-    ) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn assign_max_stack_depth(
-        newval: ::std::os::raw::c_int,
-        extra: *mut ::std::os::raw::c_void,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn die(postgres_signal_arg: ::std::os::raw::c_int);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn quickdie(postgres_signal_arg: ::std::os::raw::c_int);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn StatementCancelHandler(postgres_signal_arg: ::std::os::raw::c_int);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn FloatExceptionHandler(postgres_signal_arg: ::std::os::raw::c_int);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn RecoveryConflictInterrupt(reason: ProcSignalReason);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn ProcessClientReadInterrupt(blocked: bool);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn ProcessClientWriteInterrupt(blocked: bool);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn process_postgres_switches(
-        argc: ::std::os::raw::c_int,
-        argv: *mut *mut ::std::os::raw::c_char,
-        ctx: GucContext,
-        dbname: *mut *const ::std::os::raw::c_char,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn PostgresMain(
-        argc: ::std::os::raw::c_int,
-        argv: *mut *mut ::std::os::raw::c_char,
-        dbname: *const ::std::os::raw::c_char,
-        username: *const ::std::os::raw::c_char,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_stack_depth_rlimit() -> ::std::os::raw::c_long;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn ResetUsage();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn ShowUsage(title: *const ::std::os::raw::c_char);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn check_log_duration(
-        msec_str: *mut ::std::os::raw::c_char,
-        was_logged: bool,
-    ) -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn set_debug_options(
-        debug_flag: ::std::os::raw::c_int,
-        context: GucContext,
-        source: GucSource,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn set_plan_disabling_options(
-        arg: *const ::std::os::raw::c_char,
-        context: GucContext,
-        source: GucSource,
-    ) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_stats_option_name(
-        arg: *const ::std::os::raw::c_char,
-    ) -> *const ::std::os::raw::c_char;
-}
-pub const ProcessUtilityContext_PROCESS_UTILITY_TOPLEVEL: ProcessUtilityContext = 0;
-pub const ProcessUtilityContext_PROCESS_UTILITY_QUERY: ProcessUtilityContext = 1;
-pub const ProcessUtilityContext_PROCESS_UTILITY_QUERY_NONATOMIC: ProcessUtilityContext = 2;
-pub const ProcessUtilityContext_PROCESS_UTILITY_SUBCOMMAND: ProcessUtilityContext = 3;
-pub type ProcessUtilityContext = ::std::os::raw::c_uint;
-pub type ProcessUtility_hook_type = ::std::option::Option<
-    unsafe extern "C" fn(
-        pstmt: *mut PlannedStmt,
-        queryString: *const ::std::os::raw::c_char,
-        context: ProcessUtilityContext,
-        params: ParamListInfo,
-        queryEnv: *mut QueryEnvironment,
-        dest: *mut DestReceiver,
-        completionTag: *mut ::std::os::raw::c_char,
-    ),
->;
-extern "C" {
-    pub static mut ProcessUtility_hook: ProcessUtility_hook_type;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn ProcessUtility(
-        pstmt: *mut PlannedStmt,
-        queryString: *const ::std::os::raw::c_char,
-        context: ProcessUtilityContext,
-        params: ParamListInfo,
-        queryEnv: *mut QueryEnvironment,
-        dest: *mut DestReceiver,
-        completionTag: *mut ::std::os::raw::c_char,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn standard_ProcessUtility(
-        pstmt: *mut PlannedStmt,
-        queryString: *const ::std::os::raw::c_char,
-        context: ProcessUtilityContext,
-        params: ParamListInfo,
-        queryEnv: *mut QueryEnvironment,
-        dest: *mut DestReceiver,
-        completionTag: *mut ::std::os::raw::c_char,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn UtilityReturnsTuples(parsetree: *mut Node) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn UtilityTupleDescriptor(parsetree: *mut Node) -> TupleDesc;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn UtilityContainsQuery(parsetree: *mut Node) -> *mut Query;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn CreateCommandTag(parsetree: *mut Node) -> *const ::std::os::raw::c_char;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetCommandLogLevel(parsetree: *mut Node) -> LogStmtLevel;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn CommandIsReadOnly(pstmt: *mut PlannedStmt) -> bool;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -56221,158 +58431,6 @@ extern "C" {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct DomainConstraintCache {
-    _unused: [u8; 0],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct TypeCacheEnumData {
-    _unused: [u8; 0],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct TypeCacheEntry {
-    pub type_id: Oid,
-    pub typlen: int16,
-    pub typbyval: bool,
-    pub typalign: ::std::os::raw::c_char,
-    pub typstorage: ::std::os::raw::c_char,
-    pub typtype: ::std::os::raw::c_char,
-    pub typrelid: Oid,
-    pub typelem: Oid,
-    pub typcollation: Oid,
-    pub btree_opf: Oid,
-    pub btree_opintype: Oid,
-    pub hash_opf: Oid,
-    pub hash_opintype: Oid,
-    pub eq_opr: Oid,
-    pub lt_opr: Oid,
-    pub gt_opr: Oid,
-    pub cmp_proc: Oid,
-    pub hash_proc: Oid,
-    pub hash_extended_proc: Oid,
-    pub eq_opr_finfo: FmgrInfo,
-    pub cmp_proc_finfo: FmgrInfo,
-    pub hash_proc_finfo: FmgrInfo,
-    pub hash_extended_proc_finfo: FmgrInfo,
-    pub tupDesc: TupleDesc,
-    pub tupDesc_identifier: uint64,
-    pub rngelemtype: *mut TypeCacheEntry,
-    pub rng_collation: Oid,
-    pub rng_cmp_proc_finfo: FmgrInfo,
-    pub rng_canonical_finfo: FmgrInfo,
-    pub rng_subdiff_finfo: FmgrInfo,
-    pub domainBaseType: Oid,
-    pub domainBaseTypmod: int32,
-    pub domainData: *mut DomainConstraintCache,
-    pub flags: ::std::os::raw::c_int,
-    pub enumData: *mut TypeCacheEnumData,
-    pub nextDomain: *mut TypeCacheEntry,
-}
-impl Default for TypeCacheEntry {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct DomainConstraintRef {
-    pub constraints: *mut List,
-    pub refctx: MemoryContext,
-    pub tcache: *mut TypeCacheEntry,
-    pub need_exprstate: bool,
-    pub dcc: *mut DomainConstraintCache,
-    pub callback: MemoryContextCallback,
-}
-impl Default for DomainConstraintRef {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct SharedRecordTypmodRegistry {
-    _unused: [u8; 0],
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn lookup_type_cache(type_id: Oid, flags: ::std::os::raw::c_int) -> *mut TypeCacheEntry;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn InitDomainConstraintRef(
-        type_id: Oid,
-        ref_: *mut DomainConstraintRef,
-        refctx: MemoryContext,
-        need_exprstate: bool,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn UpdateDomainConstraintRef(ref_: *mut DomainConstraintRef);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn DomainHasConstraints(type_id: Oid) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn lookup_rowtype_tupdesc(type_id: Oid, typmod: int32) -> TupleDesc;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn lookup_rowtype_tupdesc_noerror(type_id: Oid, typmod: int32, noError: bool) -> TupleDesc;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn lookup_rowtype_tupdesc_copy(type_id: Oid, typmod: int32) -> TupleDesc;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn lookup_rowtype_tupdesc_domain(type_id: Oid, typmod: int32, noError: bool) -> TupleDesc;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn assign_record_type_typmod(tupDesc: TupleDesc);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn assign_record_type_identifier(type_id: Oid, typmod: int32) -> uint64;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn compare_values_of_enum(
-        tcache: *mut TypeCacheEntry,
-        arg1: Oid,
-        arg2: Oid,
-    ) -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn SharedRecordTypmodRegistryEstimate() -> usize;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn SharedRecordTypmodRegistryInit(
-        arg1: *mut SharedRecordTypmodRegistry,
-        segment: *mut dsm_segment,
-        area: *mut dsa_area,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn SharedRecordTypmodRegistryAttach(arg1: *mut SharedRecordTypmodRegistry);
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
 pub struct RangeType {
     pub vl_len_: int32,
     pub rangetypid: Oid,
@@ -56645,11 +58703,6 @@ pub struct ResourceOwnerData {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct _MdfdVec {
-    pub _address: u8,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct RowSecurityDesc {
     pub _address: u8,
 }
 #[repr(C)]

--- a/pgrx-pg-sys/src/pg13.rs
+++ b/pgrx-pg-sys/src/pg13.rs
@@ -3187,6 +3187,36 @@ pub const PVC_RECURSE_WINDOWFUNCS: u32 = 8;
 pub const PVC_INCLUDE_PLACEHOLDERS: u32 = 16;
 pub const PVC_RECURSE_PLACEHOLDERS: u32 = 32;
 pub const DEFAULT_CURSOR_TUPLE_FRACTION: f64 = 0.1;
+pub const ER_MAGIC: u32 = 1384727874;
+pub const ER_FLAG_FVALUE_VALID: u32 = 1;
+pub const ER_FLAG_FVALUE_ALLOCED: u32 = 2;
+pub const ER_FLAG_DVALUES_VALID: u32 = 4;
+pub const ER_FLAG_DVALUES_ALLOCED: u32 = 8;
+pub const ER_FLAG_HAVE_EXTERNAL: u32 = 16;
+pub const ER_FLAG_TUPDESC_ALLOCED: u32 = 32;
+pub const ER_FLAG_IS_DOMAIN: u32 = 64;
+pub const ER_FLAG_IS_DUMMY: u32 = 128;
+pub const ER_FLAGS_NON_DATA: u32 = 224;
+pub const TYPECACHE_EQ_OPR: u32 = 1;
+pub const TYPECACHE_LT_OPR: u32 = 2;
+pub const TYPECACHE_GT_OPR: u32 = 4;
+pub const TYPECACHE_CMP_PROC: u32 = 8;
+pub const TYPECACHE_HASH_PROC: u32 = 16;
+pub const TYPECACHE_EQ_OPR_FINFO: u32 = 32;
+pub const TYPECACHE_CMP_PROC_FINFO: u32 = 64;
+pub const TYPECACHE_HASH_PROC_FINFO: u32 = 128;
+pub const TYPECACHE_TUPDESC: u32 = 256;
+pub const TYPECACHE_BTREE_OPFAMILY: u32 = 512;
+pub const TYPECACHE_HASH_OPFAMILY: u32 = 1024;
+pub const TYPECACHE_RANGE_INFO: u32 = 2048;
+pub const TYPECACHE_DOMAIN_BASE_INFO: u32 = 4096;
+pub const TYPECACHE_DOMAIN_CONSTR_INFO: u32 = 8192;
+pub const TYPECACHE_HASH_EXTENDED_PROC: u32 = 16384;
+pub const TYPECACHE_HASH_EXTENDED_PROC_FINFO: u32 = 32768;
+pub const PLPGSQL_XCHECK_NONE: u32 = 0;
+pub const PLPGSQL_XCHECK_SHADOWVAR: u32 = 2;
+pub const PLPGSQL_XCHECK_TOOMANYROWS: u32 = 4;
+pub const PLPGSQL_XCHECK_STRICTMULTIASSIGNMENT: u32 = 8;
 pub const RBTXN_HAS_CATALOG_CHANGES: u32 = 1;
 pub const RBTXN_IS_SUBXACT: u32 = 2;
 pub const RBTXN_IS_SERIALIZED: u32 = 4;
@@ -3289,22 +3319,6 @@ pub const DEFAULT_MATCHING_SEL: f64 = 0.01;
 pub const DEFAULT_NUM_DISTINCT: u32 = 200;
 pub const DEFAULT_UNK_SEL: f64 = 0.005;
 pub const DEFAULT_NOT_UNK_SEL: f64 = 0.995;
-pub const TYPECACHE_EQ_OPR: u32 = 1;
-pub const TYPECACHE_LT_OPR: u32 = 2;
-pub const TYPECACHE_GT_OPR: u32 = 4;
-pub const TYPECACHE_CMP_PROC: u32 = 8;
-pub const TYPECACHE_HASH_PROC: u32 = 16;
-pub const TYPECACHE_EQ_OPR_FINFO: u32 = 32;
-pub const TYPECACHE_CMP_PROC_FINFO: u32 = 64;
-pub const TYPECACHE_HASH_PROC_FINFO: u32 = 128;
-pub const TYPECACHE_TUPDESC: u32 = 256;
-pub const TYPECACHE_BTREE_OPFAMILY: u32 = 512;
-pub const TYPECACHE_HASH_OPFAMILY: u32 = 1024;
-pub const TYPECACHE_RANGE_INFO: u32 = 2048;
-pub const TYPECACHE_DOMAIN_BASE_INFO: u32 = 4096;
-pub const TYPECACHE_DOMAIN_CONSTR_INFO: u32 = 8192;
-pub const TYPECACHE_HASH_EXTENDED_PROC: u32 = 16384;
-pub const TYPECACHE_HASH_EXTENDED_PROC_FINFO: u32 = 32768;
 pub const RANGE_EMPTY: u32 = 1;
 pub const RANGE_LB_INC: u32 = 2;
 pub const RANGE_UB_INC: u32 = 4;
@@ -32017,6 +32031,96 @@ extern "C" {
         sarray_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
+pub const ObjectAccessType_OAT_POST_CREATE: ObjectAccessType = 0;
+pub const ObjectAccessType_OAT_DROP: ObjectAccessType = 1;
+pub const ObjectAccessType_OAT_POST_ALTER: ObjectAccessType = 2;
+pub const ObjectAccessType_OAT_NAMESPACE_SEARCH: ObjectAccessType = 3;
+pub const ObjectAccessType_OAT_FUNCTION_EXECUTE: ObjectAccessType = 4;
+pub const ObjectAccessType_OAT_TRUNCATE: ObjectAccessType = 5;
+pub type ObjectAccessType = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ObjectAccessPostCreate {
+    pub is_internal: bool,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ObjectAccessDrop {
+    pub dropflags: ::std::os::raw::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ObjectAccessPostAlter {
+    pub auxiliary_id: Oid,
+    pub is_internal: bool,
+}
+impl Default for ObjectAccessPostAlter {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ObjectAccessNamespaceSearch {
+    pub ereport_on_violation: bool,
+    pub result: bool,
+}
+pub type object_access_hook_type = ::std::option::Option<
+    unsafe extern "C" fn(
+        access: ObjectAccessType,
+        classId: Oid,
+        objectId: Oid,
+        subId: ::std::os::raw::c_int,
+        arg: *mut ::std::os::raw::c_void,
+    ),
+>;
+extern "C" {
+    pub static mut object_access_hook: object_access_hook_type;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RunObjectPostCreateHook(
+        classId: Oid,
+        objectId: Oid,
+        subId: ::std::os::raw::c_int,
+        is_internal: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RunObjectDropHook(
+        classId: Oid,
+        objectId: Oid,
+        subId: ::std::os::raw::c_int,
+        dropflags: ::std::os::raw::c_int,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RunObjectTruncateHook(objectId: Oid);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RunObjectPostAlterHook(
+        classId: Oid,
+        objectId: Oid,
+        subId: ::std::os::raw::c_int,
+        auxiliaryId: Oid,
+        is_internal: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RunNamespaceSearchHook(objectId: Oid, ereport_on_violation: bool) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RunFunctionExecuteHook(objectId: Oid);
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct FormData_pg_authid {
@@ -34891,6 +34995,103 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn RI_FKey_trigger_type(tgfoid: Oid) -> ::std::os::raw::c_int;
+}
+pub const PasswordType_PASSWORD_TYPE_PLAINTEXT: PasswordType = 0;
+pub const PasswordType_PASSWORD_TYPE_MD5: PasswordType = 1;
+pub const PasswordType_PASSWORD_TYPE_SCRAM_SHA_256: PasswordType = 2;
+pub type PasswordType = ::std::os::raw::c_uint;
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_password_type(shadow_pass: *const ::std::os::raw::c_char) -> PasswordType;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn encrypt_password(
+        target_type: PasswordType,
+        role: *const ::std::os::raw::c_char,
+        password: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_role_password(
+        role: *const ::std::os::raw::c_char,
+        logdetail: *mut *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn md5_crypt_verify(
+        role: *const ::std::os::raw::c_char,
+        shadow_pass: *const ::std::os::raw::c_char,
+        client_pass: *const ::std::os::raw::c_char,
+        md5_salt: *const ::std::os::raw::c_char,
+        md5_salt_len: ::std::os::raw::c_int,
+        logdetail: *mut *mut ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plain_crypt_verify(
+        role: *const ::std::os::raw::c_char,
+        shadow_pass: *const ::std::os::raw::c_char,
+        client_pass: *const ::std::os::raw::c_char,
+        logdetail: *mut *mut ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut Password_encryption: ::std::os::raw::c_int;
+}
+pub type check_password_hook_type = ::std::option::Option<
+    unsafe extern "C" fn(
+        username: *const ::std::os::raw::c_char,
+        shadow_pass: *const ::std::os::raw::c_char,
+        password_type: PasswordType,
+        validuntil_time: Datum,
+        validuntil_null: bool,
+    ),
+>;
+extern "C" {
+    pub static mut check_password_hook: check_password_hook_type;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn CreateRole(pstate: *mut ParseState, stmt: *mut CreateRoleStmt) -> Oid;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn AlterRole(stmt: *mut AlterRoleStmt) -> Oid;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn AlterRoleSet(stmt: *mut AlterRoleSetStmt) -> Oid;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DropRole(stmt: *mut DropRoleStmt);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GrantRole(stmt: *mut GrantRoleStmt);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RenameRole(
+        oldname: *const ::std::os::raw::c_char,
+        newname: *const ::std::os::raw::c_char,
+    ) -> ObjectAddress;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DropOwnedObjects(stmt: *mut DropOwnedStmt);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ReassignOwnedObjects(stmt: *mut ReassignOwnedStmt);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn roleSpecsToIds(memberNames: *mut List) -> *mut List;
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -41697,6 +41898,127 @@ extern "C" {
         live_childrels: *mut List,
     );
 }
+pub type get_relation_info_hook_type = ::std::option::Option<
+    unsafe extern "C" fn(
+        root: *mut PlannerInfo,
+        relationObjectId: Oid,
+        inhparent: bool,
+        rel: *mut RelOptInfo,
+    ),
+>;
+extern "C" {
+    pub static mut get_relation_info_hook: get_relation_info_hook_type;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_relation_info(
+        root: *mut PlannerInfo,
+        relationObjectId: Oid,
+        inhparent: bool,
+        rel: *mut RelOptInfo,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn infer_arbiter_indexes(root: *mut PlannerInfo) -> *mut List;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn estimate_rel_size(
+        rel: Relation,
+        attr_widths: *mut int32,
+        pages: *mut BlockNumber,
+        tuples: *mut f64,
+        allvisfrac: *mut f64,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_rel_data_width(rel: Relation, attr_widths: *mut int32) -> int32;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_relation_data_width(relid: Oid, attr_widths: *mut int32) -> int32;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn relation_excluded_by_constraints(
+        root: *mut PlannerInfo,
+        rel: *mut RelOptInfo,
+        rte: *mut RangeTblEntry,
+    ) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn build_physical_tlist(root: *mut PlannerInfo, rel: *mut RelOptInfo) -> *mut List;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn has_unique_index(rel: *mut RelOptInfo, attno: AttrNumber) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn restriction_selectivity(
+        root: *mut PlannerInfo,
+        operatorid: Oid,
+        args: *mut List,
+        inputcollid: Oid,
+        varRelid: ::std::os::raw::c_int,
+    ) -> Selectivity;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn join_selectivity(
+        root: *mut PlannerInfo,
+        operatorid: Oid,
+        args: *mut List,
+        inputcollid: Oid,
+        jointype: JoinType,
+        sjinfo: *mut SpecialJoinInfo,
+    ) -> Selectivity;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn function_selectivity(
+        root: *mut PlannerInfo,
+        funcid: Oid,
+        args: *mut List,
+        inputcollid: Oid,
+        is_join: bool,
+        varRelid: ::std::os::raw::c_int,
+        jointype: JoinType,
+        sjinfo: *mut SpecialJoinInfo,
+    ) -> Selectivity;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn add_function_cost(
+        root: *mut PlannerInfo,
+        funcid: Oid,
+        node: *mut Node,
+        cost: *mut QualCost,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_function_rows(root: *mut PlannerInfo, funcid: Oid, node: *mut Node) -> f64;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn has_row_triggers(root: *mut PlannerInfo, rti: Index, event: CmdType) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn has_stored_generated_columns(root: *mut PlannerInfo, rti: Index) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_dependent_generated_columns(
+        root: *mut PlannerInfo,
+        rti: Index,
+        target_cols: *mut Bitmapset,
+    ) -> *mut Bitmapset;
+}
 extern "C" {
     pub static mut cursor_tuple_fraction: f64;
 }
@@ -42763,6 +43085,1858 @@ extern "C" {
 extern "C" {
     pub fn get_parse_rowmark(qry: *mut Query, rtindex: Index) -> *mut RowMarkClause;
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ExpandedRecordHeader {
+    pub hdr: ExpandedObjectHeader,
+    pub er_magic: ::std::os::raw::c_int,
+    pub flags: ::std::os::raw::c_int,
+    pub er_decltypeid: Oid,
+    pub er_typeid: Oid,
+    pub er_typmod: int32,
+    pub er_tupdesc: TupleDesc,
+    pub er_tupdesc_id: uint64,
+    pub dvalues: *mut Datum,
+    pub dnulls: *mut bool,
+    pub nfields: ::std::os::raw::c_int,
+    pub flat_size: Size,
+    pub data_len: Size,
+    pub hoff: ::std::os::raw::c_int,
+    pub hasnull: bool,
+    pub fvalue: HeapTuple,
+    pub fstartptr: *mut ::std::os::raw::c_char,
+    pub fendptr: *mut ::std::os::raw::c_char,
+    pub er_short_term_cxt: MemoryContext,
+    pub er_dummy_header: *mut ExpandedRecordHeader,
+    pub er_domaininfo: *mut ::std::os::raw::c_void,
+    pub er_mcb: MemoryContextCallback,
+}
+impl Default for ExpandedRecordHeader {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ExpandedRecordFieldInfo {
+    pub fnumber: ::std::os::raw::c_int,
+    pub ftypeid: Oid,
+    pub ftypmod: int32,
+    pub fcollation: Oid,
+}
+impl Default for ExpandedRecordFieldInfo {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn make_expanded_record_from_typeid(
+        type_id: Oid,
+        typmod: int32,
+        parentcontext: MemoryContext,
+    ) -> *mut ExpandedRecordHeader;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn make_expanded_record_from_tupdesc(
+        tupdesc: TupleDesc,
+        parentcontext: MemoryContext,
+    ) -> *mut ExpandedRecordHeader;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn make_expanded_record_from_exprecord(
+        olderh: *mut ExpandedRecordHeader,
+        parentcontext: MemoryContext,
+    ) -> *mut ExpandedRecordHeader;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn expanded_record_set_tuple(
+        erh: *mut ExpandedRecordHeader,
+        tuple: HeapTuple,
+        copy: bool,
+        expand_external: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn make_expanded_record_from_datum(
+        recorddatum: Datum,
+        parentcontext: MemoryContext,
+    ) -> Datum;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn expanded_record_fetch_tupdesc(erh: *mut ExpandedRecordHeader) -> TupleDesc;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn expanded_record_get_tuple(erh: *mut ExpandedRecordHeader) -> HeapTuple;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DatumGetExpandedRecord(d: Datum) -> *mut ExpandedRecordHeader;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn deconstruct_expanded_record(erh: *mut ExpandedRecordHeader);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn expanded_record_lookup_field(
+        erh: *mut ExpandedRecordHeader,
+        fieldname: *const ::std::os::raw::c_char,
+        finfo: *mut ExpandedRecordFieldInfo,
+    ) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn expanded_record_fetch_field(
+        erh: *mut ExpandedRecordHeader,
+        fnumber: ::std::os::raw::c_int,
+        isnull: *mut bool,
+    ) -> Datum;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn expanded_record_set_field_internal(
+        erh: *mut ExpandedRecordHeader,
+        fnumber: ::std::os::raw::c_int,
+        newValue: Datum,
+        isnull: bool,
+        expand_external: bool,
+        check_constraints: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn expanded_record_set_fields(
+        erh: *mut ExpandedRecordHeader,
+        newValues: *const Datum,
+        isnulls: *const bool,
+        expand_external: bool,
+    );
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct DomainConstraintCache {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct TypeCacheEnumData {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct TypeCacheEntry {
+    pub type_id: Oid,
+    pub type_id_hash: uint32,
+    pub typlen: int16,
+    pub typbyval: bool,
+    pub typalign: ::std::os::raw::c_char,
+    pub typstorage: ::std::os::raw::c_char,
+    pub typtype: ::std::os::raw::c_char,
+    pub typrelid: Oid,
+    pub typelem: Oid,
+    pub typcollation: Oid,
+    pub btree_opf: Oid,
+    pub btree_opintype: Oid,
+    pub hash_opf: Oid,
+    pub hash_opintype: Oid,
+    pub eq_opr: Oid,
+    pub lt_opr: Oid,
+    pub gt_opr: Oid,
+    pub cmp_proc: Oid,
+    pub hash_proc: Oid,
+    pub hash_extended_proc: Oid,
+    pub eq_opr_finfo: FmgrInfo,
+    pub cmp_proc_finfo: FmgrInfo,
+    pub hash_proc_finfo: FmgrInfo,
+    pub hash_extended_proc_finfo: FmgrInfo,
+    pub tupDesc: TupleDesc,
+    pub tupDesc_identifier: uint64,
+    pub rngelemtype: *mut TypeCacheEntry,
+    pub rng_collation: Oid,
+    pub rng_cmp_proc_finfo: FmgrInfo,
+    pub rng_canonical_finfo: FmgrInfo,
+    pub rng_subdiff_finfo: FmgrInfo,
+    pub domainBaseType: Oid,
+    pub domainBaseTypmod: int32,
+    pub domainData: *mut DomainConstraintCache,
+    pub flags: ::std::os::raw::c_int,
+    pub enumData: *mut TypeCacheEnumData,
+    pub nextDomain: *mut TypeCacheEntry,
+}
+impl Default for TypeCacheEntry {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct DomainConstraintRef {
+    pub constraints: *mut List,
+    pub refctx: MemoryContext,
+    pub tcache: *mut TypeCacheEntry,
+    pub need_exprstate: bool,
+    pub dcc: *mut DomainConstraintCache,
+    pub callback: MemoryContextCallback,
+}
+impl Default for DomainConstraintRef {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct SharedRecordTypmodRegistry {
+    _unused: [u8; 0],
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn lookup_type_cache(type_id: Oid, flags: ::std::os::raw::c_int) -> *mut TypeCacheEntry;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn InitDomainConstraintRef(
+        type_id: Oid,
+        ref_: *mut DomainConstraintRef,
+        refctx: MemoryContext,
+        need_exprstate: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UpdateDomainConstraintRef(ref_: *mut DomainConstraintRef);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DomainHasConstraints(type_id: Oid) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn lookup_rowtype_tupdesc(type_id: Oid, typmod: int32) -> TupleDesc;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn lookup_rowtype_tupdesc_noerror(type_id: Oid, typmod: int32, noError: bool) -> TupleDesc;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn lookup_rowtype_tupdesc_copy(type_id: Oid, typmod: int32) -> TupleDesc;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn lookup_rowtype_tupdesc_domain(type_id: Oid, typmod: int32, noError: bool) -> TupleDesc;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn assign_record_type_typmod(tupDesc: TupleDesc);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn assign_record_type_identifier(type_id: Oid, typmod: int32) -> uint64;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn compare_values_of_enum(
+        tcache: *mut TypeCacheEntry,
+        arg1: Oid,
+        arg2: Oid,
+    ) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SharedRecordTypmodRegistryEstimate() -> usize;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SharedRecordTypmodRegistryInit(
+        arg1: *mut SharedRecordTypmodRegistry,
+        segment: *mut dsm_segment,
+        area: *mut dsa_area,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SharedRecordTypmodRegistryAttach(arg1: *mut SharedRecordTypmodRegistry);
+}
+pub const PLpgSQL_nsitem_type_PLPGSQL_NSTYPE_LABEL: PLpgSQL_nsitem_type = 0;
+pub const PLpgSQL_nsitem_type_PLPGSQL_NSTYPE_VAR: PLpgSQL_nsitem_type = 1;
+pub const PLpgSQL_nsitem_type_PLPGSQL_NSTYPE_REC: PLpgSQL_nsitem_type = 2;
+pub type PLpgSQL_nsitem_type = ::std::os::raw::c_uint;
+pub const PLpgSQL_label_type_PLPGSQL_LABEL_BLOCK: PLpgSQL_label_type = 0;
+pub const PLpgSQL_label_type_PLPGSQL_LABEL_LOOP: PLpgSQL_label_type = 1;
+pub const PLpgSQL_label_type_PLPGSQL_LABEL_OTHER: PLpgSQL_label_type = 2;
+pub type PLpgSQL_label_type = ::std::os::raw::c_uint;
+pub const PLpgSQL_datum_type_PLPGSQL_DTYPE_VAR: PLpgSQL_datum_type = 0;
+pub const PLpgSQL_datum_type_PLPGSQL_DTYPE_ROW: PLpgSQL_datum_type = 1;
+pub const PLpgSQL_datum_type_PLPGSQL_DTYPE_REC: PLpgSQL_datum_type = 2;
+pub const PLpgSQL_datum_type_PLPGSQL_DTYPE_RECFIELD: PLpgSQL_datum_type = 3;
+pub const PLpgSQL_datum_type_PLPGSQL_DTYPE_ARRAYELEM: PLpgSQL_datum_type = 4;
+pub const PLpgSQL_datum_type_PLPGSQL_DTYPE_PROMISE: PLpgSQL_datum_type = 5;
+pub type PLpgSQL_datum_type = ::std::os::raw::c_uint;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_NONE: PLpgSQL_promise_type = 0;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_NAME: PLpgSQL_promise_type = 1;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_WHEN: PLpgSQL_promise_type = 2;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_LEVEL: PLpgSQL_promise_type = 3;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_OP: PLpgSQL_promise_type = 4;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_RELID: PLpgSQL_promise_type = 5;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_TABLE_NAME: PLpgSQL_promise_type = 6;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_TABLE_SCHEMA: PLpgSQL_promise_type = 7;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_NARGS: PLpgSQL_promise_type = 8;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_ARGV: PLpgSQL_promise_type = 9;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_EVENT: PLpgSQL_promise_type = 10;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_TAG: PLpgSQL_promise_type = 11;
+pub type PLpgSQL_promise_type = ::std::os::raw::c_uint;
+pub const PLpgSQL_type_type_PLPGSQL_TTYPE_SCALAR: PLpgSQL_type_type = 0;
+pub const PLpgSQL_type_type_PLPGSQL_TTYPE_REC: PLpgSQL_type_type = 1;
+pub const PLpgSQL_type_type_PLPGSQL_TTYPE_PSEUDO: PLpgSQL_type_type = 2;
+pub type PLpgSQL_type_type = ::std::os::raw::c_uint;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_BLOCK: PLpgSQL_stmt_type = 0;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_ASSIGN: PLpgSQL_stmt_type = 1;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_IF: PLpgSQL_stmt_type = 2;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_CASE: PLpgSQL_stmt_type = 3;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_LOOP: PLpgSQL_stmt_type = 4;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_WHILE: PLpgSQL_stmt_type = 5;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_FORI: PLpgSQL_stmt_type = 6;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_FORS: PLpgSQL_stmt_type = 7;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_FORC: PLpgSQL_stmt_type = 8;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_FOREACH_A: PLpgSQL_stmt_type = 9;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_EXIT: PLpgSQL_stmt_type = 10;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_RETURN: PLpgSQL_stmt_type = 11;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_RETURN_NEXT: PLpgSQL_stmt_type = 12;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_RETURN_QUERY: PLpgSQL_stmt_type = 13;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_RAISE: PLpgSQL_stmt_type = 14;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_ASSERT: PLpgSQL_stmt_type = 15;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_EXECSQL: PLpgSQL_stmt_type = 16;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_DYNEXECUTE: PLpgSQL_stmt_type = 17;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_DYNFORS: PLpgSQL_stmt_type = 18;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_GETDIAG: PLpgSQL_stmt_type = 19;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_OPEN: PLpgSQL_stmt_type = 20;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_FETCH: PLpgSQL_stmt_type = 21;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_CLOSE: PLpgSQL_stmt_type = 22;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_PERFORM: PLpgSQL_stmt_type = 23;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_CALL: PLpgSQL_stmt_type = 24;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_COMMIT: PLpgSQL_stmt_type = 25;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_ROLLBACK: PLpgSQL_stmt_type = 26;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_SET: PLpgSQL_stmt_type = 27;
+pub type PLpgSQL_stmt_type = ::std::os::raw::c_uint;
+pub const PLPGSQL_RC_OK: _bindgen_ty_19 = 0;
+pub const PLPGSQL_RC_EXIT: _bindgen_ty_19 = 1;
+pub const PLPGSQL_RC_RETURN: _bindgen_ty_19 = 2;
+pub const PLPGSQL_RC_CONTINUE: _bindgen_ty_19 = 3;
+pub type _bindgen_ty_19 = ::std::os::raw::c_uint;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_ROW_COUNT: PLpgSQL_getdiag_kind = 0;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_CONTEXT: PLpgSQL_getdiag_kind = 1;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_ERROR_CONTEXT: PLpgSQL_getdiag_kind = 2;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_ERROR_DETAIL: PLpgSQL_getdiag_kind = 3;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_ERROR_HINT: PLpgSQL_getdiag_kind = 4;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_RETURNED_SQLSTATE: PLpgSQL_getdiag_kind = 5;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_COLUMN_NAME: PLpgSQL_getdiag_kind = 6;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_CONSTRAINT_NAME: PLpgSQL_getdiag_kind = 7;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_DATATYPE_NAME: PLpgSQL_getdiag_kind = 8;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_MESSAGE_TEXT: PLpgSQL_getdiag_kind = 9;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_TABLE_NAME: PLpgSQL_getdiag_kind = 10;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_SCHEMA_NAME: PLpgSQL_getdiag_kind = 11;
+pub type PLpgSQL_getdiag_kind = ::std::os::raw::c_uint;
+pub const PLpgSQL_raise_option_type_PLPGSQL_RAISEOPTION_ERRCODE: PLpgSQL_raise_option_type = 0;
+pub const PLpgSQL_raise_option_type_PLPGSQL_RAISEOPTION_MESSAGE: PLpgSQL_raise_option_type = 1;
+pub const PLpgSQL_raise_option_type_PLPGSQL_RAISEOPTION_DETAIL: PLpgSQL_raise_option_type = 2;
+pub const PLpgSQL_raise_option_type_PLPGSQL_RAISEOPTION_HINT: PLpgSQL_raise_option_type = 3;
+pub const PLpgSQL_raise_option_type_PLPGSQL_RAISEOPTION_COLUMN: PLpgSQL_raise_option_type = 4;
+pub const PLpgSQL_raise_option_type_PLPGSQL_RAISEOPTION_CONSTRAINT: PLpgSQL_raise_option_type = 5;
+pub const PLpgSQL_raise_option_type_PLPGSQL_RAISEOPTION_DATATYPE: PLpgSQL_raise_option_type = 6;
+pub const PLpgSQL_raise_option_type_PLPGSQL_RAISEOPTION_TABLE: PLpgSQL_raise_option_type = 7;
+pub const PLpgSQL_raise_option_type_PLPGSQL_RAISEOPTION_SCHEMA: PLpgSQL_raise_option_type = 8;
+pub type PLpgSQL_raise_option_type = ::std::os::raw::c_uint;
+pub const PLpgSQL_resolve_option_PLPGSQL_RESOLVE_ERROR: PLpgSQL_resolve_option = 0;
+pub const PLpgSQL_resolve_option_PLPGSQL_RESOLVE_VARIABLE: PLpgSQL_resolve_option = 1;
+pub const PLpgSQL_resolve_option_PLPGSQL_RESOLVE_COLUMN: PLpgSQL_resolve_option = 2;
+pub type PLpgSQL_resolve_option = ::std::os::raw::c_uint;
+#[doc = " Node and structure definitions"]
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_type {
+    pub typname: *mut ::std::os::raw::c_char,
+    pub typoid: Oid,
+    pub ttype: PLpgSQL_type_type,
+    pub typlen: int16,
+    pub typbyval: bool,
+    pub typtype: ::std::os::raw::c_char,
+    pub collation: Oid,
+    pub typisarray: bool,
+    pub atttypmod: int32,
+    pub origtypname: *mut TypeName,
+    pub tcache: *mut TypeCacheEntry,
+    pub tupdesc_id: uint64,
+}
+impl Default for PLpgSQL_type {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_expr {
+    pub query: *mut ::std::os::raw::c_char,
+    pub plan: SPIPlanPtr,
+    pub paramnos: *mut Bitmapset,
+    pub rwparam: ::std::os::raw::c_int,
+    pub func: *mut PLpgSQL_function,
+    pub ns: *mut PLpgSQL_nsitem,
+    pub expr_simple_expr: *mut Expr,
+    pub expr_simple_type: Oid,
+    pub expr_simple_typmod: int32,
+    pub expr_simple_mutable: bool,
+    pub expr_simple_plansource: *mut CachedPlanSource,
+    pub expr_simple_plan: *mut CachedPlan,
+    pub expr_simple_plan_lxid: LocalTransactionId,
+    pub expr_simple_state: *mut ExprState,
+    pub expr_simple_in_use: bool,
+    pub expr_simple_lxid: LocalTransactionId,
+}
+impl Default for PLpgSQL_expr {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_datum {
+    pub dtype: PLpgSQL_datum_type,
+    pub dno: ::std::os::raw::c_int,
+}
+impl Default for PLpgSQL_datum {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_variable {
+    pub dtype: PLpgSQL_datum_type,
+    pub dno: ::std::os::raw::c_int,
+    pub refname: *mut ::std::os::raw::c_char,
+    pub lineno: ::std::os::raw::c_int,
+    pub isconst: bool,
+    pub notnull: bool,
+    pub default_val: *mut PLpgSQL_expr,
+}
+impl Default for PLpgSQL_variable {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_var {
+    pub dtype: PLpgSQL_datum_type,
+    pub dno: ::std::os::raw::c_int,
+    pub refname: *mut ::std::os::raw::c_char,
+    pub lineno: ::std::os::raw::c_int,
+    pub isconst: bool,
+    pub notnull: bool,
+    pub default_val: *mut PLpgSQL_expr,
+    pub datatype: *mut PLpgSQL_type,
+    pub cursor_explicit_expr: *mut PLpgSQL_expr,
+    pub cursor_explicit_argrow: ::std::os::raw::c_int,
+    pub cursor_options: ::std::os::raw::c_int,
+    pub value: Datum,
+    pub isnull: bool,
+    pub freeval: bool,
+    pub promise: PLpgSQL_promise_type,
+}
+impl Default for PLpgSQL_var {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_row {
+    pub dtype: PLpgSQL_datum_type,
+    pub dno: ::std::os::raw::c_int,
+    pub refname: *mut ::std::os::raw::c_char,
+    pub lineno: ::std::os::raw::c_int,
+    pub isconst: bool,
+    pub notnull: bool,
+    pub default_val: *mut PLpgSQL_expr,
+    pub rowtupdesc: TupleDesc,
+    pub nfields: ::std::os::raw::c_int,
+    pub fieldnames: *mut *mut ::std::os::raw::c_char,
+    pub varnos: *mut ::std::os::raw::c_int,
+}
+impl Default for PLpgSQL_row {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_rec {
+    pub dtype: PLpgSQL_datum_type,
+    pub dno: ::std::os::raw::c_int,
+    pub refname: *mut ::std::os::raw::c_char,
+    pub lineno: ::std::os::raw::c_int,
+    pub isconst: bool,
+    pub notnull: bool,
+    pub default_val: *mut PLpgSQL_expr,
+    pub datatype: *mut PLpgSQL_type,
+    pub rectypeid: Oid,
+    pub firstfield: ::std::os::raw::c_int,
+    pub erh: *mut ExpandedRecordHeader,
+}
+impl Default for PLpgSQL_rec {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_recfield {
+    pub dtype: PLpgSQL_datum_type,
+    pub dno: ::std::os::raw::c_int,
+    pub fieldname: *mut ::std::os::raw::c_char,
+    pub recparentno: ::std::os::raw::c_int,
+    pub nextfield: ::std::os::raw::c_int,
+    pub rectupledescid: uint64,
+    pub finfo: ExpandedRecordFieldInfo,
+}
+impl Default for PLpgSQL_recfield {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_arrayelem {
+    pub dtype: PLpgSQL_datum_type,
+    pub dno: ::std::os::raw::c_int,
+    pub subscript: *mut PLpgSQL_expr,
+    pub arrayparentno: ::std::os::raw::c_int,
+    pub parenttypoid: Oid,
+    pub parenttypmod: int32,
+    pub arraytypoid: Oid,
+    pub arraytypmod: int32,
+    pub arraytyplen: int16,
+    pub elemtypoid: Oid,
+    pub elemtyplen: int16,
+    pub elemtypbyval: bool,
+    pub elemtypalign: ::std::os::raw::c_char,
+}
+impl Default for PLpgSQL_arrayelem {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct PLpgSQL_nsitem {
+    pub itemtype: PLpgSQL_nsitem_type,
+    pub itemno: ::std::os::raw::c_int,
+    pub prev: *mut PLpgSQL_nsitem,
+    pub name: __IncompleteArrayField<::std::os::raw::c_char>,
+}
+impl Default for PLpgSQL_nsitem {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+}
+impl Default for PLpgSQL_stmt {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_condition {
+    pub sqlerrstate: ::std::os::raw::c_int,
+    pub condname: *mut ::std::os::raw::c_char,
+    pub next: *mut PLpgSQL_condition,
+}
+impl Default for PLpgSQL_condition {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_exception_block {
+    pub sqlstate_varno: ::std::os::raw::c_int,
+    pub sqlerrm_varno: ::std::os::raw::c_int,
+    pub exc_list: *mut List,
+}
+impl Default for PLpgSQL_exception_block {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_exception {
+    pub lineno: ::std::os::raw::c_int,
+    pub conditions: *mut PLpgSQL_condition,
+    pub action: *mut List,
+}
+impl Default for PLpgSQL_exception {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_block {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub label: *mut ::std::os::raw::c_char,
+    pub body: *mut List,
+    pub n_initvars: ::std::os::raw::c_int,
+    pub initvarnos: *mut ::std::os::raw::c_int,
+    pub exceptions: *mut PLpgSQL_exception_block,
+}
+impl Default for PLpgSQL_stmt_block {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_assign {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub varno: ::std::os::raw::c_int,
+    pub expr: *mut PLpgSQL_expr,
+}
+impl Default for PLpgSQL_stmt_assign {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_perform {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub expr: *mut PLpgSQL_expr,
+}
+impl Default for PLpgSQL_stmt_perform {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_call {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub expr: *mut PLpgSQL_expr,
+    pub is_call: bool,
+    pub target: *mut PLpgSQL_variable,
+}
+impl Default for PLpgSQL_stmt_call {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_commit {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub chain: bool,
+}
+impl Default for PLpgSQL_stmt_commit {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_rollback {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub chain: bool,
+}
+impl Default for PLpgSQL_stmt_rollback {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_set {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub expr: *mut PLpgSQL_expr,
+}
+impl Default for PLpgSQL_stmt_set {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_diag_item {
+    pub kind: PLpgSQL_getdiag_kind,
+    pub target: ::std::os::raw::c_int,
+}
+impl Default for PLpgSQL_diag_item {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_getdiag {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub is_stacked: bool,
+    pub diag_items: *mut List,
+}
+impl Default for PLpgSQL_stmt_getdiag {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_if {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub cond: *mut PLpgSQL_expr,
+    pub then_body: *mut List,
+    pub elsif_list: *mut List,
+    pub else_body: *mut List,
+}
+impl Default for PLpgSQL_stmt_if {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_if_elsif {
+    pub lineno: ::std::os::raw::c_int,
+    pub cond: *mut PLpgSQL_expr,
+    pub stmts: *mut List,
+}
+impl Default for PLpgSQL_if_elsif {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_case {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub t_expr: *mut PLpgSQL_expr,
+    pub t_varno: ::std::os::raw::c_int,
+    pub case_when_list: *mut List,
+    pub have_else: bool,
+    pub else_stmts: *mut List,
+}
+impl Default for PLpgSQL_stmt_case {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_case_when {
+    pub lineno: ::std::os::raw::c_int,
+    pub expr: *mut PLpgSQL_expr,
+    pub stmts: *mut List,
+}
+impl Default for PLpgSQL_case_when {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_loop {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub label: *mut ::std::os::raw::c_char,
+    pub body: *mut List,
+}
+impl Default for PLpgSQL_stmt_loop {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_while {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub label: *mut ::std::os::raw::c_char,
+    pub cond: *mut PLpgSQL_expr,
+    pub body: *mut List,
+}
+impl Default for PLpgSQL_stmt_while {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_fori {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub label: *mut ::std::os::raw::c_char,
+    pub var: *mut PLpgSQL_var,
+    pub lower: *mut PLpgSQL_expr,
+    pub upper: *mut PLpgSQL_expr,
+    pub step: *mut PLpgSQL_expr,
+    pub reverse: ::std::os::raw::c_int,
+    pub body: *mut List,
+}
+impl Default for PLpgSQL_stmt_fori {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_forq {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub label: *mut ::std::os::raw::c_char,
+    pub var: *mut PLpgSQL_variable,
+    pub body: *mut List,
+}
+impl Default for PLpgSQL_stmt_forq {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_fors {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub label: *mut ::std::os::raw::c_char,
+    pub var: *mut PLpgSQL_variable,
+    pub body: *mut List,
+    pub query: *mut PLpgSQL_expr,
+}
+impl Default for PLpgSQL_stmt_fors {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_forc {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub label: *mut ::std::os::raw::c_char,
+    pub var: *mut PLpgSQL_variable,
+    pub body: *mut List,
+    pub curvar: ::std::os::raw::c_int,
+    pub argquery: *mut PLpgSQL_expr,
+}
+impl Default for PLpgSQL_stmt_forc {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_dynfors {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub label: *mut ::std::os::raw::c_char,
+    pub var: *mut PLpgSQL_variable,
+    pub body: *mut List,
+    pub query: *mut PLpgSQL_expr,
+    pub params: *mut List,
+}
+impl Default for PLpgSQL_stmt_dynfors {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_foreach_a {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub label: *mut ::std::os::raw::c_char,
+    pub varno: ::std::os::raw::c_int,
+    pub slice: ::std::os::raw::c_int,
+    pub expr: *mut PLpgSQL_expr,
+    pub body: *mut List,
+}
+impl Default for PLpgSQL_stmt_foreach_a {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_open {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub curvar: ::std::os::raw::c_int,
+    pub cursor_options: ::std::os::raw::c_int,
+    pub argquery: *mut PLpgSQL_expr,
+    pub query: *mut PLpgSQL_expr,
+    pub dynquery: *mut PLpgSQL_expr,
+    pub params: *mut List,
+}
+impl Default for PLpgSQL_stmt_open {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_fetch {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub target: *mut PLpgSQL_variable,
+    pub curvar: ::std::os::raw::c_int,
+    pub direction: FetchDirection,
+    pub how_many: ::std::os::raw::c_long,
+    pub expr: *mut PLpgSQL_expr,
+    pub is_move: bool,
+    pub returns_multiple_rows: bool,
+}
+impl Default for PLpgSQL_stmt_fetch {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_close {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub curvar: ::std::os::raw::c_int,
+}
+impl Default for PLpgSQL_stmt_close {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_exit {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub is_exit: bool,
+    pub label: *mut ::std::os::raw::c_char,
+    pub cond: *mut PLpgSQL_expr,
+}
+impl Default for PLpgSQL_stmt_exit {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_return {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub expr: *mut PLpgSQL_expr,
+    pub retvarno: ::std::os::raw::c_int,
+}
+impl Default for PLpgSQL_stmt_return {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_return_next {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub expr: *mut PLpgSQL_expr,
+    pub retvarno: ::std::os::raw::c_int,
+}
+impl Default for PLpgSQL_stmt_return_next {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_return_query {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub query: *mut PLpgSQL_expr,
+    pub dynquery: *mut PLpgSQL_expr,
+    pub params: *mut List,
+}
+impl Default for PLpgSQL_stmt_return_query {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_raise {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub elog_level: ::std::os::raw::c_int,
+    pub condname: *mut ::std::os::raw::c_char,
+    pub message: *mut ::std::os::raw::c_char,
+    pub params: *mut List,
+    pub options: *mut List,
+}
+impl Default for PLpgSQL_stmt_raise {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_raise_option {
+    pub opt_type: PLpgSQL_raise_option_type,
+    pub expr: *mut PLpgSQL_expr,
+}
+impl Default for PLpgSQL_raise_option {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_assert {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub cond: *mut PLpgSQL_expr,
+    pub message: *mut PLpgSQL_expr,
+}
+impl Default for PLpgSQL_stmt_assert {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_execsql {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub sqlstmt: *mut PLpgSQL_expr,
+    pub mod_stmt: bool,
+    pub into: bool,
+    pub strict: bool,
+    pub mod_stmt_set: bool,
+    pub target: *mut PLpgSQL_variable,
+}
+impl Default for PLpgSQL_stmt_execsql {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_dynexecute {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub query: *mut PLpgSQL_expr,
+    pub into: bool,
+    pub strict: bool,
+    pub target: *mut PLpgSQL_variable,
+    pub params: *mut List,
+}
+impl Default for PLpgSQL_stmt_dynexecute {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_func_hashkey {
+    pub funcOid: Oid,
+    pub isTrigger: bool,
+    pub isEventTrigger: bool,
+    pub trigOid: Oid,
+    pub inputCollation: Oid,
+    pub argtypes: [Oid; 100usize],
+}
+impl Default for PLpgSQL_func_hashkey {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub const PLpgSQL_trigtype_PLPGSQL_DML_TRIGGER: PLpgSQL_trigtype = 0;
+pub const PLpgSQL_trigtype_PLPGSQL_EVENT_TRIGGER: PLpgSQL_trigtype = 1;
+pub const PLpgSQL_trigtype_PLPGSQL_NOT_TRIGGER: PLpgSQL_trigtype = 2;
+pub type PLpgSQL_trigtype = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_function {
+    pub fn_signature: *mut ::std::os::raw::c_char,
+    pub fn_oid: Oid,
+    pub fn_xmin: TransactionId,
+    pub fn_tid: ItemPointerData,
+    pub fn_is_trigger: PLpgSQL_trigtype,
+    pub fn_input_collation: Oid,
+    pub fn_hashkey: *mut PLpgSQL_func_hashkey,
+    pub fn_cxt: MemoryContext,
+    pub fn_rettype: Oid,
+    pub fn_rettyplen: ::std::os::raw::c_int,
+    pub fn_retbyval: bool,
+    pub fn_retistuple: bool,
+    pub fn_retisdomain: bool,
+    pub fn_retset: bool,
+    pub fn_readonly: bool,
+    pub fn_prokind: ::std::os::raw::c_char,
+    pub fn_nargs: ::std::os::raw::c_int,
+    pub fn_argvarnos: [::std::os::raw::c_int; 100usize],
+    pub out_param_varno: ::std::os::raw::c_int,
+    pub found_varno: ::std::os::raw::c_int,
+    pub new_varno: ::std::os::raw::c_int,
+    pub old_varno: ::std::os::raw::c_int,
+    pub resolve_option: PLpgSQL_resolve_option,
+    pub print_strict_params: bool,
+    pub extra_warnings: ::std::os::raw::c_int,
+    pub extra_errors: ::std::os::raw::c_int,
+    pub nstatements: ::std::os::raw::c_uint,
+    pub ndatums: ::std::os::raw::c_int,
+    pub datums: *mut *mut PLpgSQL_datum,
+    pub copiable_size: Size,
+    pub action: *mut PLpgSQL_stmt_block,
+    pub cur_estate: *mut PLpgSQL_execstate,
+    pub use_count: ::std::os::raw::c_ulong,
+}
+impl Default for PLpgSQL_function {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_execstate {
+    pub func: *mut PLpgSQL_function,
+    pub trigdata: *mut TriggerData,
+    pub evtrigdata: *mut EventTriggerData,
+    pub retval: Datum,
+    pub retisnull: bool,
+    pub rettype: Oid,
+    pub fn_rettype: Oid,
+    pub retistuple: bool,
+    pub retisset: bool,
+    pub readonly_func: bool,
+    pub atomic: bool,
+    pub exitlabel: *mut ::std::os::raw::c_char,
+    pub cur_error: *mut ErrorData,
+    pub tuple_store: *mut Tuplestorestate,
+    pub tuple_store_desc: TupleDesc,
+    pub tuple_store_cxt: MemoryContext,
+    pub tuple_store_owner: ResourceOwner,
+    pub rsi: *mut ReturnSetInfo,
+    pub found_varno: ::std::os::raw::c_int,
+    pub ndatums: ::std::os::raw::c_int,
+    pub datums: *mut *mut PLpgSQL_datum,
+    pub datum_context: MemoryContext,
+    pub paramLI: ParamListInfo,
+    pub simple_eval_estate: *mut EState,
+    pub simple_eval_resowner: ResourceOwner,
+    pub cast_hash: *mut HTAB,
+    pub cast_hash_context: MemoryContext,
+    pub stmt_mcontext: MemoryContext,
+    pub stmt_mcontext_parent: MemoryContext,
+    pub eval_tuptable: *mut SPITupleTable,
+    pub eval_processed: uint64,
+    pub eval_econtext: *mut ExprContext,
+    pub err_stmt: *mut PLpgSQL_stmt,
+    pub err_text: *const ::std::os::raw::c_char,
+    pub plugin_info: *mut ::std::os::raw::c_void,
+}
+impl Default for PLpgSQL_execstate {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct PLpgSQL_plugin {
+    pub func_setup: ::std::option::Option<
+        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, func: *mut PLpgSQL_function),
+    >,
+    pub func_beg: ::std::option::Option<
+        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, func: *mut PLpgSQL_function),
+    >,
+    pub func_end: ::std::option::Option<
+        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, func: *mut PLpgSQL_function),
+    >,
+    pub stmt_beg: ::std::option::Option<
+        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, stmt: *mut PLpgSQL_stmt),
+    >,
+    pub stmt_end: ::std::option::Option<
+        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, stmt: *mut PLpgSQL_stmt),
+    >,
+    pub error_callback:
+        ::std::option::Option<unsafe extern "C" fn(arg: *mut ::std::os::raw::c_void)>,
+    pub assign_expr: ::std::option::Option<
+        unsafe extern "C" fn(
+            estate: *mut PLpgSQL_execstate,
+            target: *mut PLpgSQL_datum,
+            expr: *mut PLpgSQL_expr,
+        ),
+    >,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLword {
+    pub ident: *mut ::std::os::raw::c_char,
+    pub quoted: bool,
+}
+impl Default for PLword {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLcword {
+    pub idents: *mut List,
+}
+impl Default for PLcword {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLwdatum {
+    pub datum: *mut PLpgSQL_datum,
+    pub ident: *mut ::std::os::raw::c_char,
+    pub quoted: bool,
+    pub idents: *mut List,
+}
+impl Default for PLwdatum {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub const IdentifierLookup_IDENTIFIER_LOOKUP_NORMAL: IdentifierLookup = 0;
+pub const IdentifierLookup_IDENTIFIER_LOOKUP_DECLARE: IdentifierLookup = 1;
+pub const IdentifierLookup_IDENTIFIER_LOOKUP_EXPR: IdentifierLookup = 2;
+#[doc = " Global variable declarations"]
+pub type IdentifierLookup = ::std::os::raw::c_uint;
+extern "C" {
+    pub static mut plpgsql_IdentifierLookup: IdentifierLookup;
+}
+extern "C" {
+    pub static mut plpgsql_variable_conflict: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut plpgsql_print_strict_params: bool;
+}
+extern "C" {
+    pub static mut plpgsql_check_asserts: bool;
+}
+extern "C" {
+    pub static mut plpgsql_extra_warnings: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut plpgsql_extra_errors: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut plpgsql_check_syntax: bool;
+}
+extern "C" {
+    pub static mut plpgsql_DumpExecTree: bool;
+}
+extern "C" {
+    pub static mut plpgsql_parse_result: *mut PLpgSQL_stmt_block;
+}
+extern "C" {
+    pub static mut plpgsql_nDatums: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut plpgsql_Datums: *mut *mut PLpgSQL_datum;
+}
+extern "C" {
+    pub static mut plpgsql_error_funcname: *mut ::std::os::raw::c_char;
+}
+extern "C" {
+    pub static mut plpgsql_curr_compile: *mut PLpgSQL_function;
+}
+extern "C" {
+    pub static mut plpgsql_compile_tmp_cxt: MemoryContext;
+}
+extern "C" {
+    pub static mut plpgsql_plugin_ptr: *mut *mut PLpgSQL_plugin;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    #[doc = " Function declarations"]
+    pub fn plpgsql_compile(fcinfo: FunctionCallInfo, forValidator: bool) -> *mut PLpgSQL_function;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_compile_inline(
+        proc_source: *mut ::std::os::raw::c_char,
+    ) -> *mut PLpgSQL_function;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_parser_setup(pstate: *mut ParseState, expr: *mut PLpgSQL_expr);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_parse_word(
+        word1: *mut ::std::os::raw::c_char,
+        yytxt: *const ::std::os::raw::c_char,
+        lookup: bool,
+        wdatum: *mut PLwdatum,
+        word: *mut PLword,
+    ) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_parse_dblword(
+        word1: *mut ::std::os::raw::c_char,
+        word2: *mut ::std::os::raw::c_char,
+        wdatum: *mut PLwdatum,
+        cword: *mut PLcword,
+    ) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_parse_tripword(
+        word1: *mut ::std::os::raw::c_char,
+        word2: *mut ::std::os::raw::c_char,
+        word3: *mut ::std::os::raw::c_char,
+        wdatum: *mut PLwdatum,
+        cword: *mut PLcword,
+    ) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_parse_wordtype(ident: *mut ::std::os::raw::c_char) -> *mut PLpgSQL_type;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_parse_cwordtype(idents: *mut List) -> *mut PLpgSQL_type;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_parse_wordrowtype(ident: *mut ::std::os::raw::c_char) -> *mut PLpgSQL_type;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_parse_cwordrowtype(idents: *mut List) -> *mut PLpgSQL_type;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_build_datatype(
+        typeOid: Oid,
+        typmod: int32,
+        collation: Oid,
+        origtypname: *mut TypeName,
+    ) -> *mut PLpgSQL_type;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_build_variable(
+        refname: *const ::std::os::raw::c_char,
+        lineno: ::std::os::raw::c_int,
+        dtype: *mut PLpgSQL_type,
+        add2namespace: bool,
+    ) -> *mut PLpgSQL_variable;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_build_record(
+        refname: *const ::std::os::raw::c_char,
+        lineno: ::std::os::raw::c_int,
+        dtype: *mut PLpgSQL_type,
+        rectypeid: Oid,
+        add2namespace: bool,
+    ) -> *mut PLpgSQL_rec;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_build_recfield(
+        rec: *mut PLpgSQL_rec,
+        fldname: *const ::std::os::raw::c_char,
+    ) -> *mut PLpgSQL_recfield;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_recognize_err_condition(
+        condname: *const ::std::os::raw::c_char,
+        allow_sqlstate: bool,
+    ) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_parse_err_condition(
+        condname: *mut ::std::os::raw::c_char,
+    ) -> *mut PLpgSQL_condition;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_adddatum(newdatum: *mut PLpgSQL_datum);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_add_initdatums(varnos: *mut *mut ::std::os::raw::c_int)
+        -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_HashTableInit();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn _PG_init();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_exec_function(
+        func: *mut PLpgSQL_function,
+        fcinfo: FunctionCallInfo,
+        simple_eval_estate: *mut EState,
+        simple_eval_resowner: ResourceOwner,
+        atomic: bool,
+    ) -> Datum;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_exec_trigger(
+        func: *mut PLpgSQL_function,
+        trigdata: *mut TriggerData,
+    ) -> HeapTuple;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_exec_event_trigger(func: *mut PLpgSQL_function, trigdata: *mut EventTriggerData);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_xact_cb(event: XactEvent, arg: *mut ::std::os::raw::c_void);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_subxact_cb(
+        event: SubXactEvent,
+        mySubid: SubTransactionId,
+        parentSubid: SubTransactionId,
+        arg: *mut ::std::os::raw::c_void,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_exec_get_datum_type(
+        estate: *mut PLpgSQL_execstate,
+        datum: *mut PLpgSQL_datum,
+    ) -> Oid;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_exec_get_datum_type_info(
+        estate: *mut PLpgSQL_execstate,
+        datum: *mut PLpgSQL_datum,
+        typeId: *mut Oid,
+        typMod: *mut int32,
+        collation: *mut Oid,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_ns_init();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_ns_push(label: *const ::std::os::raw::c_char, label_type: PLpgSQL_label_type);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_ns_pop();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_ns_top() -> *mut PLpgSQL_nsitem;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_ns_additem(
+        itemtype: PLpgSQL_nsitem_type,
+        itemno: ::std::os::raw::c_int,
+        name: *const ::std::os::raw::c_char,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_ns_lookup(
+        ns_cur: *mut PLpgSQL_nsitem,
+        localmode: bool,
+        name1: *const ::std::os::raw::c_char,
+        name2: *const ::std::os::raw::c_char,
+        name3: *const ::std::os::raw::c_char,
+        names_used: *mut ::std::os::raw::c_int,
+    ) -> *mut PLpgSQL_nsitem;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_ns_lookup_label(
+        ns_cur: *mut PLpgSQL_nsitem,
+        name: *const ::std::os::raw::c_char,
+    ) -> *mut PLpgSQL_nsitem;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_ns_find_nearest_loop(ns_cur: *mut PLpgSQL_nsitem) -> *mut PLpgSQL_nsitem;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_stmt_typename(stmt: *mut PLpgSQL_stmt) -> *const ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_getdiag_kindname(kind: PLpgSQL_getdiag_kind) -> *const ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_free_function_memory(func: *mut PLpgSQL_function);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_dumptree(func: *mut PLpgSQL_function);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_base_yylex() -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_yylex() -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_push_back_token(token: ::std::os::raw::c_int);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_token_is_unreserved_keyword(token: ::std::os::raw::c_int) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_append_source_text(
+        buf: StringInfo,
+        startlocation: ::std::os::raw::c_int,
+        endlocation: ::std::os::raw::c_int,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_peek() -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_peek2(
+        tok1_p: *mut ::std::os::raw::c_int,
+        tok2_p: *mut ::std::os::raw::c_int,
+        tok1_loc: *mut ::std::os::raw::c_int,
+        tok2_loc: *mut ::std::os::raw::c_int,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_scanner_errposition(location: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_yyerror(message: *const ::std::os::raw::c_char);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_location_to_lineno(location: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_latest_lineno() -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_scanner_init(str_: *const ::std::os::raw::c_char);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_scanner_finish();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_yyparse() -> ::std::os::raw::c_int;
+}
 extern "C" {
     pub static mut logical_decoding_work_mem: ::std::os::raw::c_int;
 }
@@ -43628,6 +45802,61 @@ extern "C" {
         include_triggers: bool,
         include_cols: *mut Bitmapset,
     ) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct RowSecurityPolicy {
+    pub policy_name: *mut ::std::os::raw::c_char,
+    pub polcmd: ::std::os::raw::c_char,
+    pub roles: *mut ArrayType,
+    pub permissive: bool,
+    pub qual: *mut Expr,
+    pub with_check_qual: *mut Expr,
+    pub hassublinks: bool,
+}
+impl Default for RowSecurityPolicy {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct RowSecurityDesc {
+    pub rscxt: MemoryContext,
+    pub policies: *mut List,
+}
+impl Default for RowSecurityDesc {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type row_security_policy_hook_type =
+    ::std::option::Option<unsafe extern "C" fn(cmdtype: CmdType, relation: Relation) -> *mut List>;
+extern "C" {
+    pub static mut row_security_policy_hook_permissive: row_security_policy_hook_type;
+}
+extern "C" {
+    pub static mut row_security_policy_hook_restrictive: row_security_policy_hook_type;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_row_security_policies(
+        root: *mut Query,
+        rte: *mut RangeTblEntry,
+        rt_index: ::std::os::raw::c_int,
+        securityQuals: *mut *mut List,
+        withCheckOptions: *mut *mut List,
+        hasRowSecurity: *mut bool,
+        hasSubLinks: *mut bool,
+    );
 }
 extern "C" {
     pub static mut old_snapshot_threshold: ::std::os::raw::c_int;
@@ -58144,159 +60373,6 @@ extern "C" {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct DomainConstraintCache {
-    _unused: [u8; 0],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct TypeCacheEnumData {
-    _unused: [u8; 0],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct TypeCacheEntry {
-    pub type_id: Oid,
-    pub type_id_hash: uint32,
-    pub typlen: int16,
-    pub typbyval: bool,
-    pub typalign: ::std::os::raw::c_char,
-    pub typstorage: ::std::os::raw::c_char,
-    pub typtype: ::std::os::raw::c_char,
-    pub typrelid: Oid,
-    pub typelem: Oid,
-    pub typcollation: Oid,
-    pub btree_opf: Oid,
-    pub btree_opintype: Oid,
-    pub hash_opf: Oid,
-    pub hash_opintype: Oid,
-    pub eq_opr: Oid,
-    pub lt_opr: Oid,
-    pub gt_opr: Oid,
-    pub cmp_proc: Oid,
-    pub hash_proc: Oid,
-    pub hash_extended_proc: Oid,
-    pub eq_opr_finfo: FmgrInfo,
-    pub cmp_proc_finfo: FmgrInfo,
-    pub hash_proc_finfo: FmgrInfo,
-    pub hash_extended_proc_finfo: FmgrInfo,
-    pub tupDesc: TupleDesc,
-    pub tupDesc_identifier: uint64,
-    pub rngelemtype: *mut TypeCacheEntry,
-    pub rng_collation: Oid,
-    pub rng_cmp_proc_finfo: FmgrInfo,
-    pub rng_canonical_finfo: FmgrInfo,
-    pub rng_subdiff_finfo: FmgrInfo,
-    pub domainBaseType: Oid,
-    pub domainBaseTypmod: int32,
-    pub domainData: *mut DomainConstraintCache,
-    pub flags: ::std::os::raw::c_int,
-    pub enumData: *mut TypeCacheEnumData,
-    pub nextDomain: *mut TypeCacheEntry,
-}
-impl Default for TypeCacheEntry {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct DomainConstraintRef {
-    pub constraints: *mut List,
-    pub refctx: MemoryContext,
-    pub tcache: *mut TypeCacheEntry,
-    pub need_exprstate: bool,
-    pub dcc: *mut DomainConstraintCache,
-    pub callback: MemoryContextCallback,
-}
-impl Default for DomainConstraintRef {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct SharedRecordTypmodRegistry {
-    _unused: [u8; 0],
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn lookup_type_cache(type_id: Oid, flags: ::std::os::raw::c_int) -> *mut TypeCacheEntry;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn InitDomainConstraintRef(
-        type_id: Oid,
-        ref_: *mut DomainConstraintRef,
-        refctx: MemoryContext,
-        need_exprstate: bool,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn UpdateDomainConstraintRef(ref_: *mut DomainConstraintRef);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn DomainHasConstraints(type_id: Oid) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn lookup_rowtype_tupdesc(type_id: Oid, typmod: int32) -> TupleDesc;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn lookup_rowtype_tupdesc_noerror(type_id: Oid, typmod: int32, noError: bool) -> TupleDesc;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn lookup_rowtype_tupdesc_copy(type_id: Oid, typmod: int32) -> TupleDesc;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn lookup_rowtype_tupdesc_domain(type_id: Oid, typmod: int32, noError: bool) -> TupleDesc;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn assign_record_type_typmod(tupDesc: TupleDesc);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn assign_record_type_identifier(type_id: Oid, typmod: int32) -> uint64;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn compare_values_of_enum(
-        tcache: *mut TypeCacheEntry,
-        arg1: Oid,
-        arg2: Oid,
-    ) -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn SharedRecordTypmodRegistryEstimate() -> usize;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn SharedRecordTypmodRegistryInit(
-        arg1: *mut SharedRecordTypmodRegistry,
-        segment: *mut dsm_segment,
-        area: *mut dsa_area,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn SharedRecordTypmodRegistryAttach(arg1: *mut SharedRecordTypmodRegistry);
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
 pub struct RangeType {
     pub vl_len_: int32,
     pub rangetypid: Oid,
@@ -58579,11 +60655,6 @@ pub struct ResourceOwnerData {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct _MdfdVec {
-    pub _address: u8,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct RowSecurityDesc {
     pub _address: u8,
 }
 #[repr(C)]

--- a/pgrx-pg-sys/src/pg14.rs
+++ b/pgrx-pg-sys/src/pg14.rs
@@ -3089,6 +3089,37 @@ pub const PVC_INCLUDE_PLACEHOLDERS: u32 = 16;
 pub const PVC_RECURSE_PLACEHOLDERS: u32 = 32;
 pub const DEFAULT_CURSOR_TUPLE_FRACTION: f64 = 0.1;
 pub const JUMBLE_SIZE: u32 = 1024;
+pub const ER_MAGIC: u32 = 1384727874;
+pub const ER_FLAG_FVALUE_VALID: u32 = 1;
+pub const ER_FLAG_FVALUE_ALLOCED: u32 = 2;
+pub const ER_FLAG_DVALUES_VALID: u32 = 4;
+pub const ER_FLAG_DVALUES_ALLOCED: u32 = 8;
+pub const ER_FLAG_HAVE_EXTERNAL: u32 = 16;
+pub const ER_FLAG_TUPDESC_ALLOCED: u32 = 32;
+pub const ER_FLAG_IS_DOMAIN: u32 = 64;
+pub const ER_FLAG_IS_DUMMY: u32 = 128;
+pub const ER_FLAGS_NON_DATA: u32 = 224;
+pub const TYPECACHE_EQ_OPR: u32 = 1;
+pub const TYPECACHE_LT_OPR: u32 = 2;
+pub const TYPECACHE_GT_OPR: u32 = 4;
+pub const TYPECACHE_CMP_PROC: u32 = 8;
+pub const TYPECACHE_HASH_PROC: u32 = 16;
+pub const TYPECACHE_EQ_OPR_FINFO: u32 = 32;
+pub const TYPECACHE_CMP_PROC_FINFO: u32 = 64;
+pub const TYPECACHE_HASH_PROC_FINFO: u32 = 128;
+pub const TYPECACHE_TUPDESC: u32 = 256;
+pub const TYPECACHE_BTREE_OPFAMILY: u32 = 512;
+pub const TYPECACHE_HASH_OPFAMILY: u32 = 1024;
+pub const TYPECACHE_RANGE_INFO: u32 = 2048;
+pub const TYPECACHE_DOMAIN_BASE_INFO: u32 = 4096;
+pub const TYPECACHE_DOMAIN_CONSTR_INFO: u32 = 8192;
+pub const TYPECACHE_HASH_EXTENDED_PROC: u32 = 16384;
+pub const TYPECACHE_HASH_EXTENDED_PROC_FINFO: u32 = 32768;
+pub const TYPECACHE_MULTIRANGE_INFO: u32 = 65536;
+pub const PLPGSQL_XCHECK_NONE: u32 = 0;
+pub const PLPGSQL_XCHECK_SHADOWVAR: u32 = 2;
+pub const PLPGSQL_XCHECK_TOOMANYROWS: u32 = 4;
+pub const PLPGSQL_XCHECK_STRICTMULTIASSIGNMENT: u32 = 8;
 pub const RBTXN_HAS_CATALOG_CHANGES: u32 = 1;
 pub const RBTXN_IS_SUBXACT: u32 = 2;
 pub const RBTXN_IS_SERIALIZED: u32 = 4;
@@ -3305,23 +3336,6 @@ pub const DEFAULT_NUM_DISTINCT: u32 = 200;
 pub const DEFAULT_UNK_SEL: f64 = 0.005;
 pub const DEFAULT_NOT_UNK_SEL: f64 = 0.995;
 pub const SELFLAG_USED_DEFAULT: u32 = 1;
-pub const TYPECACHE_EQ_OPR: u32 = 1;
-pub const TYPECACHE_LT_OPR: u32 = 2;
-pub const TYPECACHE_GT_OPR: u32 = 4;
-pub const TYPECACHE_CMP_PROC: u32 = 8;
-pub const TYPECACHE_HASH_PROC: u32 = 16;
-pub const TYPECACHE_EQ_OPR_FINFO: u32 = 32;
-pub const TYPECACHE_CMP_PROC_FINFO: u32 = 64;
-pub const TYPECACHE_HASH_PROC_FINFO: u32 = 128;
-pub const TYPECACHE_TUPDESC: u32 = 256;
-pub const TYPECACHE_BTREE_OPFAMILY: u32 = 512;
-pub const TYPECACHE_HASH_OPFAMILY: u32 = 1024;
-pub const TYPECACHE_RANGE_INFO: u32 = 2048;
-pub const TYPECACHE_DOMAIN_BASE_INFO: u32 = 4096;
-pub const TYPECACHE_DOMAIN_CONSTR_INFO: u32 = 8192;
-pub const TYPECACHE_HASH_EXTENDED_PROC: u32 = 16384;
-pub const TYPECACHE_HASH_EXTENDED_PROC_FINFO: u32 = 32768;
-pub const TYPECACHE_MULTIRANGE_INFO: u32 = 65536;
 pub const RANGE_EMPTY_LITERAL: &[u8; 6usize] = b"empty\0";
 pub const RANGE_EMPTY: u32 = 1;
 pub const RANGE_LB_INC: u32 = 2;
@@ -32177,6 +32191,96 @@ extern "C" {
         sarray_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
+pub const ObjectAccessType_OAT_POST_CREATE: ObjectAccessType = 0;
+pub const ObjectAccessType_OAT_DROP: ObjectAccessType = 1;
+pub const ObjectAccessType_OAT_POST_ALTER: ObjectAccessType = 2;
+pub const ObjectAccessType_OAT_NAMESPACE_SEARCH: ObjectAccessType = 3;
+pub const ObjectAccessType_OAT_FUNCTION_EXECUTE: ObjectAccessType = 4;
+pub const ObjectAccessType_OAT_TRUNCATE: ObjectAccessType = 5;
+pub type ObjectAccessType = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ObjectAccessPostCreate {
+    pub is_internal: bool,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ObjectAccessDrop {
+    pub dropflags: ::std::os::raw::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ObjectAccessPostAlter {
+    pub auxiliary_id: Oid,
+    pub is_internal: bool,
+}
+impl Default for ObjectAccessPostAlter {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ObjectAccessNamespaceSearch {
+    pub ereport_on_violation: bool,
+    pub result: bool,
+}
+pub type object_access_hook_type = ::std::option::Option<
+    unsafe extern "C" fn(
+        access: ObjectAccessType,
+        classId: Oid,
+        objectId: Oid,
+        subId: ::std::os::raw::c_int,
+        arg: *mut ::std::os::raw::c_void,
+    ),
+>;
+extern "C" {
+    pub static mut object_access_hook: object_access_hook_type;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RunObjectPostCreateHook(
+        classId: Oid,
+        objectId: Oid,
+        subId: ::std::os::raw::c_int,
+        is_internal: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RunObjectDropHook(
+        classId: Oid,
+        objectId: Oid,
+        subId: ::std::os::raw::c_int,
+        dropflags: ::std::os::raw::c_int,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RunObjectTruncateHook(objectId: Oid);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RunObjectPostAlterHook(
+        classId: Oid,
+        objectId: Oid,
+        subId: ::std::os::raw::c_int,
+        auxiliaryId: Oid,
+        is_internal: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RunNamespaceSearchHook(objectId: Oid, ereport_on_violation: bool) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RunFunctionExecuteHook(objectId: Oid);
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct FormData_pg_authid {
@@ -35022,6 +35126,103 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn RI_FKey_trigger_type(tgfoid: Oid) -> ::std::os::raw::c_int;
+}
+pub const PasswordType_PASSWORD_TYPE_PLAINTEXT: PasswordType = 0;
+pub const PasswordType_PASSWORD_TYPE_MD5: PasswordType = 1;
+pub const PasswordType_PASSWORD_TYPE_SCRAM_SHA_256: PasswordType = 2;
+pub type PasswordType = ::std::os::raw::c_uint;
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_password_type(shadow_pass: *const ::std::os::raw::c_char) -> PasswordType;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn encrypt_password(
+        target_type: PasswordType,
+        role: *const ::std::os::raw::c_char,
+        password: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_role_password(
+        role: *const ::std::os::raw::c_char,
+        logdetail: *mut *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn md5_crypt_verify(
+        role: *const ::std::os::raw::c_char,
+        shadow_pass: *const ::std::os::raw::c_char,
+        client_pass: *const ::std::os::raw::c_char,
+        md5_salt: *const ::std::os::raw::c_char,
+        md5_salt_len: ::std::os::raw::c_int,
+        logdetail: *mut *mut ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plain_crypt_verify(
+        role: *const ::std::os::raw::c_char,
+        shadow_pass: *const ::std::os::raw::c_char,
+        client_pass: *const ::std::os::raw::c_char,
+        logdetail: *mut *mut ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut Password_encryption: ::std::os::raw::c_int;
+}
+pub type check_password_hook_type = ::std::option::Option<
+    unsafe extern "C" fn(
+        username: *const ::std::os::raw::c_char,
+        shadow_pass: *const ::std::os::raw::c_char,
+        password_type: PasswordType,
+        validuntil_time: Datum,
+        validuntil_null: bool,
+    ),
+>;
+extern "C" {
+    pub static mut check_password_hook: check_password_hook_type;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn CreateRole(pstate: *mut ParseState, stmt: *mut CreateRoleStmt) -> Oid;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn AlterRole(stmt: *mut AlterRoleStmt) -> Oid;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn AlterRoleSet(stmt: *mut AlterRoleSetStmt) -> Oid;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DropRole(stmt: *mut DropRoleStmt);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GrantRole(stmt: *mut GrantRoleStmt);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RenameRole(
+        oldname: *const ::std::os::raw::c_char,
+        newname: *const ::std::os::raw::c_char,
+    ) -> ObjectAddress;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DropOwnedObjects(stmt: *mut DropOwnedStmt);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ReassignOwnedObjects(stmt: *mut ReassignOwnedStmt);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn roleSpecsToIds(memberNames: *mut List) -> *mut List;
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -42739,6 +42940,127 @@ extern "C" {
         live_childrels: *mut List,
     );
 }
+pub type get_relation_info_hook_type = ::std::option::Option<
+    unsafe extern "C" fn(
+        root: *mut PlannerInfo,
+        relationObjectId: Oid,
+        inhparent: bool,
+        rel: *mut RelOptInfo,
+    ),
+>;
+extern "C" {
+    pub static mut get_relation_info_hook: get_relation_info_hook_type;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_relation_info(
+        root: *mut PlannerInfo,
+        relationObjectId: Oid,
+        inhparent: bool,
+        rel: *mut RelOptInfo,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn infer_arbiter_indexes(root: *mut PlannerInfo) -> *mut List;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn estimate_rel_size(
+        rel: Relation,
+        attr_widths: *mut int32,
+        pages: *mut BlockNumber,
+        tuples: *mut f64,
+        allvisfrac: *mut f64,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_rel_data_width(rel: Relation, attr_widths: *mut int32) -> int32;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_relation_data_width(relid: Oid, attr_widths: *mut int32) -> int32;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn relation_excluded_by_constraints(
+        root: *mut PlannerInfo,
+        rel: *mut RelOptInfo,
+        rte: *mut RangeTblEntry,
+    ) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn build_physical_tlist(root: *mut PlannerInfo, rel: *mut RelOptInfo) -> *mut List;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn has_unique_index(rel: *mut RelOptInfo, attno: AttrNumber) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn restriction_selectivity(
+        root: *mut PlannerInfo,
+        operatorid: Oid,
+        args: *mut List,
+        inputcollid: Oid,
+        varRelid: ::std::os::raw::c_int,
+    ) -> Selectivity;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn join_selectivity(
+        root: *mut PlannerInfo,
+        operatorid: Oid,
+        args: *mut List,
+        inputcollid: Oid,
+        jointype: JoinType,
+        sjinfo: *mut SpecialJoinInfo,
+    ) -> Selectivity;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn function_selectivity(
+        root: *mut PlannerInfo,
+        funcid: Oid,
+        args: *mut List,
+        inputcollid: Oid,
+        is_join: bool,
+        varRelid: ::std::os::raw::c_int,
+        jointype: JoinType,
+        sjinfo: *mut SpecialJoinInfo,
+    ) -> Selectivity;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn add_function_cost(
+        root: *mut PlannerInfo,
+        funcid: Oid,
+        node: *mut Node,
+        cost: *mut QualCost,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_function_rows(root: *mut PlannerInfo, funcid: Oid, node: *mut Node) -> f64;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn has_row_triggers(root: *mut PlannerInfo, rti: Index, event: CmdType) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn has_stored_generated_columns(root: *mut PlannerInfo, rti: Index) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_dependent_generated_columns(
+        root: *mut PlannerInfo,
+        rti: Index,
+        target_cols: *mut Bitmapset,
+    ) -> *mut Bitmapset;
+}
 extern "C" {
     pub static mut cursor_tuple_fraction: f64;
 }
@@ -43822,6 +44144,1820 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn get_parse_rowmark(qry: *mut Query, rtindex: Index) -> *mut RowMarkClause;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ExpandedRecordHeader {
+    pub hdr: ExpandedObjectHeader,
+    pub er_magic: ::std::os::raw::c_int,
+    pub flags: ::std::os::raw::c_int,
+    pub er_decltypeid: Oid,
+    pub er_typeid: Oid,
+    pub er_typmod: int32,
+    pub er_tupdesc: TupleDesc,
+    pub er_tupdesc_id: uint64,
+    pub dvalues: *mut Datum,
+    pub dnulls: *mut bool,
+    pub nfields: ::std::os::raw::c_int,
+    pub flat_size: Size,
+    pub data_len: Size,
+    pub hoff: ::std::os::raw::c_int,
+    pub hasnull: bool,
+    pub fvalue: HeapTuple,
+    pub fstartptr: *mut ::std::os::raw::c_char,
+    pub fendptr: *mut ::std::os::raw::c_char,
+    pub er_short_term_cxt: MemoryContext,
+    pub er_dummy_header: *mut ExpandedRecordHeader,
+    pub er_domaininfo: *mut ::std::os::raw::c_void,
+    pub er_mcb: MemoryContextCallback,
+}
+impl Default for ExpandedRecordHeader {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ExpandedRecordFieldInfo {
+    pub fnumber: ::std::os::raw::c_int,
+    pub ftypeid: Oid,
+    pub ftypmod: int32,
+    pub fcollation: Oid,
+}
+impl Default for ExpandedRecordFieldInfo {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn make_expanded_record_from_typeid(
+        type_id: Oid,
+        typmod: int32,
+        parentcontext: MemoryContext,
+    ) -> *mut ExpandedRecordHeader;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn make_expanded_record_from_tupdesc(
+        tupdesc: TupleDesc,
+        parentcontext: MemoryContext,
+    ) -> *mut ExpandedRecordHeader;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn make_expanded_record_from_exprecord(
+        olderh: *mut ExpandedRecordHeader,
+        parentcontext: MemoryContext,
+    ) -> *mut ExpandedRecordHeader;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn expanded_record_set_tuple(
+        erh: *mut ExpandedRecordHeader,
+        tuple: HeapTuple,
+        copy: bool,
+        expand_external: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn make_expanded_record_from_datum(
+        recorddatum: Datum,
+        parentcontext: MemoryContext,
+    ) -> Datum;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn expanded_record_fetch_tupdesc(erh: *mut ExpandedRecordHeader) -> TupleDesc;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn expanded_record_get_tuple(erh: *mut ExpandedRecordHeader) -> HeapTuple;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DatumGetExpandedRecord(d: Datum) -> *mut ExpandedRecordHeader;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn deconstruct_expanded_record(erh: *mut ExpandedRecordHeader);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn expanded_record_lookup_field(
+        erh: *mut ExpandedRecordHeader,
+        fieldname: *const ::std::os::raw::c_char,
+        finfo: *mut ExpandedRecordFieldInfo,
+    ) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn expanded_record_fetch_field(
+        erh: *mut ExpandedRecordHeader,
+        fnumber: ::std::os::raw::c_int,
+        isnull: *mut bool,
+    ) -> Datum;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn expanded_record_set_field_internal(
+        erh: *mut ExpandedRecordHeader,
+        fnumber: ::std::os::raw::c_int,
+        newValue: Datum,
+        isnull: bool,
+        expand_external: bool,
+        check_constraints: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn expanded_record_set_fields(
+        erh: *mut ExpandedRecordHeader,
+        newValues: *const Datum,
+        isnulls: *const bool,
+        expand_external: bool,
+    );
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct DomainConstraintCache {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct TypeCacheEnumData {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct TypeCacheEntry {
+    pub type_id: Oid,
+    pub type_id_hash: uint32,
+    pub typlen: int16,
+    pub typbyval: bool,
+    pub typalign: ::std::os::raw::c_char,
+    pub typstorage: ::std::os::raw::c_char,
+    pub typtype: ::std::os::raw::c_char,
+    pub typrelid: Oid,
+    pub typsubscript: Oid,
+    pub typelem: Oid,
+    pub typcollation: Oid,
+    pub btree_opf: Oid,
+    pub btree_opintype: Oid,
+    pub hash_opf: Oid,
+    pub hash_opintype: Oid,
+    pub eq_opr: Oid,
+    pub lt_opr: Oid,
+    pub gt_opr: Oid,
+    pub cmp_proc: Oid,
+    pub hash_proc: Oid,
+    pub hash_extended_proc: Oid,
+    pub eq_opr_finfo: FmgrInfo,
+    pub cmp_proc_finfo: FmgrInfo,
+    pub hash_proc_finfo: FmgrInfo,
+    pub hash_extended_proc_finfo: FmgrInfo,
+    pub tupDesc: TupleDesc,
+    pub tupDesc_identifier: uint64,
+    pub rngelemtype: *mut TypeCacheEntry,
+    pub rng_collation: Oid,
+    pub rng_cmp_proc_finfo: FmgrInfo,
+    pub rng_canonical_finfo: FmgrInfo,
+    pub rng_subdiff_finfo: FmgrInfo,
+    pub rngtype: *mut TypeCacheEntry,
+    pub domainBaseType: Oid,
+    pub domainBaseTypmod: int32,
+    pub domainData: *mut DomainConstraintCache,
+    pub flags: ::std::os::raw::c_int,
+    pub enumData: *mut TypeCacheEnumData,
+    pub nextDomain: *mut TypeCacheEntry,
+}
+impl Default for TypeCacheEntry {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct DomainConstraintRef {
+    pub constraints: *mut List,
+    pub refctx: MemoryContext,
+    pub tcache: *mut TypeCacheEntry,
+    pub need_exprstate: bool,
+    pub dcc: *mut DomainConstraintCache,
+    pub callback: MemoryContextCallback,
+}
+impl Default for DomainConstraintRef {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct SharedRecordTypmodRegistry {
+    _unused: [u8; 0],
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn lookup_type_cache(type_id: Oid, flags: ::std::os::raw::c_int) -> *mut TypeCacheEntry;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn InitDomainConstraintRef(
+        type_id: Oid,
+        ref_: *mut DomainConstraintRef,
+        refctx: MemoryContext,
+        need_exprstate: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UpdateDomainConstraintRef(ref_: *mut DomainConstraintRef);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DomainHasConstraints(type_id: Oid) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn lookup_rowtype_tupdesc(type_id: Oid, typmod: int32) -> TupleDesc;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn lookup_rowtype_tupdesc_noerror(type_id: Oid, typmod: int32, noError: bool) -> TupleDesc;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn lookup_rowtype_tupdesc_copy(type_id: Oid, typmod: int32) -> TupleDesc;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn lookup_rowtype_tupdesc_domain(type_id: Oid, typmod: int32, noError: bool) -> TupleDesc;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn assign_record_type_typmod(tupDesc: TupleDesc);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn assign_record_type_identifier(type_id: Oid, typmod: int32) -> uint64;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn compare_values_of_enum(
+        tcache: *mut TypeCacheEntry,
+        arg1: Oid,
+        arg2: Oid,
+    ) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SharedRecordTypmodRegistryEstimate() -> usize;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SharedRecordTypmodRegistryInit(
+        arg1: *mut SharedRecordTypmodRegistry,
+        segment: *mut dsm_segment,
+        area: *mut dsa_area,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SharedRecordTypmodRegistryAttach(arg1: *mut SharedRecordTypmodRegistry);
+}
+pub const PLpgSQL_nsitem_type_PLPGSQL_NSTYPE_LABEL: PLpgSQL_nsitem_type = 0;
+pub const PLpgSQL_nsitem_type_PLPGSQL_NSTYPE_VAR: PLpgSQL_nsitem_type = 1;
+pub const PLpgSQL_nsitem_type_PLPGSQL_NSTYPE_REC: PLpgSQL_nsitem_type = 2;
+pub type PLpgSQL_nsitem_type = ::std::os::raw::c_uint;
+pub const PLpgSQL_label_type_PLPGSQL_LABEL_BLOCK: PLpgSQL_label_type = 0;
+pub const PLpgSQL_label_type_PLPGSQL_LABEL_LOOP: PLpgSQL_label_type = 1;
+pub const PLpgSQL_label_type_PLPGSQL_LABEL_OTHER: PLpgSQL_label_type = 2;
+pub type PLpgSQL_label_type = ::std::os::raw::c_uint;
+pub const PLpgSQL_datum_type_PLPGSQL_DTYPE_VAR: PLpgSQL_datum_type = 0;
+pub const PLpgSQL_datum_type_PLPGSQL_DTYPE_ROW: PLpgSQL_datum_type = 1;
+pub const PLpgSQL_datum_type_PLPGSQL_DTYPE_REC: PLpgSQL_datum_type = 2;
+pub const PLpgSQL_datum_type_PLPGSQL_DTYPE_RECFIELD: PLpgSQL_datum_type = 3;
+pub const PLpgSQL_datum_type_PLPGSQL_DTYPE_PROMISE: PLpgSQL_datum_type = 4;
+pub type PLpgSQL_datum_type = ::std::os::raw::c_uint;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_NONE: PLpgSQL_promise_type = 0;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_NAME: PLpgSQL_promise_type = 1;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_WHEN: PLpgSQL_promise_type = 2;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_LEVEL: PLpgSQL_promise_type = 3;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_OP: PLpgSQL_promise_type = 4;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_RELID: PLpgSQL_promise_type = 5;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_TABLE_NAME: PLpgSQL_promise_type = 6;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_TABLE_SCHEMA: PLpgSQL_promise_type = 7;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_NARGS: PLpgSQL_promise_type = 8;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_ARGV: PLpgSQL_promise_type = 9;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_EVENT: PLpgSQL_promise_type = 10;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_TAG: PLpgSQL_promise_type = 11;
+pub type PLpgSQL_promise_type = ::std::os::raw::c_uint;
+pub const PLpgSQL_type_type_PLPGSQL_TTYPE_SCALAR: PLpgSQL_type_type = 0;
+pub const PLpgSQL_type_type_PLPGSQL_TTYPE_REC: PLpgSQL_type_type = 1;
+pub const PLpgSQL_type_type_PLPGSQL_TTYPE_PSEUDO: PLpgSQL_type_type = 2;
+pub type PLpgSQL_type_type = ::std::os::raw::c_uint;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_BLOCK: PLpgSQL_stmt_type = 0;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_ASSIGN: PLpgSQL_stmt_type = 1;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_IF: PLpgSQL_stmt_type = 2;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_CASE: PLpgSQL_stmt_type = 3;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_LOOP: PLpgSQL_stmt_type = 4;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_WHILE: PLpgSQL_stmt_type = 5;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_FORI: PLpgSQL_stmt_type = 6;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_FORS: PLpgSQL_stmt_type = 7;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_FORC: PLpgSQL_stmt_type = 8;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_FOREACH_A: PLpgSQL_stmt_type = 9;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_EXIT: PLpgSQL_stmt_type = 10;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_RETURN: PLpgSQL_stmt_type = 11;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_RETURN_NEXT: PLpgSQL_stmt_type = 12;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_RETURN_QUERY: PLpgSQL_stmt_type = 13;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_RAISE: PLpgSQL_stmt_type = 14;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_ASSERT: PLpgSQL_stmt_type = 15;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_EXECSQL: PLpgSQL_stmt_type = 16;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_DYNEXECUTE: PLpgSQL_stmt_type = 17;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_DYNFORS: PLpgSQL_stmt_type = 18;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_GETDIAG: PLpgSQL_stmt_type = 19;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_OPEN: PLpgSQL_stmt_type = 20;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_FETCH: PLpgSQL_stmt_type = 21;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_CLOSE: PLpgSQL_stmt_type = 22;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_PERFORM: PLpgSQL_stmt_type = 23;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_CALL: PLpgSQL_stmt_type = 24;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_COMMIT: PLpgSQL_stmt_type = 25;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_ROLLBACK: PLpgSQL_stmt_type = 26;
+pub type PLpgSQL_stmt_type = ::std::os::raw::c_uint;
+pub const PLPGSQL_RC_OK: _bindgen_ty_19 = 0;
+pub const PLPGSQL_RC_EXIT: _bindgen_ty_19 = 1;
+pub const PLPGSQL_RC_RETURN: _bindgen_ty_19 = 2;
+pub const PLPGSQL_RC_CONTINUE: _bindgen_ty_19 = 3;
+pub type _bindgen_ty_19 = ::std::os::raw::c_uint;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_ROW_COUNT: PLpgSQL_getdiag_kind = 0;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_CONTEXT: PLpgSQL_getdiag_kind = 1;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_ERROR_CONTEXT: PLpgSQL_getdiag_kind = 2;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_ERROR_DETAIL: PLpgSQL_getdiag_kind = 3;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_ERROR_HINT: PLpgSQL_getdiag_kind = 4;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_RETURNED_SQLSTATE: PLpgSQL_getdiag_kind = 5;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_COLUMN_NAME: PLpgSQL_getdiag_kind = 6;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_CONSTRAINT_NAME: PLpgSQL_getdiag_kind = 7;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_DATATYPE_NAME: PLpgSQL_getdiag_kind = 8;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_MESSAGE_TEXT: PLpgSQL_getdiag_kind = 9;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_TABLE_NAME: PLpgSQL_getdiag_kind = 10;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_SCHEMA_NAME: PLpgSQL_getdiag_kind = 11;
+pub type PLpgSQL_getdiag_kind = ::std::os::raw::c_uint;
+pub const PLpgSQL_raise_option_type_PLPGSQL_RAISEOPTION_ERRCODE: PLpgSQL_raise_option_type = 0;
+pub const PLpgSQL_raise_option_type_PLPGSQL_RAISEOPTION_MESSAGE: PLpgSQL_raise_option_type = 1;
+pub const PLpgSQL_raise_option_type_PLPGSQL_RAISEOPTION_DETAIL: PLpgSQL_raise_option_type = 2;
+pub const PLpgSQL_raise_option_type_PLPGSQL_RAISEOPTION_HINT: PLpgSQL_raise_option_type = 3;
+pub const PLpgSQL_raise_option_type_PLPGSQL_RAISEOPTION_COLUMN: PLpgSQL_raise_option_type = 4;
+pub const PLpgSQL_raise_option_type_PLPGSQL_RAISEOPTION_CONSTRAINT: PLpgSQL_raise_option_type = 5;
+pub const PLpgSQL_raise_option_type_PLPGSQL_RAISEOPTION_DATATYPE: PLpgSQL_raise_option_type = 6;
+pub const PLpgSQL_raise_option_type_PLPGSQL_RAISEOPTION_TABLE: PLpgSQL_raise_option_type = 7;
+pub const PLpgSQL_raise_option_type_PLPGSQL_RAISEOPTION_SCHEMA: PLpgSQL_raise_option_type = 8;
+pub type PLpgSQL_raise_option_type = ::std::os::raw::c_uint;
+pub const PLpgSQL_resolve_option_PLPGSQL_RESOLVE_ERROR: PLpgSQL_resolve_option = 0;
+pub const PLpgSQL_resolve_option_PLPGSQL_RESOLVE_VARIABLE: PLpgSQL_resolve_option = 1;
+pub const PLpgSQL_resolve_option_PLPGSQL_RESOLVE_COLUMN: PLpgSQL_resolve_option = 2;
+pub type PLpgSQL_resolve_option = ::std::os::raw::c_uint;
+#[doc = " Node and structure definitions"]
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_type {
+    pub typname: *mut ::std::os::raw::c_char,
+    pub typoid: Oid,
+    pub ttype: PLpgSQL_type_type,
+    pub typlen: int16,
+    pub typbyval: bool,
+    pub typtype: ::std::os::raw::c_char,
+    pub collation: Oid,
+    pub typisarray: bool,
+    pub atttypmod: int32,
+    pub origtypname: *mut TypeName,
+    pub tcache: *mut TypeCacheEntry,
+    pub tupdesc_id: uint64,
+}
+impl Default for PLpgSQL_type {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_expr {
+    pub query: *mut ::std::os::raw::c_char,
+    pub parseMode: RawParseMode,
+    pub plan: SPIPlanPtr,
+    pub paramnos: *mut Bitmapset,
+    pub func: *mut PLpgSQL_function,
+    pub ns: *mut PLpgSQL_nsitem,
+    pub expr_simple_expr: *mut Expr,
+    pub expr_simple_type: Oid,
+    pub expr_simple_typmod: int32,
+    pub expr_simple_mutable: bool,
+    pub target_param: ::std::os::raw::c_int,
+    pub expr_rw_param: *mut Param,
+    pub expr_simple_plansource: *mut CachedPlanSource,
+    pub expr_simple_plan: *mut CachedPlan,
+    pub expr_simple_plan_lxid: LocalTransactionId,
+    pub expr_simple_state: *mut ExprState,
+    pub expr_simple_in_use: bool,
+    pub expr_simple_lxid: LocalTransactionId,
+}
+impl Default for PLpgSQL_expr {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_datum {
+    pub dtype: PLpgSQL_datum_type,
+    pub dno: ::std::os::raw::c_int,
+}
+impl Default for PLpgSQL_datum {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_variable {
+    pub dtype: PLpgSQL_datum_type,
+    pub dno: ::std::os::raw::c_int,
+    pub refname: *mut ::std::os::raw::c_char,
+    pub lineno: ::std::os::raw::c_int,
+    pub isconst: bool,
+    pub notnull: bool,
+    pub default_val: *mut PLpgSQL_expr,
+}
+impl Default for PLpgSQL_variable {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_var {
+    pub dtype: PLpgSQL_datum_type,
+    pub dno: ::std::os::raw::c_int,
+    pub refname: *mut ::std::os::raw::c_char,
+    pub lineno: ::std::os::raw::c_int,
+    pub isconst: bool,
+    pub notnull: bool,
+    pub default_val: *mut PLpgSQL_expr,
+    pub datatype: *mut PLpgSQL_type,
+    pub cursor_explicit_expr: *mut PLpgSQL_expr,
+    pub cursor_explicit_argrow: ::std::os::raw::c_int,
+    pub cursor_options: ::std::os::raw::c_int,
+    pub value: Datum,
+    pub isnull: bool,
+    pub freeval: bool,
+    pub promise: PLpgSQL_promise_type,
+}
+impl Default for PLpgSQL_var {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_row {
+    pub dtype: PLpgSQL_datum_type,
+    pub dno: ::std::os::raw::c_int,
+    pub refname: *mut ::std::os::raw::c_char,
+    pub lineno: ::std::os::raw::c_int,
+    pub isconst: bool,
+    pub notnull: bool,
+    pub default_val: *mut PLpgSQL_expr,
+    pub rowtupdesc: TupleDesc,
+    pub nfields: ::std::os::raw::c_int,
+    pub fieldnames: *mut *mut ::std::os::raw::c_char,
+    pub varnos: *mut ::std::os::raw::c_int,
+}
+impl Default for PLpgSQL_row {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_rec {
+    pub dtype: PLpgSQL_datum_type,
+    pub dno: ::std::os::raw::c_int,
+    pub refname: *mut ::std::os::raw::c_char,
+    pub lineno: ::std::os::raw::c_int,
+    pub isconst: bool,
+    pub notnull: bool,
+    pub default_val: *mut PLpgSQL_expr,
+    pub datatype: *mut PLpgSQL_type,
+    pub rectypeid: Oid,
+    pub firstfield: ::std::os::raw::c_int,
+    pub erh: *mut ExpandedRecordHeader,
+}
+impl Default for PLpgSQL_rec {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_recfield {
+    pub dtype: PLpgSQL_datum_type,
+    pub dno: ::std::os::raw::c_int,
+    pub fieldname: *mut ::std::os::raw::c_char,
+    pub recparentno: ::std::os::raw::c_int,
+    pub nextfield: ::std::os::raw::c_int,
+    pub rectupledescid: uint64,
+    pub finfo: ExpandedRecordFieldInfo,
+}
+impl Default for PLpgSQL_recfield {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct PLpgSQL_nsitem {
+    pub itemtype: PLpgSQL_nsitem_type,
+    pub itemno: ::std::os::raw::c_int,
+    pub prev: *mut PLpgSQL_nsitem,
+    pub name: __IncompleteArrayField<::std::os::raw::c_char>,
+}
+impl Default for PLpgSQL_nsitem {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+}
+impl Default for PLpgSQL_stmt {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_condition {
+    pub sqlerrstate: ::std::os::raw::c_int,
+    pub condname: *mut ::std::os::raw::c_char,
+    pub next: *mut PLpgSQL_condition,
+}
+impl Default for PLpgSQL_condition {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_exception_block {
+    pub sqlstate_varno: ::std::os::raw::c_int,
+    pub sqlerrm_varno: ::std::os::raw::c_int,
+    pub exc_list: *mut List,
+}
+impl Default for PLpgSQL_exception_block {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_exception {
+    pub lineno: ::std::os::raw::c_int,
+    pub conditions: *mut PLpgSQL_condition,
+    pub action: *mut List,
+}
+impl Default for PLpgSQL_exception {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_block {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub label: *mut ::std::os::raw::c_char,
+    pub body: *mut List,
+    pub n_initvars: ::std::os::raw::c_int,
+    pub initvarnos: *mut ::std::os::raw::c_int,
+    pub exceptions: *mut PLpgSQL_exception_block,
+}
+impl Default for PLpgSQL_stmt_block {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_assign {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub varno: ::std::os::raw::c_int,
+    pub expr: *mut PLpgSQL_expr,
+}
+impl Default for PLpgSQL_stmt_assign {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_perform {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub expr: *mut PLpgSQL_expr,
+}
+impl Default for PLpgSQL_stmt_perform {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_call {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub expr: *mut PLpgSQL_expr,
+    pub is_call: bool,
+    pub target: *mut PLpgSQL_variable,
+}
+impl Default for PLpgSQL_stmt_call {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_commit {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub chain: bool,
+}
+impl Default for PLpgSQL_stmt_commit {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_rollback {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub chain: bool,
+}
+impl Default for PLpgSQL_stmt_rollback {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_diag_item {
+    pub kind: PLpgSQL_getdiag_kind,
+    pub target: ::std::os::raw::c_int,
+}
+impl Default for PLpgSQL_diag_item {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_getdiag {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub is_stacked: bool,
+    pub diag_items: *mut List,
+}
+impl Default for PLpgSQL_stmt_getdiag {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_if {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub cond: *mut PLpgSQL_expr,
+    pub then_body: *mut List,
+    pub elsif_list: *mut List,
+    pub else_body: *mut List,
+}
+impl Default for PLpgSQL_stmt_if {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_if_elsif {
+    pub lineno: ::std::os::raw::c_int,
+    pub cond: *mut PLpgSQL_expr,
+    pub stmts: *mut List,
+}
+impl Default for PLpgSQL_if_elsif {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_case {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub t_expr: *mut PLpgSQL_expr,
+    pub t_varno: ::std::os::raw::c_int,
+    pub case_when_list: *mut List,
+    pub have_else: bool,
+    pub else_stmts: *mut List,
+}
+impl Default for PLpgSQL_stmt_case {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_case_when {
+    pub lineno: ::std::os::raw::c_int,
+    pub expr: *mut PLpgSQL_expr,
+    pub stmts: *mut List,
+}
+impl Default for PLpgSQL_case_when {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_loop {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub label: *mut ::std::os::raw::c_char,
+    pub body: *mut List,
+}
+impl Default for PLpgSQL_stmt_loop {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_while {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub label: *mut ::std::os::raw::c_char,
+    pub cond: *mut PLpgSQL_expr,
+    pub body: *mut List,
+}
+impl Default for PLpgSQL_stmt_while {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_fori {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub label: *mut ::std::os::raw::c_char,
+    pub var: *mut PLpgSQL_var,
+    pub lower: *mut PLpgSQL_expr,
+    pub upper: *mut PLpgSQL_expr,
+    pub step: *mut PLpgSQL_expr,
+    pub reverse: ::std::os::raw::c_int,
+    pub body: *mut List,
+}
+impl Default for PLpgSQL_stmt_fori {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_forq {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub label: *mut ::std::os::raw::c_char,
+    pub var: *mut PLpgSQL_variable,
+    pub body: *mut List,
+}
+impl Default for PLpgSQL_stmt_forq {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_fors {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub label: *mut ::std::os::raw::c_char,
+    pub var: *mut PLpgSQL_variable,
+    pub body: *mut List,
+    pub query: *mut PLpgSQL_expr,
+}
+impl Default for PLpgSQL_stmt_fors {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_forc {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub label: *mut ::std::os::raw::c_char,
+    pub var: *mut PLpgSQL_variable,
+    pub body: *mut List,
+    pub curvar: ::std::os::raw::c_int,
+    pub argquery: *mut PLpgSQL_expr,
+}
+impl Default for PLpgSQL_stmt_forc {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_dynfors {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub label: *mut ::std::os::raw::c_char,
+    pub var: *mut PLpgSQL_variable,
+    pub body: *mut List,
+    pub query: *mut PLpgSQL_expr,
+    pub params: *mut List,
+}
+impl Default for PLpgSQL_stmt_dynfors {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_foreach_a {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub label: *mut ::std::os::raw::c_char,
+    pub varno: ::std::os::raw::c_int,
+    pub slice: ::std::os::raw::c_int,
+    pub expr: *mut PLpgSQL_expr,
+    pub body: *mut List,
+}
+impl Default for PLpgSQL_stmt_foreach_a {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_open {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub curvar: ::std::os::raw::c_int,
+    pub cursor_options: ::std::os::raw::c_int,
+    pub argquery: *mut PLpgSQL_expr,
+    pub query: *mut PLpgSQL_expr,
+    pub dynquery: *mut PLpgSQL_expr,
+    pub params: *mut List,
+}
+impl Default for PLpgSQL_stmt_open {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_fetch {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub target: *mut PLpgSQL_variable,
+    pub curvar: ::std::os::raw::c_int,
+    pub direction: FetchDirection,
+    pub how_many: ::std::os::raw::c_long,
+    pub expr: *mut PLpgSQL_expr,
+    pub is_move: bool,
+    pub returns_multiple_rows: bool,
+}
+impl Default for PLpgSQL_stmt_fetch {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_close {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub curvar: ::std::os::raw::c_int,
+}
+impl Default for PLpgSQL_stmt_close {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_exit {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub is_exit: bool,
+    pub label: *mut ::std::os::raw::c_char,
+    pub cond: *mut PLpgSQL_expr,
+}
+impl Default for PLpgSQL_stmt_exit {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_return {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub expr: *mut PLpgSQL_expr,
+    pub retvarno: ::std::os::raw::c_int,
+}
+impl Default for PLpgSQL_stmt_return {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_return_next {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub expr: *mut PLpgSQL_expr,
+    pub retvarno: ::std::os::raw::c_int,
+}
+impl Default for PLpgSQL_stmt_return_next {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_return_query {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub query: *mut PLpgSQL_expr,
+    pub dynquery: *mut PLpgSQL_expr,
+    pub params: *mut List,
+}
+impl Default for PLpgSQL_stmt_return_query {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_raise {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub elog_level: ::std::os::raw::c_int,
+    pub condname: *mut ::std::os::raw::c_char,
+    pub message: *mut ::std::os::raw::c_char,
+    pub params: *mut List,
+    pub options: *mut List,
+}
+impl Default for PLpgSQL_stmt_raise {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_raise_option {
+    pub opt_type: PLpgSQL_raise_option_type,
+    pub expr: *mut PLpgSQL_expr,
+}
+impl Default for PLpgSQL_raise_option {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_assert {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub cond: *mut PLpgSQL_expr,
+    pub message: *mut PLpgSQL_expr,
+}
+impl Default for PLpgSQL_stmt_assert {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_execsql {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub sqlstmt: *mut PLpgSQL_expr,
+    pub mod_stmt: bool,
+    pub into: bool,
+    pub strict: bool,
+    pub mod_stmt_set: bool,
+    pub target: *mut PLpgSQL_variable,
+}
+impl Default for PLpgSQL_stmt_execsql {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_dynexecute {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub query: *mut PLpgSQL_expr,
+    pub into: bool,
+    pub strict: bool,
+    pub target: *mut PLpgSQL_variable,
+    pub params: *mut List,
+}
+impl Default for PLpgSQL_stmt_dynexecute {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_func_hashkey {
+    pub funcOid: Oid,
+    pub isTrigger: bool,
+    pub isEventTrigger: bool,
+    pub trigOid: Oid,
+    pub inputCollation: Oid,
+    pub argtypes: [Oid; 100usize],
+}
+impl Default for PLpgSQL_func_hashkey {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub const PLpgSQL_trigtype_PLPGSQL_DML_TRIGGER: PLpgSQL_trigtype = 0;
+pub const PLpgSQL_trigtype_PLPGSQL_EVENT_TRIGGER: PLpgSQL_trigtype = 1;
+pub const PLpgSQL_trigtype_PLPGSQL_NOT_TRIGGER: PLpgSQL_trigtype = 2;
+pub type PLpgSQL_trigtype = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_function {
+    pub fn_signature: *mut ::std::os::raw::c_char,
+    pub fn_oid: Oid,
+    pub fn_xmin: TransactionId,
+    pub fn_tid: ItemPointerData,
+    pub fn_is_trigger: PLpgSQL_trigtype,
+    pub fn_input_collation: Oid,
+    pub fn_hashkey: *mut PLpgSQL_func_hashkey,
+    pub fn_cxt: MemoryContext,
+    pub fn_rettype: Oid,
+    pub fn_rettyplen: ::std::os::raw::c_int,
+    pub fn_retbyval: bool,
+    pub fn_retistuple: bool,
+    pub fn_retisdomain: bool,
+    pub fn_retset: bool,
+    pub fn_readonly: bool,
+    pub fn_prokind: ::std::os::raw::c_char,
+    pub fn_nargs: ::std::os::raw::c_int,
+    pub fn_argvarnos: [::std::os::raw::c_int; 100usize],
+    pub out_param_varno: ::std::os::raw::c_int,
+    pub found_varno: ::std::os::raw::c_int,
+    pub new_varno: ::std::os::raw::c_int,
+    pub old_varno: ::std::os::raw::c_int,
+    pub resolve_option: PLpgSQL_resolve_option,
+    pub print_strict_params: bool,
+    pub extra_warnings: ::std::os::raw::c_int,
+    pub extra_errors: ::std::os::raw::c_int,
+    pub ndatums: ::std::os::raw::c_int,
+    pub datums: *mut *mut PLpgSQL_datum,
+    pub copiable_size: Size,
+    pub action: *mut PLpgSQL_stmt_block,
+    pub nstatements: ::std::os::raw::c_uint,
+    pub requires_procedure_resowner: bool,
+    pub cur_estate: *mut PLpgSQL_execstate,
+    pub use_count: ::std::os::raw::c_ulong,
+}
+impl Default for PLpgSQL_function {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_execstate {
+    pub func: *mut PLpgSQL_function,
+    pub trigdata: *mut TriggerData,
+    pub evtrigdata: *mut EventTriggerData,
+    pub retval: Datum,
+    pub retisnull: bool,
+    pub rettype: Oid,
+    pub fn_rettype: Oid,
+    pub retistuple: bool,
+    pub retisset: bool,
+    pub readonly_func: bool,
+    pub atomic: bool,
+    pub exitlabel: *mut ::std::os::raw::c_char,
+    pub cur_error: *mut ErrorData,
+    pub tuple_store: *mut Tuplestorestate,
+    pub tuple_store_desc: TupleDesc,
+    pub tuple_store_cxt: MemoryContext,
+    pub tuple_store_owner: ResourceOwner,
+    pub rsi: *mut ReturnSetInfo,
+    pub found_varno: ::std::os::raw::c_int,
+    pub ndatums: ::std::os::raw::c_int,
+    pub datums: *mut *mut PLpgSQL_datum,
+    pub datum_context: MemoryContext,
+    pub paramLI: ParamListInfo,
+    pub simple_eval_estate: *mut EState,
+    pub simple_eval_resowner: ResourceOwner,
+    pub procedure_resowner: ResourceOwner,
+    pub cast_hash: *mut HTAB,
+    pub cast_hash_context: MemoryContext,
+    pub stmt_mcontext: MemoryContext,
+    pub stmt_mcontext_parent: MemoryContext,
+    pub eval_tuptable: *mut SPITupleTable,
+    pub eval_processed: uint64,
+    pub eval_econtext: *mut ExprContext,
+    pub err_stmt: *mut PLpgSQL_stmt,
+    pub err_text: *const ::std::os::raw::c_char,
+    pub plugin_info: *mut ::std::os::raw::c_void,
+}
+impl Default for PLpgSQL_execstate {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct PLpgSQL_plugin {
+    pub func_setup: ::std::option::Option<
+        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, func: *mut PLpgSQL_function),
+    >,
+    pub func_beg: ::std::option::Option<
+        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, func: *mut PLpgSQL_function),
+    >,
+    pub func_end: ::std::option::Option<
+        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, func: *mut PLpgSQL_function),
+    >,
+    pub stmt_beg: ::std::option::Option<
+        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, stmt: *mut PLpgSQL_stmt),
+    >,
+    pub stmt_end: ::std::option::Option<
+        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, stmt: *mut PLpgSQL_stmt),
+    >,
+    pub error_callback:
+        ::std::option::Option<unsafe extern "C" fn(arg: *mut ::std::os::raw::c_void)>,
+    pub assign_expr: ::std::option::Option<
+        unsafe extern "C" fn(
+            estate: *mut PLpgSQL_execstate,
+            target: *mut PLpgSQL_datum,
+            expr: *mut PLpgSQL_expr,
+        ),
+    >,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLword {
+    pub ident: *mut ::std::os::raw::c_char,
+    pub quoted: bool,
+}
+impl Default for PLword {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLcword {
+    pub idents: *mut List,
+}
+impl Default for PLcword {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLwdatum {
+    pub datum: *mut PLpgSQL_datum,
+    pub ident: *mut ::std::os::raw::c_char,
+    pub quoted: bool,
+    pub idents: *mut List,
+}
+impl Default for PLwdatum {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub const IdentifierLookup_IDENTIFIER_LOOKUP_NORMAL: IdentifierLookup = 0;
+pub const IdentifierLookup_IDENTIFIER_LOOKUP_DECLARE: IdentifierLookup = 1;
+pub const IdentifierLookup_IDENTIFIER_LOOKUP_EXPR: IdentifierLookup = 2;
+#[doc = " Global variable declarations"]
+pub type IdentifierLookup = ::std::os::raw::c_uint;
+extern "C" {
+    pub static mut plpgsql_IdentifierLookup: IdentifierLookup;
+}
+extern "C" {
+    pub static mut plpgsql_variable_conflict: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut plpgsql_print_strict_params: bool;
+}
+extern "C" {
+    pub static mut plpgsql_check_asserts: bool;
+}
+extern "C" {
+    pub static mut plpgsql_extra_warnings: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut plpgsql_extra_errors: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut plpgsql_check_syntax: bool;
+}
+extern "C" {
+    pub static mut plpgsql_DumpExecTree: bool;
+}
+extern "C" {
+    pub static mut plpgsql_parse_result: *mut PLpgSQL_stmt_block;
+}
+extern "C" {
+    pub static mut plpgsql_nDatums: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut plpgsql_Datums: *mut *mut PLpgSQL_datum;
+}
+extern "C" {
+    pub static mut plpgsql_error_funcname: *mut ::std::os::raw::c_char;
+}
+extern "C" {
+    pub static mut plpgsql_curr_compile: *mut PLpgSQL_function;
+}
+extern "C" {
+    pub static mut plpgsql_compile_tmp_cxt: MemoryContext;
+}
+extern "C" {
+    pub static mut plpgsql_plugin_ptr: *mut *mut PLpgSQL_plugin;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    #[doc = " Function declarations"]
+    pub fn plpgsql_compile(fcinfo: FunctionCallInfo, forValidator: bool) -> *mut PLpgSQL_function;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_compile_inline(
+        proc_source: *mut ::std::os::raw::c_char,
+    ) -> *mut PLpgSQL_function;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_parser_setup(pstate: *mut ParseState, expr: *mut PLpgSQL_expr);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_parse_word(
+        word1: *mut ::std::os::raw::c_char,
+        yytxt: *const ::std::os::raw::c_char,
+        lookup: bool,
+        wdatum: *mut PLwdatum,
+        word: *mut PLword,
+    ) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_parse_dblword(
+        word1: *mut ::std::os::raw::c_char,
+        word2: *mut ::std::os::raw::c_char,
+        wdatum: *mut PLwdatum,
+        cword: *mut PLcword,
+    ) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_parse_tripword(
+        word1: *mut ::std::os::raw::c_char,
+        word2: *mut ::std::os::raw::c_char,
+        word3: *mut ::std::os::raw::c_char,
+        wdatum: *mut PLwdatum,
+        cword: *mut PLcword,
+    ) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_parse_wordtype(ident: *mut ::std::os::raw::c_char) -> *mut PLpgSQL_type;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_parse_cwordtype(idents: *mut List) -> *mut PLpgSQL_type;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_parse_wordrowtype(ident: *mut ::std::os::raw::c_char) -> *mut PLpgSQL_type;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_parse_cwordrowtype(idents: *mut List) -> *mut PLpgSQL_type;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_build_datatype(
+        typeOid: Oid,
+        typmod: int32,
+        collation: Oid,
+        origtypname: *mut TypeName,
+    ) -> *mut PLpgSQL_type;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_build_variable(
+        refname: *const ::std::os::raw::c_char,
+        lineno: ::std::os::raw::c_int,
+        dtype: *mut PLpgSQL_type,
+        add2namespace: bool,
+    ) -> *mut PLpgSQL_variable;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_build_record(
+        refname: *const ::std::os::raw::c_char,
+        lineno: ::std::os::raw::c_int,
+        dtype: *mut PLpgSQL_type,
+        rectypeid: Oid,
+        add2namespace: bool,
+    ) -> *mut PLpgSQL_rec;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_build_recfield(
+        rec: *mut PLpgSQL_rec,
+        fldname: *const ::std::os::raw::c_char,
+    ) -> *mut PLpgSQL_recfield;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_recognize_err_condition(
+        condname: *const ::std::os::raw::c_char,
+        allow_sqlstate: bool,
+    ) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_parse_err_condition(
+        condname: *mut ::std::os::raw::c_char,
+    ) -> *mut PLpgSQL_condition;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_adddatum(newdatum: *mut PLpgSQL_datum);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_add_initdatums(varnos: *mut *mut ::std::os::raw::c_int)
+        -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_HashTableInit();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn _PG_init();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_exec_function(
+        func: *mut PLpgSQL_function,
+        fcinfo: FunctionCallInfo,
+        simple_eval_estate: *mut EState,
+        simple_eval_resowner: ResourceOwner,
+        procedure_resowner: ResourceOwner,
+        atomic: bool,
+    ) -> Datum;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_exec_trigger(
+        func: *mut PLpgSQL_function,
+        trigdata: *mut TriggerData,
+    ) -> HeapTuple;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_exec_event_trigger(func: *mut PLpgSQL_function, trigdata: *mut EventTriggerData);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_xact_cb(event: XactEvent, arg: *mut ::std::os::raw::c_void);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_subxact_cb(
+        event: SubXactEvent,
+        mySubid: SubTransactionId,
+        parentSubid: SubTransactionId,
+        arg: *mut ::std::os::raw::c_void,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_exec_get_datum_type(
+        estate: *mut PLpgSQL_execstate,
+        datum: *mut PLpgSQL_datum,
+    ) -> Oid;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_exec_get_datum_type_info(
+        estate: *mut PLpgSQL_execstate,
+        datum: *mut PLpgSQL_datum,
+        typeId: *mut Oid,
+        typMod: *mut int32,
+        collation: *mut Oid,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_ns_init();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_ns_push(label: *const ::std::os::raw::c_char, label_type: PLpgSQL_label_type);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_ns_pop();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_ns_top() -> *mut PLpgSQL_nsitem;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_ns_additem(
+        itemtype: PLpgSQL_nsitem_type,
+        itemno: ::std::os::raw::c_int,
+        name: *const ::std::os::raw::c_char,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_ns_lookup(
+        ns_cur: *mut PLpgSQL_nsitem,
+        localmode: bool,
+        name1: *const ::std::os::raw::c_char,
+        name2: *const ::std::os::raw::c_char,
+        name3: *const ::std::os::raw::c_char,
+        names_used: *mut ::std::os::raw::c_int,
+    ) -> *mut PLpgSQL_nsitem;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_ns_lookup_label(
+        ns_cur: *mut PLpgSQL_nsitem,
+        name: *const ::std::os::raw::c_char,
+    ) -> *mut PLpgSQL_nsitem;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_ns_find_nearest_loop(ns_cur: *mut PLpgSQL_nsitem) -> *mut PLpgSQL_nsitem;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_stmt_typename(stmt: *mut PLpgSQL_stmt) -> *const ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_getdiag_kindname(kind: PLpgSQL_getdiag_kind) -> *const ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_free_function_memory(func: *mut PLpgSQL_function);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_dumptree(func: *mut PLpgSQL_function);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_base_yylex() -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_yylex() -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_push_back_token(token: ::std::os::raw::c_int);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_token_is_unreserved_keyword(token: ::std::os::raw::c_int) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_append_source_text(
+        buf: StringInfo,
+        startlocation: ::std::os::raw::c_int,
+        endlocation: ::std::os::raw::c_int,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_peek() -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_peek2(
+        tok1_p: *mut ::std::os::raw::c_int,
+        tok2_p: *mut ::std::os::raw::c_int,
+        tok1_loc: *mut ::std::os::raw::c_int,
+        tok2_loc: *mut ::std::os::raw::c_int,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_scanner_errposition(location: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_yyerror(message: *const ::std::os::raw::c_char);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_location_to_lineno(location: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_latest_lineno() -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_scanner_init(str_: *const ::std::os::raw::c_char);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_scanner_finish();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_yyparse() -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub static mut logical_decoding_work_mem: ::std::os::raw::c_int;
@@ -45623,6 +47759,61 @@ extern "C" {
         include_triggers: bool,
         include_cols: *mut Bitmapset,
     ) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct RowSecurityPolicy {
+    pub policy_name: *mut ::std::os::raw::c_char,
+    pub polcmd: ::std::os::raw::c_char,
+    pub roles: *mut ArrayType,
+    pub permissive: bool,
+    pub qual: *mut Expr,
+    pub with_check_qual: *mut Expr,
+    pub hassublinks: bool,
+}
+impl Default for RowSecurityPolicy {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct RowSecurityDesc {
+    pub rscxt: MemoryContext,
+    pub policies: *mut List,
+}
+impl Default for RowSecurityDesc {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type row_security_policy_hook_type =
+    ::std::option::Option<unsafe extern "C" fn(cmdtype: CmdType, relation: Relation) -> *mut List>;
+extern "C" {
+    pub static mut row_security_policy_hook_permissive: row_security_policy_hook_type;
+}
+extern "C" {
+    pub static mut row_security_policy_hook_restrictive: row_security_policy_hook_type;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_row_security_policies(
+        root: *mut Query,
+        rte: *mut RangeTblEntry,
+        rt_index: ::std::os::raw::c_int,
+        securityQuals: *mut *mut List,
+        withCheckOptions: *mut *mut List,
+        hasRowSecurity: *mut bool,
+        hasSubLinks: *mut bool,
+    );
 }
 extern "C" {
     pub static mut old_snapshot_threshold: ::std::os::raw::c_int;
@@ -61149,161 +63340,6 @@ extern "C" {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct DomainConstraintCache {
-    _unused: [u8; 0],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct TypeCacheEnumData {
-    _unused: [u8; 0],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct TypeCacheEntry {
-    pub type_id: Oid,
-    pub type_id_hash: uint32,
-    pub typlen: int16,
-    pub typbyval: bool,
-    pub typalign: ::std::os::raw::c_char,
-    pub typstorage: ::std::os::raw::c_char,
-    pub typtype: ::std::os::raw::c_char,
-    pub typrelid: Oid,
-    pub typsubscript: Oid,
-    pub typelem: Oid,
-    pub typcollation: Oid,
-    pub btree_opf: Oid,
-    pub btree_opintype: Oid,
-    pub hash_opf: Oid,
-    pub hash_opintype: Oid,
-    pub eq_opr: Oid,
-    pub lt_opr: Oid,
-    pub gt_opr: Oid,
-    pub cmp_proc: Oid,
-    pub hash_proc: Oid,
-    pub hash_extended_proc: Oid,
-    pub eq_opr_finfo: FmgrInfo,
-    pub cmp_proc_finfo: FmgrInfo,
-    pub hash_proc_finfo: FmgrInfo,
-    pub hash_extended_proc_finfo: FmgrInfo,
-    pub tupDesc: TupleDesc,
-    pub tupDesc_identifier: uint64,
-    pub rngelemtype: *mut TypeCacheEntry,
-    pub rng_collation: Oid,
-    pub rng_cmp_proc_finfo: FmgrInfo,
-    pub rng_canonical_finfo: FmgrInfo,
-    pub rng_subdiff_finfo: FmgrInfo,
-    pub rngtype: *mut TypeCacheEntry,
-    pub domainBaseType: Oid,
-    pub domainBaseTypmod: int32,
-    pub domainData: *mut DomainConstraintCache,
-    pub flags: ::std::os::raw::c_int,
-    pub enumData: *mut TypeCacheEnumData,
-    pub nextDomain: *mut TypeCacheEntry,
-}
-impl Default for TypeCacheEntry {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct DomainConstraintRef {
-    pub constraints: *mut List,
-    pub refctx: MemoryContext,
-    pub tcache: *mut TypeCacheEntry,
-    pub need_exprstate: bool,
-    pub dcc: *mut DomainConstraintCache,
-    pub callback: MemoryContextCallback,
-}
-impl Default for DomainConstraintRef {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct SharedRecordTypmodRegistry {
-    _unused: [u8; 0],
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn lookup_type_cache(type_id: Oid, flags: ::std::os::raw::c_int) -> *mut TypeCacheEntry;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn InitDomainConstraintRef(
-        type_id: Oid,
-        ref_: *mut DomainConstraintRef,
-        refctx: MemoryContext,
-        need_exprstate: bool,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn UpdateDomainConstraintRef(ref_: *mut DomainConstraintRef);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn DomainHasConstraints(type_id: Oid) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn lookup_rowtype_tupdesc(type_id: Oid, typmod: int32) -> TupleDesc;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn lookup_rowtype_tupdesc_noerror(type_id: Oid, typmod: int32, noError: bool) -> TupleDesc;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn lookup_rowtype_tupdesc_copy(type_id: Oid, typmod: int32) -> TupleDesc;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn lookup_rowtype_tupdesc_domain(type_id: Oid, typmod: int32, noError: bool) -> TupleDesc;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn assign_record_type_typmod(tupDesc: TupleDesc);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn assign_record_type_identifier(type_id: Oid, typmod: int32) -> uint64;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn compare_values_of_enum(
-        tcache: *mut TypeCacheEntry,
-        arg1: Oid,
-        arg2: Oid,
-    ) -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn SharedRecordTypmodRegistryEstimate() -> usize;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn SharedRecordTypmodRegistryInit(
-        arg1: *mut SharedRecordTypmodRegistry,
-        segment: *mut dsm_segment,
-        area: *mut dsa_area,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn SharedRecordTypmodRegistryAttach(arg1: *mut SharedRecordTypmodRegistry);
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
 pub struct RangeType {
     pub vl_len_: int32,
     pub rangetypid: Oid,
@@ -61634,11 +63670,6 @@ pub struct TupleQueueReader {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct _MdfdVec {
-    pub _address: u8,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct RowSecurityDesc {
     pub _address: u8,
 }
 #[repr(C)]

--- a/pgrx-pg-sys/src/pg15.rs
+++ b/pgrx-pg-sys/src/pg15.rs
@@ -3124,6 +3124,37 @@ pub const PVC_INCLUDE_PLACEHOLDERS: u32 = 16;
 pub const PVC_RECURSE_PLACEHOLDERS: u32 = 32;
 pub const DEFAULT_CURSOR_TUPLE_FRACTION: f64 = 0.1;
 pub const JUMBLE_SIZE: u32 = 1024;
+pub const ER_MAGIC: u32 = 1384727874;
+pub const ER_FLAG_FVALUE_VALID: u32 = 1;
+pub const ER_FLAG_FVALUE_ALLOCED: u32 = 2;
+pub const ER_FLAG_DVALUES_VALID: u32 = 4;
+pub const ER_FLAG_DVALUES_ALLOCED: u32 = 8;
+pub const ER_FLAG_HAVE_EXTERNAL: u32 = 16;
+pub const ER_FLAG_TUPDESC_ALLOCED: u32 = 32;
+pub const ER_FLAG_IS_DOMAIN: u32 = 64;
+pub const ER_FLAG_IS_DUMMY: u32 = 128;
+pub const ER_FLAGS_NON_DATA: u32 = 224;
+pub const TYPECACHE_EQ_OPR: u32 = 1;
+pub const TYPECACHE_LT_OPR: u32 = 2;
+pub const TYPECACHE_GT_OPR: u32 = 4;
+pub const TYPECACHE_CMP_PROC: u32 = 8;
+pub const TYPECACHE_HASH_PROC: u32 = 16;
+pub const TYPECACHE_EQ_OPR_FINFO: u32 = 32;
+pub const TYPECACHE_CMP_PROC_FINFO: u32 = 64;
+pub const TYPECACHE_HASH_PROC_FINFO: u32 = 128;
+pub const TYPECACHE_TUPDESC: u32 = 256;
+pub const TYPECACHE_BTREE_OPFAMILY: u32 = 512;
+pub const TYPECACHE_HASH_OPFAMILY: u32 = 1024;
+pub const TYPECACHE_RANGE_INFO: u32 = 2048;
+pub const TYPECACHE_DOMAIN_BASE_INFO: u32 = 4096;
+pub const TYPECACHE_DOMAIN_CONSTR_INFO: u32 = 8192;
+pub const TYPECACHE_HASH_EXTENDED_PROC: u32 = 16384;
+pub const TYPECACHE_HASH_EXTENDED_PROC_FINFO: u32 = 32768;
+pub const TYPECACHE_MULTIRANGE_INFO: u32 = 65536;
+pub const PLPGSQL_XCHECK_NONE: u32 = 0;
+pub const PLPGSQL_XCHECK_SHADOWVAR: u32 = 2;
+pub const PLPGSQL_XCHECK_TOOMANYROWS: u32 = 4;
+pub const PLPGSQL_XCHECK_STRICTMULTIASSIGNMENT: u32 = 8;
 pub const RBTXN_HAS_CATALOG_CHANGES: u32 = 1;
 pub const RBTXN_IS_SUBXACT: u32 = 2;
 pub const RBTXN_IS_SERIALIZED: u32 = 4;
@@ -3343,23 +3374,6 @@ pub const DEFAULT_NUM_DISTINCT: u32 = 200;
 pub const DEFAULT_UNK_SEL: f64 = 0.005;
 pub const DEFAULT_NOT_UNK_SEL: f64 = 0.995;
 pub const SELFLAG_USED_DEFAULT: u32 = 1;
-pub const TYPECACHE_EQ_OPR: u32 = 1;
-pub const TYPECACHE_LT_OPR: u32 = 2;
-pub const TYPECACHE_GT_OPR: u32 = 4;
-pub const TYPECACHE_CMP_PROC: u32 = 8;
-pub const TYPECACHE_HASH_PROC: u32 = 16;
-pub const TYPECACHE_EQ_OPR_FINFO: u32 = 32;
-pub const TYPECACHE_CMP_PROC_FINFO: u32 = 64;
-pub const TYPECACHE_HASH_PROC_FINFO: u32 = 128;
-pub const TYPECACHE_TUPDESC: u32 = 256;
-pub const TYPECACHE_BTREE_OPFAMILY: u32 = 512;
-pub const TYPECACHE_HASH_OPFAMILY: u32 = 1024;
-pub const TYPECACHE_RANGE_INFO: u32 = 2048;
-pub const TYPECACHE_DOMAIN_BASE_INFO: u32 = 4096;
-pub const TYPECACHE_DOMAIN_CONSTR_INFO: u32 = 8192;
-pub const TYPECACHE_HASH_EXTENDED_PROC: u32 = 16384;
-pub const TYPECACHE_HASH_EXTENDED_PROC_FINFO: u32 = 32768;
-pub const TYPECACHE_MULTIRANGE_INFO: u32 = 65536;
 pub const RANGE_EMPTY_LITERAL: &[u8; 6usize] = b"empty\0";
 pub const RANGE_EMPTY: u32 = 1;
 pub const RANGE_LB_INC: u32 = 2;
@@ -32168,6 +32182,151 @@ extern "C" {
         sarray_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
+pub const ObjectAccessType_OAT_POST_CREATE: ObjectAccessType = 0;
+pub const ObjectAccessType_OAT_DROP: ObjectAccessType = 1;
+pub const ObjectAccessType_OAT_POST_ALTER: ObjectAccessType = 2;
+pub const ObjectAccessType_OAT_NAMESPACE_SEARCH: ObjectAccessType = 3;
+pub const ObjectAccessType_OAT_FUNCTION_EXECUTE: ObjectAccessType = 4;
+pub const ObjectAccessType_OAT_TRUNCATE: ObjectAccessType = 5;
+pub type ObjectAccessType = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ObjectAccessPostCreate {
+    pub is_internal: bool,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ObjectAccessDrop {
+    pub dropflags: ::std::os::raw::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ObjectAccessPostAlter {
+    pub auxiliary_id: Oid,
+    pub is_internal: bool,
+}
+impl Default for ObjectAccessPostAlter {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ObjectAccessNamespaceSearch {
+    pub ereport_on_violation: bool,
+    pub result: bool,
+}
+pub type object_access_hook_type = ::std::option::Option<
+    unsafe extern "C" fn(
+        access: ObjectAccessType,
+        classId: Oid,
+        objectId: Oid,
+        subId: ::std::os::raw::c_int,
+        arg: *mut ::std::os::raw::c_void,
+    ),
+>;
+pub type object_access_hook_type_str = ::std::option::Option<
+    unsafe extern "C" fn(
+        access: ObjectAccessType,
+        classId: Oid,
+        objectStr: *const ::std::os::raw::c_char,
+        subId: ::std::os::raw::c_int,
+        arg: *mut ::std::os::raw::c_void,
+    ),
+>;
+extern "C" {
+    pub static mut object_access_hook: object_access_hook_type;
+}
+extern "C" {
+    pub static mut object_access_hook_str: object_access_hook_type_str;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RunObjectPostCreateHook(
+        classId: Oid,
+        objectId: Oid,
+        subId: ::std::os::raw::c_int,
+        is_internal: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RunObjectDropHook(
+        classId: Oid,
+        objectId: Oid,
+        subId: ::std::os::raw::c_int,
+        dropflags: ::std::os::raw::c_int,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RunObjectTruncateHook(objectId: Oid);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RunObjectPostAlterHook(
+        classId: Oid,
+        objectId: Oid,
+        subId: ::std::os::raw::c_int,
+        auxiliaryId: Oid,
+        is_internal: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RunNamespaceSearchHook(objectId: Oid, ereport_on_violation: bool) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RunFunctionExecuteHook(objectId: Oid);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RunObjectPostCreateHookStr(
+        classId: Oid,
+        objectStr: *const ::std::os::raw::c_char,
+        subId: ::std::os::raw::c_int,
+        is_internal: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RunObjectDropHookStr(
+        classId: Oid,
+        objectStr: *const ::std::os::raw::c_char,
+        subId: ::std::os::raw::c_int,
+        dropflags: ::std::os::raw::c_int,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RunObjectTruncateHookStr(objectStr: *const ::std::os::raw::c_char);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RunObjectPostAlterHookStr(
+        classId: Oid,
+        objectStr: *const ::std::os::raw::c_char,
+        subId: ::std::os::raw::c_int,
+        auxiliaryId: Oid,
+        is_internal: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RunNamespaceSearchHookStr(
+        objectStr: *const ::std::os::raw::c_char,
+        ereport_on_violation: bool,
+    ) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RunFunctionExecuteHookStr(objectStr: *const ::std::os::raw::c_char);
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct FormData_pg_authid {
@@ -35074,6 +35233,103 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn RI_FKey_trigger_type(tgfoid: Oid) -> ::std::os::raw::c_int;
+}
+pub const PasswordType_PASSWORD_TYPE_PLAINTEXT: PasswordType = 0;
+pub const PasswordType_PASSWORD_TYPE_MD5: PasswordType = 1;
+pub const PasswordType_PASSWORD_TYPE_SCRAM_SHA_256: PasswordType = 2;
+pub type PasswordType = ::std::os::raw::c_uint;
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_password_type(shadow_pass: *const ::std::os::raw::c_char) -> PasswordType;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn encrypt_password(
+        target_type: PasswordType,
+        role: *const ::std::os::raw::c_char,
+        password: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_role_password(
+        role: *const ::std::os::raw::c_char,
+        logdetail: *mut *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn md5_crypt_verify(
+        role: *const ::std::os::raw::c_char,
+        shadow_pass: *const ::std::os::raw::c_char,
+        client_pass: *const ::std::os::raw::c_char,
+        md5_salt: *const ::std::os::raw::c_char,
+        md5_salt_len: ::std::os::raw::c_int,
+        logdetail: *mut *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plain_crypt_verify(
+        role: *const ::std::os::raw::c_char,
+        shadow_pass: *const ::std::os::raw::c_char,
+        client_pass: *const ::std::os::raw::c_char,
+        logdetail: *mut *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut Password_encryption: ::std::os::raw::c_int;
+}
+pub type check_password_hook_type = ::std::option::Option<
+    unsafe extern "C" fn(
+        username: *const ::std::os::raw::c_char,
+        shadow_pass: *const ::std::os::raw::c_char,
+        password_type: PasswordType,
+        validuntil_time: Datum,
+        validuntil_null: bool,
+    ),
+>;
+extern "C" {
+    pub static mut check_password_hook: check_password_hook_type;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn CreateRole(pstate: *mut ParseState, stmt: *mut CreateRoleStmt) -> Oid;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn AlterRole(pstate: *mut ParseState, stmt: *mut AlterRoleStmt) -> Oid;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn AlterRoleSet(stmt: *mut AlterRoleSetStmt) -> Oid;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DropRole(stmt: *mut DropRoleStmt);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GrantRole(stmt: *mut GrantRoleStmt);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RenameRole(
+        oldname: *const ::std::os::raw::c_char,
+        newname: *const ::std::os::raw::c_char,
+    ) -> ObjectAddress;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DropOwnedObjects(stmt: *mut DropOwnedStmt);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ReassignOwnedObjects(stmt: *mut ReassignOwnedStmt);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn roleSpecsToIds(memberNames: *mut List) -> *mut List;
 }
 pub type bgworker_main_type = ::std::option::Option<unsafe extern "C" fn(main_arg: Datum)>;
 pub const BgWorkerStartTime_BgWorkerStart_PostmasterStart: BgWorkerStartTime = 0;
@@ -42903,6 +43159,127 @@ extern "C" {
         live_childrels: *mut List,
     );
 }
+pub type get_relation_info_hook_type = ::std::option::Option<
+    unsafe extern "C" fn(
+        root: *mut PlannerInfo,
+        relationObjectId: Oid,
+        inhparent: bool,
+        rel: *mut RelOptInfo,
+    ),
+>;
+extern "C" {
+    pub static mut get_relation_info_hook: get_relation_info_hook_type;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_relation_info(
+        root: *mut PlannerInfo,
+        relationObjectId: Oid,
+        inhparent: bool,
+        rel: *mut RelOptInfo,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn infer_arbiter_indexes(root: *mut PlannerInfo) -> *mut List;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn estimate_rel_size(
+        rel: Relation,
+        attr_widths: *mut int32,
+        pages: *mut BlockNumber,
+        tuples: *mut f64,
+        allvisfrac: *mut f64,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_rel_data_width(rel: Relation, attr_widths: *mut int32) -> int32;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_relation_data_width(relid: Oid, attr_widths: *mut int32) -> int32;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn relation_excluded_by_constraints(
+        root: *mut PlannerInfo,
+        rel: *mut RelOptInfo,
+        rte: *mut RangeTblEntry,
+    ) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn build_physical_tlist(root: *mut PlannerInfo, rel: *mut RelOptInfo) -> *mut List;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn has_unique_index(rel: *mut RelOptInfo, attno: AttrNumber) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn restriction_selectivity(
+        root: *mut PlannerInfo,
+        operatorid: Oid,
+        args: *mut List,
+        inputcollid: Oid,
+        varRelid: ::std::os::raw::c_int,
+    ) -> Selectivity;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn join_selectivity(
+        root: *mut PlannerInfo,
+        operatorid: Oid,
+        args: *mut List,
+        inputcollid: Oid,
+        jointype: JoinType,
+        sjinfo: *mut SpecialJoinInfo,
+    ) -> Selectivity;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn function_selectivity(
+        root: *mut PlannerInfo,
+        funcid: Oid,
+        args: *mut List,
+        inputcollid: Oid,
+        is_join: bool,
+        varRelid: ::std::os::raw::c_int,
+        jointype: JoinType,
+        sjinfo: *mut SpecialJoinInfo,
+    ) -> Selectivity;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn add_function_cost(
+        root: *mut PlannerInfo,
+        funcid: Oid,
+        node: *mut Node,
+        cost: *mut QualCost,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_function_rows(root: *mut PlannerInfo, funcid: Oid, node: *mut Node) -> f64;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn has_row_triggers(root: *mut PlannerInfo, rti: Index, event: CmdType) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn has_stored_generated_columns(root: *mut PlannerInfo, rti: Index) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_dependent_generated_columns(
+        root: *mut PlannerInfo,
+        rti: Index,
+        target_cols: *mut Bitmapset,
+    ) -> *mut Bitmapset;
+}
 extern "C" {
     pub static mut cursor_tuple_fraction: f64;
 }
@@ -44016,6 +44393,1852 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn get_parse_rowmark(qry: *mut Query, rtindex: Index) -> *mut RowMarkClause;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ExpandedRecordHeader {
+    pub hdr: ExpandedObjectHeader,
+    pub er_magic: ::std::os::raw::c_int,
+    pub flags: ::std::os::raw::c_int,
+    pub er_decltypeid: Oid,
+    pub er_typeid: Oid,
+    pub er_typmod: int32,
+    pub er_tupdesc: TupleDesc,
+    pub er_tupdesc_id: uint64,
+    pub dvalues: *mut Datum,
+    pub dnulls: *mut bool,
+    pub nfields: ::std::os::raw::c_int,
+    pub flat_size: Size,
+    pub data_len: Size,
+    pub hoff: ::std::os::raw::c_int,
+    pub hasnull: bool,
+    pub fvalue: HeapTuple,
+    pub fstartptr: *mut ::std::os::raw::c_char,
+    pub fendptr: *mut ::std::os::raw::c_char,
+    pub er_short_term_cxt: MemoryContext,
+    pub er_dummy_header: *mut ExpandedRecordHeader,
+    pub er_domaininfo: *mut ::std::os::raw::c_void,
+    pub er_mcb: MemoryContextCallback,
+}
+impl Default for ExpandedRecordHeader {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ExpandedRecordFieldInfo {
+    pub fnumber: ::std::os::raw::c_int,
+    pub ftypeid: Oid,
+    pub ftypmod: int32,
+    pub fcollation: Oid,
+}
+impl Default for ExpandedRecordFieldInfo {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn make_expanded_record_from_typeid(
+        type_id: Oid,
+        typmod: int32,
+        parentcontext: MemoryContext,
+    ) -> *mut ExpandedRecordHeader;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn make_expanded_record_from_tupdesc(
+        tupdesc: TupleDesc,
+        parentcontext: MemoryContext,
+    ) -> *mut ExpandedRecordHeader;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn make_expanded_record_from_exprecord(
+        olderh: *mut ExpandedRecordHeader,
+        parentcontext: MemoryContext,
+    ) -> *mut ExpandedRecordHeader;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn expanded_record_set_tuple(
+        erh: *mut ExpandedRecordHeader,
+        tuple: HeapTuple,
+        copy: bool,
+        expand_external: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn make_expanded_record_from_datum(
+        recorddatum: Datum,
+        parentcontext: MemoryContext,
+    ) -> Datum;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn expanded_record_fetch_tupdesc(erh: *mut ExpandedRecordHeader) -> TupleDesc;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn expanded_record_get_tuple(erh: *mut ExpandedRecordHeader) -> HeapTuple;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DatumGetExpandedRecord(d: Datum) -> *mut ExpandedRecordHeader;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn deconstruct_expanded_record(erh: *mut ExpandedRecordHeader);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn expanded_record_lookup_field(
+        erh: *mut ExpandedRecordHeader,
+        fieldname: *const ::std::os::raw::c_char,
+        finfo: *mut ExpandedRecordFieldInfo,
+    ) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn expanded_record_fetch_field(
+        erh: *mut ExpandedRecordHeader,
+        fnumber: ::std::os::raw::c_int,
+        isnull: *mut bool,
+    ) -> Datum;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn expanded_record_set_field_internal(
+        erh: *mut ExpandedRecordHeader,
+        fnumber: ::std::os::raw::c_int,
+        newValue: Datum,
+        isnull: bool,
+        expand_external: bool,
+        check_constraints: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn expanded_record_set_fields(
+        erh: *mut ExpandedRecordHeader,
+        newValues: *const Datum,
+        isnulls: *const bool,
+        expand_external: bool,
+    );
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct DomainConstraintCache {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct TypeCacheEnumData {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct TypeCacheEntry {
+    pub type_id: Oid,
+    pub type_id_hash: uint32,
+    pub typlen: int16,
+    pub typbyval: bool,
+    pub typalign: ::std::os::raw::c_char,
+    pub typstorage: ::std::os::raw::c_char,
+    pub typtype: ::std::os::raw::c_char,
+    pub typrelid: Oid,
+    pub typsubscript: Oid,
+    pub typelem: Oid,
+    pub typcollation: Oid,
+    pub btree_opf: Oid,
+    pub btree_opintype: Oid,
+    pub hash_opf: Oid,
+    pub hash_opintype: Oid,
+    pub eq_opr: Oid,
+    pub lt_opr: Oid,
+    pub gt_opr: Oid,
+    pub cmp_proc: Oid,
+    pub hash_proc: Oid,
+    pub hash_extended_proc: Oid,
+    pub eq_opr_finfo: FmgrInfo,
+    pub cmp_proc_finfo: FmgrInfo,
+    pub hash_proc_finfo: FmgrInfo,
+    pub hash_extended_proc_finfo: FmgrInfo,
+    pub tupDesc: TupleDesc,
+    pub tupDesc_identifier: uint64,
+    pub rngelemtype: *mut TypeCacheEntry,
+    pub rng_collation: Oid,
+    pub rng_cmp_proc_finfo: FmgrInfo,
+    pub rng_canonical_finfo: FmgrInfo,
+    pub rng_subdiff_finfo: FmgrInfo,
+    pub rngtype: *mut TypeCacheEntry,
+    pub domainBaseType: Oid,
+    pub domainBaseTypmod: int32,
+    pub domainData: *mut DomainConstraintCache,
+    pub flags: ::std::os::raw::c_int,
+    pub enumData: *mut TypeCacheEnumData,
+    pub nextDomain: *mut TypeCacheEntry,
+}
+impl Default for TypeCacheEntry {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct DomainConstraintRef {
+    pub constraints: *mut List,
+    pub refctx: MemoryContext,
+    pub tcache: *mut TypeCacheEntry,
+    pub need_exprstate: bool,
+    pub dcc: *mut DomainConstraintCache,
+    pub callback: MemoryContextCallback,
+}
+impl Default for DomainConstraintRef {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct SharedRecordTypmodRegistry {
+    _unused: [u8; 0],
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn lookup_type_cache(type_id: Oid, flags: ::std::os::raw::c_int) -> *mut TypeCacheEntry;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn InitDomainConstraintRef(
+        type_id: Oid,
+        ref_: *mut DomainConstraintRef,
+        refctx: MemoryContext,
+        need_exprstate: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UpdateDomainConstraintRef(ref_: *mut DomainConstraintRef);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DomainHasConstraints(type_id: Oid) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn lookup_rowtype_tupdesc(type_id: Oid, typmod: int32) -> TupleDesc;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn lookup_rowtype_tupdesc_noerror(type_id: Oid, typmod: int32, noError: bool) -> TupleDesc;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn lookup_rowtype_tupdesc_copy(type_id: Oid, typmod: int32) -> TupleDesc;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn lookup_rowtype_tupdesc_domain(type_id: Oid, typmod: int32, noError: bool) -> TupleDesc;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn assign_record_type_typmod(tupDesc: TupleDesc);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn assign_record_type_identifier(type_id: Oid, typmod: int32) -> uint64;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn compare_values_of_enum(
+        tcache: *mut TypeCacheEntry,
+        arg1: Oid,
+        arg2: Oid,
+    ) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SharedRecordTypmodRegistryEstimate() -> usize;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SharedRecordTypmodRegistryInit(
+        arg1: *mut SharedRecordTypmodRegistry,
+        segment: *mut dsm_segment,
+        area: *mut dsa_area,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SharedRecordTypmodRegistryAttach(arg1: *mut SharedRecordTypmodRegistry);
+}
+pub const PLpgSQL_nsitem_type_PLPGSQL_NSTYPE_LABEL: PLpgSQL_nsitem_type = 0;
+pub const PLpgSQL_nsitem_type_PLPGSQL_NSTYPE_VAR: PLpgSQL_nsitem_type = 1;
+pub const PLpgSQL_nsitem_type_PLPGSQL_NSTYPE_REC: PLpgSQL_nsitem_type = 2;
+pub type PLpgSQL_nsitem_type = ::std::os::raw::c_uint;
+pub const PLpgSQL_label_type_PLPGSQL_LABEL_BLOCK: PLpgSQL_label_type = 0;
+pub const PLpgSQL_label_type_PLPGSQL_LABEL_LOOP: PLpgSQL_label_type = 1;
+pub const PLpgSQL_label_type_PLPGSQL_LABEL_OTHER: PLpgSQL_label_type = 2;
+pub type PLpgSQL_label_type = ::std::os::raw::c_uint;
+pub const PLpgSQL_datum_type_PLPGSQL_DTYPE_VAR: PLpgSQL_datum_type = 0;
+pub const PLpgSQL_datum_type_PLPGSQL_DTYPE_ROW: PLpgSQL_datum_type = 1;
+pub const PLpgSQL_datum_type_PLPGSQL_DTYPE_REC: PLpgSQL_datum_type = 2;
+pub const PLpgSQL_datum_type_PLPGSQL_DTYPE_RECFIELD: PLpgSQL_datum_type = 3;
+pub const PLpgSQL_datum_type_PLPGSQL_DTYPE_PROMISE: PLpgSQL_datum_type = 4;
+pub type PLpgSQL_datum_type = ::std::os::raw::c_uint;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_NONE: PLpgSQL_promise_type = 0;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_NAME: PLpgSQL_promise_type = 1;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_WHEN: PLpgSQL_promise_type = 2;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_LEVEL: PLpgSQL_promise_type = 3;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_OP: PLpgSQL_promise_type = 4;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_RELID: PLpgSQL_promise_type = 5;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_TABLE_NAME: PLpgSQL_promise_type = 6;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_TABLE_SCHEMA: PLpgSQL_promise_type = 7;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_NARGS: PLpgSQL_promise_type = 8;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_ARGV: PLpgSQL_promise_type = 9;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_EVENT: PLpgSQL_promise_type = 10;
+pub const PLpgSQL_promise_type_PLPGSQL_PROMISE_TG_TAG: PLpgSQL_promise_type = 11;
+pub type PLpgSQL_promise_type = ::std::os::raw::c_uint;
+pub const PLpgSQL_type_type_PLPGSQL_TTYPE_SCALAR: PLpgSQL_type_type = 0;
+pub const PLpgSQL_type_type_PLPGSQL_TTYPE_REC: PLpgSQL_type_type = 1;
+pub const PLpgSQL_type_type_PLPGSQL_TTYPE_PSEUDO: PLpgSQL_type_type = 2;
+pub type PLpgSQL_type_type = ::std::os::raw::c_uint;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_BLOCK: PLpgSQL_stmt_type = 0;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_ASSIGN: PLpgSQL_stmt_type = 1;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_IF: PLpgSQL_stmt_type = 2;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_CASE: PLpgSQL_stmt_type = 3;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_LOOP: PLpgSQL_stmt_type = 4;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_WHILE: PLpgSQL_stmt_type = 5;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_FORI: PLpgSQL_stmt_type = 6;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_FORS: PLpgSQL_stmt_type = 7;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_FORC: PLpgSQL_stmt_type = 8;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_FOREACH_A: PLpgSQL_stmt_type = 9;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_EXIT: PLpgSQL_stmt_type = 10;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_RETURN: PLpgSQL_stmt_type = 11;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_RETURN_NEXT: PLpgSQL_stmt_type = 12;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_RETURN_QUERY: PLpgSQL_stmt_type = 13;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_RAISE: PLpgSQL_stmt_type = 14;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_ASSERT: PLpgSQL_stmt_type = 15;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_EXECSQL: PLpgSQL_stmt_type = 16;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_DYNEXECUTE: PLpgSQL_stmt_type = 17;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_DYNFORS: PLpgSQL_stmt_type = 18;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_GETDIAG: PLpgSQL_stmt_type = 19;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_OPEN: PLpgSQL_stmt_type = 20;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_FETCH: PLpgSQL_stmt_type = 21;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_CLOSE: PLpgSQL_stmt_type = 22;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_PERFORM: PLpgSQL_stmt_type = 23;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_CALL: PLpgSQL_stmt_type = 24;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_COMMIT: PLpgSQL_stmt_type = 25;
+pub const PLpgSQL_stmt_type_PLPGSQL_STMT_ROLLBACK: PLpgSQL_stmt_type = 26;
+pub type PLpgSQL_stmt_type = ::std::os::raw::c_uint;
+pub const PLPGSQL_RC_OK: _bindgen_ty_19 = 0;
+pub const PLPGSQL_RC_EXIT: _bindgen_ty_19 = 1;
+pub const PLPGSQL_RC_RETURN: _bindgen_ty_19 = 2;
+pub const PLPGSQL_RC_CONTINUE: _bindgen_ty_19 = 3;
+pub type _bindgen_ty_19 = ::std::os::raw::c_uint;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_ROW_COUNT: PLpgSQL_getdiag_kind = 0;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_CONTEXT: PLpgSQL_getdiag_kind = 1;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_ERROR_CONTEXT: PLpgSQL_getdiag_kind = 2;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_ERROR_DETAIL: PLpgSQL_getdiag_kind = 3;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_ERROR_HINT: PLpgSQL_getdiag_kind = 4;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_RETURNED_SQLSTATE: PLpgSQL_getdiag_kind = 5;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_COLUMN_NAME: PLpgSQL_getdiag_kind = 6;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_CONSTRAINT_NAME: PLpgSQL_getdiag_kind = 7;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_DATATYPE_NAME: PLpgSQL_getdiag_kind = 8;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_MESSAGE_TEXT: PLpgSQL_getdiag_kind = 9;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_TABLE_NAME: PLpgSQL_getdiag_kind = 10;
+pub const PLpgSQL_getdiag_kind_PLPGSQL_GETDIAG_SCHEMA_NAME: PLpgSQL_getdiag_kind = 11;
+pub type PLpgSQL_getdiag_kind = ::std::os::raw::c_uint;
+pub const PLpgSQL_raise_option_type_PLPGSQL_RAISEOPTION_ERRCODE: PLpgSQL_raise_option_type = 0;
+pub const PLpgSQL_raise_option_type_PLPGSQL_RAISEOPTION_MESSAGE: PLpgSQL_raise_option_type = 1;
+pub const PLpgSQL_raise_option_type_PLPGSQL_RAISEOPTION_DETAIL: PLpgSQL_raise_option_type = 2;
+pub const PLpgSQL_raise_option_type_PLPGSQL_RAISEOPTION_HINT: PLpgSQL_raise_option_type = 3;
+pub const PLpgSQL_raise_option_type_PLPGSQL_RAISEOPTION_COLUMN: PLpgSQL_raise_option_type = 4;
+pub const PLpgSQL_raise_option_type_PLPGSQL_RAISEOPTION_CONSTRAINT: PLpgSQL_raise_option_type = 5;
+pub const PLpgSQL_raise_option_type_PLPGSQL_RAISEOPTION_DATATYPE: PLpgSQL_raise_option_type = 6;
+pub const PLpgSQL_raise_option_type_PLPGSQL_RAISEOPTION_TABLE: PLpgSQL_raise_option_type = 7;
+pub const PLpgSQL_raise_option_type_PLPGSQL_RAISEOPTION_SCHEMA: PLpgSQL_raise_option_type = 8;
+pub type PLpgSQL_raise_option_type = ::std::os::raw::c_uint;
+pub const PLpgSQL_resolve_option_PLPGSQL_RESOLVE_ERROR: PLpgSQL_resolve_option = 0;
+pub const PLpgSQL_resolve_option_PLPGSQL_RESOLVE_VARIABLE: PLpgSQL_resolve_option = 1;
+pub const PLpgSQL_resolve_option_PLPGSQL_RESOLVE_COLUMN: PLpgSQL_resolve_option = 2;
+pub type PLpgSQL_resolve_option = ::std::os::raw::c_uint;
+#[doc = " Node and structure definitions"]
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_type {
+    pub typname: *mut ::std::os::raw::c_char,
+    pub typoid: Oid,
+    pub ttype: PLpgSQL_type_type,
+    pub typlen: int16,
+    pub typbyval: bool,
+    pub typtype: ::std::os::raw::c_char,
+    pub collation: Oid,
+    pub typisarray: bool,
+    pub atttypmod: int32,
+    pub origtypname: *mut TypeName,
+    pub tcache: *mut TypeCacheEntry,
+    pub tupdesc_id: uint64,
+}
+impl Default for PLpgSQL_type {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_expr {
+    pub query: *mut ::std::os::raw::c_char,
+    pub parseMode: RawParseMode,
+    pub plan: SPIPlanPtr,
+    pub paramnos: *mut Bitmapset,
+    pub func: *mut PLpgSQL_function,
+    pub ns: *mut PLpgSQL_nsitem,
+    pub expr_simple_expr: *mut Expr,
+    pub expr_simple_type: Oid,
+    pub expr_simple_typmod: int32,
+    pub expr_simple_mutable: bool,
+    pub target_param: ::std::os::raw::c_int,
+    pub expr_rw_param: *mut Param,
+    pub expr_simple_plansource: *mut CachedPlanSource,
+    pub expr_simple_plan: *mut CachedPlan,
+    pub expr_simple_plan_lxid: LocalTransactionId,
+    pub expr_simple_state: *mut ExprState,
+    pub expr_simple_in_use: bool,
+    pub expr_simple_lxid: LocalTransactionId,
+}
+impl Default for PLpgSQL_expr {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_datum {
+    pub dtype: PLpgSQL_datum_type,
+    pub dno: ::std::os::raw::c_int,
+}
+impl Default for PLpgSQL_datum {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_variable {
+    pub dtype: PLpgSQL_datum_type,
+    pub dno: ::std::os::raw::c_int,
+    pub refname: *mut ::std::os::raw::c_char,
+    pub lineno: ::std::os::raw::c_int,
+    pub isconst: bool,
+    pub notnull: bool,
+    pub default_val: *mut PLpgSQL_expr,
+}
+impl Default for PLpgSQL_variable {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_var {
+    pub dtype: PLpgSQL_datum_type,
+    pub dno: ::std::os::raw::c_int,
+    pub refname: *mut ::std::os::raw::c_char,
+    pub lineno: ::std::os::raw::c_int,
+    pub isconst: bool,
+    pub notnull: bool,
+    pub default_val: *mut PLpgSQL_expr,
+    pub datatype: *mut PLpgSQL_type,
+    pub cursor_explicit_expr: *mut PLpgSQL_expr,
+    pub cursor_explicit_argrow: ::std::os::raw::c_int,
+    pub cursor_options: ::std::os::raw::c_int,
+    pub value: Datum,
+    pub isnull: bool,
+    pub freeval: bool,
+    pub promise: PLpgSQL_promise_type,
+}
+impl Default for PLpgSQL_var {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_row {
+    pub dtype: PLpgSQL_datum_type,
+    pub dno: ::std::os::raw::c_int,
+    pub refname: *mut ::std::os::raw::c_char,
+    pub lineno: ::std::os::raw::c_int,
+    pub isconst: bool,
+    pub notnull: bool,
+    pub default_val: *mut PLpgSQL_expr,
+    pub rowtupdesc: TupleDesc,
+    pub nfields: ::std::os::raw::c_int,
+    pub fieldnames: *mut *mut ::std::os::raw::c_char,
+    pub varnos: *mut ::std::os::raw::c_int,
+}
+impl Default for PLpgSQL_row {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_rec {
+    pub dtype: PLpgSQL_datum_type,
+    pub dno: ::std::os::raw::c_int,
+    pub refname: *mut ::std::os::raw::c_char,
+    pub lineno: ::std::os::raw::c_int,
+    pub isconst: bool,
+    pub notnull: bool,
+    pub default_val: *mut PLpgSQL_expr,
+    pub datatype: *mut PLpgSQL_type,
+    pub rectypeid: Oid,
+    pub firstfield: ::std::os::raw::c_int,
+    pub erh: *mut ExpandedRecordHeader,
+}
+impl Default for PLpgSQL_rec {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_recfield {
+    pub dtype: PLpgSQL_datum_type,
+    pub dno: ::std::os::raw::c_int,
+    pub fieldname: *mut ::std::os::raw::c_char,
+    pub recparentno: ::std::os::raw::c_int,
+    pub nextfield: ::std::os::raw::c_int,
+    pub rectupledescid: uint64,
+    pub finfo: ExpandedRecordFieldInfo,
+}
+impl Default for PLpgSQL_recfield {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct PLpgSQL_nsitem {
+    pub itemtype: PLpgSQL_nsitem_type,
+    pub itemno: ::std::os::raw::c_int,
+    pub prev: *mut PLpgSQL_nsitem,
+    pub name: __IncompleteArrayField<::std::os::raw::c_char>,
+}
+impl Default for PLpgSQL_nsitem {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+}
+impl Default for PLpgSQL_stmt {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_condition {
+    pub sqlerrstate: ::std::os::raw::c_int,
+    pub condname: *mut ::std::os::raw::c_char,
+    pub next: *mut PLpgSQL_condition,
+}
+impl Default for PLpgSQL_condition {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_exception_block {
+    pub sqlstate_varno: ::std::os::raw::c_int,
+    pub sqlerrm_varno: ::std::os::raw::c_int,
+    pub exc_list: *mut List,
+}
+impl Default for PLpgSQL_exception_block {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_exception {
+    pub lineno: ::std::os::raw::c_int,
+    pub conditions: *mut PLpgSQL_condition,
+    pub action: *mut List,
+}
+impl Default for PLpgSQL_exception {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_block {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub label: *mut ::std::os::raw::c_char,
+    pub body: *mut List,
+    pub n_initvars: ::std::os::raw::c_int,
+    pub initvarnos: *mut ::std::os::raw::c_int,
+    pub exceptions: *mut PLpgSQL_exception_block,
+}
+impl Default for PLpgSQL_stmt_block {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_assign {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub varno: ::std::os::raw::c_int,
+    pub expr: *mut PLpgSQL_expr,
+}
+impl Default for PLpgSQL_stmt_assign {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_perform {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub expr: *mut PLpgSQL_expr,
+}
+impl Default for PLpgSQL_stmt_perform {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_call {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub expr: *mut PLpgSQL_expr,
+    pub is_call: bool,
+    pub target: *mut PLpgSQL_variable,
+}
+impl Default for PLpgSQL_stmt_call {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_commit {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub chain: bool,
+}
+impl Default for PLpgSQL_stmt_commit {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_rollback {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub chain: bool,
+}
+impl Default for PLpgSQL_stmt_rollback {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_diag_item {
+    pub kind: PLpgSQL_getdiag_kind,
+    pub target: ::std::os::raw::c_int,
+}
+impl Default for PLpgSQL_diag_item {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_getdiag {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub is_stacked: bool,
+    pub diag_items: *mut List,
+}
+impl Default for PLpgSQL_stmt_getdiag {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_if {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub cond: *mut PLpgSQL_expr,
+    pub then_body: *mut List,
+    pub elsif_list: *mut List,
+    pub else_body: *mut List,
+}
+impl Default for PLpgSQL_stmt_if {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_if_elsif {
+    pub lineno: ::std::os::raw::c_int,
+    pub cond: *mut PLpgSQL_expr,
+    pub stmts: *mut List,
+}
+impl Default for PLpgSQL_if_elsif {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_case {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub t_expr: *mut PLpgSQL_expr,
+    pub t_varno: ::std::os::raw::c_int,
+    pub case_when_list: *mut List,
+    pub have_else: bool,
+    pub else_stmts: *mut List,
+}
+impl Default for PLpgSQL_stmt_case {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_case_when {
+    pub lineno: ::std::os::raw::c_int,
+    pub expr: *mut PLpgSQL_expr,
+    pub stmts: *mut List,
+}
+impl Default for PLpgSQL_case_when {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_loop {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub label: *mut ::std::os::raw::c_char,
+    pub body: *mut List,
+}
+impl Default for PLpgSQL_stmt_loop {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_while {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub label: *mut ::std::os::raw::c_char,
+    pub cond: *mut PLpgSQL_expr,
+    pub body: *mut List,
+}
+impl Default for PLpgSQL_stmt_while {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_fori {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub label: *mut ::std::os::raw::c_char,
+    pub var: *mut PLpgSQL_var,
+    pub lower: *mut PLpgSQL_expr,
+    pub upper: *mut PLpgSQL_expr,
+    pub step: *mut PLpgSQL_expr,
+    pub reverse: ::std::os::raw::c_int,
+    pub body: *mut List,
+}
+impl Default for PLpgSQL_stmt_fori {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_forq {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub label: *mut ::std::os::raw::c_char,
+    pub var: *mut PLpgSQL_variable,
+    pub body: *mut List,
+}
+impl Default for PLpgSQL_stmt_forq {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_fors {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub label: *mut ::std::os::raw::c_char,
+    pub var: *mut PLpgSQL_variable,
+    pub body: *mut List,
+    pub query: *mut PLpgSQL_expr,
+}
+impl Default for PLpgSQL_stmt_fors {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_forc {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub label: *mut ::std::os::raw::c_char,
+    pub var: *mut PLpgSQL_variable,
+    pub body: *mut List,
+    pub curvar: ::std::os::raw::c_int,
+    pub argquery: *mut PLpgSQL_expr,
+}
+impl Default for PLpgSQL_stmt_forc {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_dynfors {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub label: *mut ::std::os::raw::c_char,
+    pub var: *mut PLpgSQL_variable,
+    pub body: *mut List,
+    pub query: *mut PLpgSQL_expr,
+    pub params: *mut List,
+}
+impl Default for PLpgSQL_stmt_dynfors {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_foreach_a {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub label: *mut ::std::os::raw::c_char,
+    pub varno: ::std::os::raw::c_int,
+    pub slice: ::std::os::raw::c_int,
+    pub expr: *mut PLpgSQL_expr,
+    pub body: *mut List,
+}
+impl Default for PLpgSQL_stmt_foreach_a {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_open {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub curvar: ::std::os::raw::c_int,
+    pub cursor_options: ::std::os::raw::c_int,
+    pub argquery: *mut PLpgSQL_expr,
+    pub query: *mut PLpgSQL_expr,
+    pub dynquery: *mut PLpgSQL_expr,
+    pub params: *mut List,
+}
+impl Default for PLpgSQL_stmt_open {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_fetch {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub target: *mut PLpgSQL_variable,
+    pub curvar: ::std::os::raw::c_int,
+    pub direction: FetchDirection,
+    pub how_many: ::std::os::raw::c_long,
+    pub expr: *mut PLpgSQL_expr,
+    pub is_move: bool,
+    pub returns_multiple_rows: bool,
+}
+impl Default for PLpgSQL_stmt_fetch {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_close {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub curvar: ::std::os::raw::c_int,
+}
+impl Default for PLpgSQL_stmt_close {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_exit {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub is_exit: bool,
+    pub label: *mut ::std::os::raw::c_char,
+    pub cond: *mut PLpgSQL_expr,
+}
+impl Default for PLpgSQL_stmt_exit {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_return {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub expr: *mut PLpgSQL_expr,
+    pub retvarno: ::std::os::raw::c_int,
+}
+impl Default for PLpgSQL_stmt_return {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_return_next {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub expr: *mut PLpgSQL_expr,
+    pub retvarno: ::std::os::raw::c_int,
+}
+impl Default for PLpgSQL_stmt_return_next {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_return_query {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub query: *mut PLpgSQL_expr,
+    pub dynquery: *mut PLpgSQL_expr,
+    pub params: *mut List,
+}
+impl Default for PLpgSQL_stmt_return_query {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_raise {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub elog_level: ::std::os::raw::c_int,
+    pub condname: *mut ::std::os::raw::c_char,
+    pub message: *mut ::std::os::raw::c_char,
+    pub params: *mut List,
+    pub options: *mut List,
+}
+impl Default for PLpgSQL_stmt_raise {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_raise_option {
+    pub opt_type: PLpgSQL_raise_option_type,
+    pub expr: *mut PLpgSQL_expr,
+}
+impl Default for PLpgSQL_raise_option {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_assert {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub cond: *mut PLpgSQL_expr,
+    pub message: *mut PLpgSQL_expr,
+}
+impl Default for PLpgSQL_stmt_assert {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_execsql {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub sqlstmt: *mut PLpgSQL_expr,
+    pub mod_stmt: bool,
+    pub mod_stmt_set: bool,
+    pub into: bool,
+    pub strict: bool,
+    pub target: *mut PLpgSQL_variable,
+}
+impl Default for PLpgSQL_stmt_execsql {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_stmt_dynexecute {
+    pub cmd_type: PLpgSQL_stmt_type,
+    pub lineno: ::std::os::raw::c_int,
+    pub stmtid: ::std::os::raw::c_uint,
+    pub query: *mut PLpgSQL_expr,
+    pub into: bool,
+    pub strict: bool,
+    pub target: *mut PLpgSQL_variable,
+    pub params: *mut List,
+}
+impl Default for PLpgSQL_stmt_dynexecute {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_func_hashkey {
+    pub funcOid: Oid,
+    pub isTrigger: bool,
+    pub isEventTrigger: bool,
+    pub trigOid: Oid,
+    pub inputCollation: Oid,
+    pub argtypes: [Oid; 100usize],
+}
+impl Default for PLpgSQL_func_hashkey {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub const PLpgSQL_trigtype_PLPGSQL_DML_TRIGGER: PLpgSQL_trigtype = 0;
+pub const PLpgSQL_trigtype_PLPGSQL_EVENT_TRIGGER: PLpgSQL_trigtype = 1;
+pub const PLpgSQL_trigtype_PLPGSQL_NOT_TRIGGER: PLpgSQL_trigtype = 2;
+pub type PLpgSQL_trigtype = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_function {
+    pub fn_signature: *mut ::std::os::raw::c_char,
+    pub fn_oid: Oid,
+    pub fn_xmin: TransactionId,
+    pub fn_tid: ItemPointerData,
+    pub fn_is_trigger: PLpgSQL_trigtype,
+    pub fn_input_collation: Oid,
+    pub fn_hashkey: *mut PLpgSQL_func_hashkey,
+    pub fn_cxt: MemoryContext,
+    pub fn_rettype: Oid,
+    pub fn_rettyplen: ::std::os::raw::c_int,
+    pub fn_retbyval: bool,
+    pub fn_retistuple: bool,
+    pub fn_retisdomain: bool,
+    pub fn_retset: bool,
+    pub fn_readonly: bool,
+    pub fn_prokind: ::std::os::raw::c_char,
+    pub fn_nargs: ::std::os::raw::c_int,
+    pub fn_argvarnos: [::std::os::raw::c_int; 100usize],
+    pub out_param_varno: ::std::os::raw::c_int,
+    pub found_varno: ::std::os::raw::c_int,
+    pub new_varno: ::std::os::raw::c_int,
+    pub old_varno: ::std::os::raw::c_int,
+    pub resolve_option: PLpgSQL_resolve_option,
+    pub print_strict_params: bool,
+    pub extra_warnings: ::std::os::raw::c_int,
+    pub extra_errors: ::std::os::raw::c_int,
+    pub ndatums: ::std::os::raw::c_int,
+    pub datums: *mut *mut PLpgSQL_datum,
+    pub copiable_size: Size,
+    pub action: *mut PLpgSQL_stmt_block,
+    pub nstatements: ::std::os::raw::c_uint,
+    pub requires_procedure_resowner: bool,
+    pub cur_estate: *mut PLpgSQL_execstate,
+    pub use_count: ::std::os::raw::c_ulong,
+}
+impl Default for PLpgSQL_function {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLpgSQL_execstate {
+    pub func: *mut PLpgSQL_function,
+    pub trigdata: *mut TriggerData,
+    pub evtrigdata: *mut EventTriggerData,
+    pub retval: Datum,
+    pub retisnull: bool,
+    pub rettype: Oid,
+    pub fn_rettype: Oid,
+    pub retistuple: bool,
+    pub retisset: bool,
+    pub readonly_func: bool,
+    pub atomic: bool,
+    pub exitlabel: *mut ::std::os::raw::c_char,
+    pub cur_error: *mut ErrorData,
+    pub tuple_store: *mut Tuplestorestate,
+    pub tuple_store_desc: TupleDesc,
+    pub tuple_store_cxt: MemoryContext,
+    pub tuple_store_owner: ResourceOwner,
+    pub rsi: *mut ReturnSetInfo,
+    pub found_varno: ::std::os::raw::c_int,
+    pub ndatums: ::std::os::raw::c_int,
+    pub datums: *mut *mut PLpgSQL_datum,
+    pub datum_context: MemoryContext,
+    pub paramLI: ParamListInfo,
+    pub simple_eval_estate: *mut EState,
+    pub simple_eval_resowner: ResourceOwner,
+    pub procedure_resowner: ResourceOwner,
+    pub cast_hash: *mut HTAB,
+    pub cast_hash_context: MemoryContext,
+    pub stmt_mcontext: MemoryContext,
+    pub stmt_mcontext_parent: MemoryContext,
+    pub eval_tuptable: *mut SPITupleTable,
+    pub eval_processed: uint64,
+    pub eval_econtext: *mut ExprContext,
+    pub err_stmt: *mut PLpgSQL_stmt,
+    pub err_var: *mut PLpgSQL_variable,
+    pub err_text: *const ::std::os::raw::c_char,
+    pub plugin_info: *mut ::std::os::raw::c_void,
+}
+impl Default for PLpgSQL_execstate {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct PLpgSQL_plugin {
+    pub func_setup: ::std::option::Option<
+        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, func: *mut PLpgSQL_function),
+    >,
+    pub func_beg: ::std::option::Option<
+        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, func: *mut PLpgSQL_function),
+    >,
+    pub func_end: ::std::option::Option<
+        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, func: *mut PLpgSQL_function),
+    >,
+    pub stmt_beg: ::std::option::Option<
+        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, stmt: *mut PLpgSQL_stmt),
+    >,
+    pub stmt_end: ::std::option::Option<
+        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, stmt: *mut PLpgSQL_stmt),
+    >,
+    pub error_callback:
+        ::std::option::Option<unsafe extern "C" fn(arg: *mut ::std::os::raw::c_void)>,
+    pub assign_expr: ::std::option::Option<
+        unsafe extern "C" fn(
+            estate: *mut PLpgSQL_execstate,
+            target: *mut PLpgSQL_datum,
+            expr: *mut PLpgSQL_expr,
+        ),
+    >,
+    pub assign_value: ::std::option::Option<
+        unsafe extern "C" fn(
+            estate: *mut PLpgSQL_execstate,
+            target: *mut PLpgSQL_datum,
+            value: Datum,
+            isNull: bool,
+            valtype: Oid,
+            valtypmod: int32,
+        ),
+    >,
+    pub eval_datum: ::std::option::Option<
+        unsafe extern "C" fn(
+            estate: *mut PLpgSQL_execstate,
+            datum: *mut PLpgSQL_datum,
+            typeId: *mut Oid,
+            typetypmod: *mut int32,
+            value: *mut Datum,
+            isnull: *mut bool,
+        ),
+    >,
+    pub cast_value: ::std::option::Option<
+        unsafe extern "C" fn(
+            estate: *mut PLpgSQL_execstate,
+            value: Datum,
+            isnull: *mut bool,
+            valtype: Oid,
+            valtypmod: int32,
+            reqtype: Oid,
+            reqtypmod: int32,
+        ) -> Datum,
+    >,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLword {
+    pub ident: *mut ::std::os::raw::c_char,
+    pub quoted: bool,
+}
+impl Default for PLword {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLcword {
+    pub idents: *mut List,
+}
+impl Default for PLcword {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PLwdatum {
+    pub datum: *mut PLpgSQL_datum,
+    pub ident: *mut ::std::os::raw::c_char,
+    pub quoted: bool,
+    pub idents: *mut List,
+}
+impl Default for PLwdatum {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub const IdentifierLookup_IDENTIFIER_LOOKUP_NORMAL: IdentifierLookup = 0;
+pub const IdentifierLookup_IDENTIFIER_LOOKUP_DECLARE: IdentifierLookup = 1;
+pub const IdentifierLookup_IDENTIFIER_LOOKUP_EXPR: IdentifierLookup = 2;
+#[doc = " Global variable declarations"]
+pub type IdentifierLookup = ::std::os::raw::c_uint;
+extern "C" {
+    pub static mut plpgsql_IdentifierLookup: IdentifierLookup;
+}
+extern "C" {
+    pub static mut plpgsql_variable_conflict: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut plpgsql_print_strict_params: bool;
+}
+extern "C" {
+    pub static mut plpgsql_check_asserts: bool;
+}
+extern "C" {
+    pub static mut plpgsql_extra_warnings: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut plpgsql_extra_errors: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut plpgsql_check_syntax: bool;
+}
+extern "C" {
+    pub static mut plpgsql_DumpExecTree: bool;
+}
+extern "C" {
+    pub static mut plpgsql_parse_result: *mut PLpgSQL_stmt_block;
+}
+extern "C" {
+    pub static mut plpgsql_nDatums: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut plpgsql_Datums: *mut *mut PLpgSQL_datum;
+}
+extern "C" {
+    pub static mut plpgsql_error_funcname: *mut ::std::os::raw::c_char;
+}
+extern "C" {
+    pub static mut plpgsql_curr_compile: *mut PLpgSQL_function;
+}
+extern "C" {
+    pub static mut plpgsql_compile_tmp_cxt: MemoryContext;
+}
+extern "C" {
+    pub static mut plpgsql_plugin_ptr: *mut *mut PLpgSQL_plugin;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    #[doc = " Function declarations"]
+    pub fn plpgsql_compile(fcinfo: FunctionCallInfo, forValidator: bool) -> *mut PLpgSQL_function;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_compile_inline(
+        proc_source: *mut ::std::os::raw::c_char,
+    ) -> *mut PLpgSQL_function;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_parser_setup(pstate: *mut ParseState, expr: *mut PLpgSQL_expr);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_parse_word(
+        word1: *mut ::std::os::raw::c_char,
+        yytxt: *const ::std::os::raw::c_char,
+        lookup: bool,
+        wdatum: *mut PLwdatum,
+        word: *mut PLword,
+    ) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_parse_dblword(
+        word1: *mut ::std::os::raw::c_char,
+        word2: *mut ::std::os::raw::c_char,
+        wdatum: *mut PLwdatum,
+        cword: *mut PLcword,
+    ) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_parse_tripword(
+        word1: *mut ::std::os::raw::c_char,
+        word2: *mut ::std::os::raw::c_char,
+        word3: *mut ::std::os::raw::c_char,
+        wdatum: *mut PLwdatum,
+        cword: *mut PLcword,
+    ) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_parse_wordtype(ident: *mut ::std::os::raw::c_char) -> *mut PLpgSQL_type;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_parse_cwordtype(idents: *mut List) -> *mut PLpgSQL_type;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_parse_wordrowtype(ident: *mut ::std::os::raw::c_char) -> *mut PLpgSQL_type;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_parse_cwordrowtype(idents: *mut List) -> *mut PLpgSQL_type;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_build_datatype(
+        typeOid: Oid,
+        typmod: int32,
+        collation: Oid,
+        origtypname: *mut TypeName,
+    ) -> *mut PLpgSQL_type;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_build_variable(
+        refname: *const ::std::os::raw::c_char,
+        lineno: ::std::os::raw::c_int,
+        dtype: *mut PLpgSQL_type,
+        add2namespace: bool,
+    ) -> *mut PLpgSQL_variable;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_build_record(
+        refname: *const ::std::os::raw::c_char,
+        lineno: ::std::os::raw::c_int,
+        dtype: *mut PLpgSQL_type,
+        rectypeid: Oid,
+        add2namespace: bool,
+    ) -> *mut PLpgSQL_rec;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_build_recfield(
+        rec: *mut PLpgSQL_rec,
+        fldname: *const ::std::os::raw::c_char,
+    ) -> *mut PLpgSQL_recfield;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_recognize_err_condition(
+        condname: *const ::std::os::raw::c_char,
+        allow_sqlstate: bool,
+    ) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_parse_err_condition(
+        condname: *mut ::std::os::raw::c_char,
+    ) -> *mut PLpgSQL_condition;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_adddatum(newdatum: *mut PLpgSQL_datum);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_add_initdatums(varnos: *mut *mut ::std::os::raw::c_int)
+        -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_HashTableInit();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn _PG_init();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_exec_function(
+        func: *mut PLpgSQL_function,
+        fcinfo: FunctionCallInfo,
+        simple_eval_estate: *mut EState,
+        simple_eval_resowner: ResourceOwner,
+        procedure_resowner: ResourceOwner,
+        atomic: bool,
+    ) -> Datum;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_exec_trigger(
+        func: *mut PLpgSQL_function,
+        trigdata: *mut TriggerData,
+    ) -> HeapTuple;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_exec_event_trigger(func: *mut PLpgSQL_function, trigdata: *mut EventTriggerData);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_xact_cb(event: XactEvent, arg: *mut ::std::os::raw::c_void);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_subxact_cb(
+        event: SubXactEvent,
+        mySubid: SubTransactionId,
+        parentSubid: SubTransactionId,
+        arg: *mut ::std::os::raw::c_void,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_exec_get_datum_type(
+        estate: *mut PLpgSQL_execstate,
+        datum: *mut PLpgSQL_datum,
+    ) -> Oid;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_exec_get_datum_type_info(
+        estate: *mut PLpgSQL_execstate,
+        datum: *mut PLpgSQL_datum,
+        typeId: *mut Oid,
+        typMod: *mut int32,
+        collation: *mut Oid,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_ns_init();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_ns_push(label: *const ::std::os::raw::c_char, label_type: PLpgSQL_label_type);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_ns_pop();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_ns_top() -> *mut PLpgSQL_nsitem;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_ns_additem(
+        itemtype: PLpgSQL_nsitem_type,
+        itemno: ::std::os::raw::c_int,
+        name: *const ::std::os::raw::c_char,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_ns_lookup(
+        ns_cur: *mut PLpgSQL_nsitem,
+        localmode: bool,
+        name1: *const ::std::os::raw::c_char,
+        name2: *const ::std::os::raw::c_char,
+        name3: *const ::std::os::raw::c_char,
+        names_used: *mut ::std::os::raw::c_int,
+    ) -> *mut PLpgSQL_nsitem;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_ns_lookup_label(
+        ns_cur: *mut PLpgSQL_nsitem,
+        name: *const ::std::os::raw::c_char,
+    ) -> *mut PLpgSQL_nsitem;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_ns_find_nearest_loop(ns_cur: *mut PLpgSQL_nsitem) -> *mut PLpgSQL_nsitem;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_stmt_typename(stmt: *mut PLpgSQL_stmt) -> *const ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_getdiag_kindname(kind: PLpgSQL_getdiag_kind) -> *const ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_free_function_memory(func: *mut PLpgSQL_function);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_dumptree(func: *mut PLpgSQL_function);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_base_yylex() -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_yylex() -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_push_back_token(token: ::std::os::raw::c_int);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_token_is_unreserved_keyword(token: ::std::os::raw::c_int) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_append_source_text(
+        buf: StringInfo,
+        startlocation: ::std::os::raw::c_int,
+        endlocation: ::std::os::raw::c_int,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_peek() -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_peek2(
+        tok1_p: *mut ::std::os::raw::c_int,
+        tok2_p: *mut ::std::os::raw::c_int,
+        tok1_loc: *mut ::std::os::raw::c_int,
+        tok2_loc: *mut ::std::os::raw::c_int,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_scanner_errposition(location: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_yyerror(message: *const ::std::os::raw::c_char);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_location_to_lineno(location: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_latest_lineno() -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_scanner_init(str_: *const ::std::os::raw::c_char);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_scanner_finish();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn plpgsql_yyparse() -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub static mut logical_decoding_work_mem: ::std::os::raw::c_int;
@@ -45997,6 +48220,61 @@ extern "C" {
         include_triggers: bool,
         include_cols: *mut Bitmapset,
     ) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct RowSecurityPolicy {
+    pub policy_name: *mut ::std::os::raw::c_char,
+    pub polcmd: ::std::os::raw::c_char,
+    pub roles: *mut ArrayType,
+    pub permissive: bool,
+    pub qual: *mut Expr,
+    pub with_check_qual: *mut Expr,
+    pub hassublinks: bool,
+}
+impl Default for RowSecurityPolicy {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct RowSecurityDesc {
+    pub rscxt: MemoryContext,
+    pub policies: *mut List,
+}
+impl Default for RowSecurityDesc {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type row_security_policy_hook_type =
+    ::std::option::Option<unsafe extern "C" fn(cmdtype: CmdType, relation: Relation) -> *mut List>;
+extern "C" {
+    pub static mut row_security_policy_hook_permissive: row_security_policy_hook_type;
+}
+extern "C" {
+    pub static mut row_security_policy_hook_restrictive: row_security_policy_hook_type;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_row_security_policies(
+        root: *mut Query,
+        rte: *mut RangeTblEntry,
+        rt_index: ::std::os::raw::c_int,
+        securityQuals: *mut *mut List,
+        withCheckOptions: *mut *mut List,
+        hasRowSecurity: *mut bool,
+        hasSubLinks: *mut bool,
+    );
 }
 extern "C" {
     pub static mut old_snapshot_threshold: ::std::os::raw::c_int;
@@ -61748,161 +64026,6 @@ extern "C" {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct DomainConstraintCache {
-    _unused: [u8; 0],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct TypeCacheEnumData {
-    _unused: [u8; 0],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct TypeCacheEntry {
-    pub type_id: Oid,
-    pub type_id_hash: uint32,
-    pub typlen: int16,
-    pub typbyval: bool,
-    pub typalign: ::std::os::raw::c_char,
-    pub typstorage: ::std::os::raw::c_char,
-    pub typtype: ::std::os::raw::c_char,
-    pub typrelid: Oid,
-    pub typsubscript: Oid,
-    pub typelem: Oid,
-    pub typcollation: Oid,
-    pub btree_opf: Oid,
-    pub btree_opintype: Oid,
-    pub hash_opf: Oid,
-    pub hash_opintype: Oid,
-    pub eq_opr: Oid,
-    pub lt_opr: Oid,
-    pub gt_opr: Oid,
-    pub cmp_proc: Oid,
-    pub hash_proc: Oid,
-    pub hash_extended_proc: Oid,
-    pub eq_opr_finfo: FmgrInfo,
-    pub cmp_proc_finfo: FmgrInfo,
-    pub hash_proc_finfo: FmgrInfo,
-    pub hash_extended_proc_finfo: FmgrInfo,
-    pub tupDesc: TupleDesc,
-    pub tupDesc_identifier: uint64,
-    pub rngelemtype: *mut TypeCacheEntry,
-    pub rng_collation: Oid,
-    pub rng_cmp_proc_finfo: FmgrInfo,
-    pub rng_canonical_finfo: FmgrInfo,
-    pub rng_subdiff_finfo: FmgrInfo,
-    pub rngtype: *mut TypeCacheEntry,
-    pub domainBaseType: Oid,
-    pub domainBaseTypmod: int32,
-    pub domainData: *mut DomainConstraintCache,
-    pub flags: ::std::os::raw::c_int,
-    pub enumData: *mut TypeCacheEnumData,
-    pub nextDomain: *mut TypeCacheEntry,
-}
-impl Default for TypeCacheEntry {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct DomainConstraintRef {
-    pub constraints: *mut List,
-    pub refctx: MemoryContext,
-    pub tcache: *mut TypeCacheEntry,
-    pub need_exprstate: bool,
-    pub dcc: *mut DomainConstraintCache,
-    pub callback: MemoryContextCallback,
-}
-impl Default for DomainConstraintRef {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct SharedRecordTypmodRegistry {
-    _unused: [u8; 0],
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn lookup_type_cache(type_id: Oid, flags: ::std::os::raw::c_int) -> *mut TypeCacheEntry;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn InitDomainConstraintRef(
-        type_id: Oid,
-        ref_: *mut DomainConstraintRef,
-        refctx: MemoryContext,
-        need_exprstate: bool,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn UpdateDomainConstraintRef(ref_: *mut DomainConstraintRef);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn DomainHasConstraints(type_id: Oid) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn lookup_rowtype_tupdesc(type_id: Oid, typmod: int32) -> TupleDesc;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn lookup_rowtype_tupdesc_noerror(type_id: Oid, typmod: int32, noError: bool) -> TupleDesc;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn lookup_rowtype_tupdesc_copy(type_id: Oid, typmod: int32) -> TupleDesc;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn lookup_rowtype_tupdesc_domain(type_id: Oid, typmod: int32, noError: bool) -> TupleDesc;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn assign_record_type_typmod(tupDesc: TupleDesc);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn assign_record_type_identifier(type_id: Oid, typmod: int32) -> uint64;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn compare_values_of_enum(
-        tcache: *mut TypeCacheEntry,
-        arg1: Oid,
-        arg2: Oid,
-    ) -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn SharedRecordTypmodRegistryEstimate() -> usize;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn SharedRecordTypmodRegistryInit(
-        arg1: *mut SharedRecordTypmodRegistry,
-        segment: *mut dsm_segment,
-        area: *mut dsa_area,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn SharedRecordTypmodRegistryAttach(arg1: *mut SharedRecordTypmodRegistry);
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
 pub struct RangeType {
     pub vl_len_: int32,
     pub rangetypid: Oid,
@@ -62228,11 +64351,6 @@ pub struct TupleQueueReader {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct _MdfdVec {
-    pub _address: u8,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct RowSecurityDesc {
     pub _address: u8,
 }
 #[repr(C)]

--- a/pgrx-sql-entity-graph/Cargo.toml
+++ b/pgrx-sql-entity-graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx-sql-entity-graph"
-version = "0.7.4"
+version = "0.8.0"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Sql Entity Graph for `pgrx`"

--- a/pgrx-tests/Cargo.toml
+++ b/pgrx-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx-tests"
-version = "0.7.4"
+version = "0.8.0"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Test framework for 'pgrx'-based Postgres extensions"
@@ -36,11 +36,11 @@ rustdoc-args = ["--cfg", "docsrs"]
 clap-cargo = "0.10.0"
 owo-colors = "3.5.0"
 once_cell = "1.17.1"
-libc = "0.2.141"
-pgrx-macros = { path = "../pgrx-macros", version = "=0.7.4" }
-pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.7.4" }
+libc = "0.2.142"
+pgrx-macros = { path = "../pgrx-macros", version = "=0.8.0" }
+pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.8.0" }
 postgres = "0.19.5"
-regex = "1.7.3"
+regex = "1.8.1"
 serde = "1.0.160"
 serde_json = "1.0.96"
 sysinfo = "0.28.4"
@@ -55,4 +55,4 @@ eyre = "0.6.8"  # testing functions that return `eyre::Result`
 path = "../pgrx"
 default-features = false
 features = [ "time-crate" ] # testing purposes
-version = "=0.7.4"
+version = "=0.8.0"

--- a/pgrx/Cargo.toml
+++ b/pgrx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx"
-version = "0.7.4"
+version = "0.8.0"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "pgrx:  A Rust framework for creating Postgres extensions"
@@ -34,9 +34,9 @@ no-default-features = true
 rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-pgrx-macros = { path = "../pgrx-macros", version = "=0.7.4" }
-pgrx-pg-sys = { path = "../pgrx-pg-sys", version = "=0.7.4" }
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.7.4" }
+pgrx-macros = { path = "../pgrx-macros", version = "=0.8.0" }
+pgrx-pg-sys = { path = "../pgrx-pg-sys", version = "=0.8.0" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.8.0" }
 
 # used to internally impl things
 once_cell = "1.17.1" # polyfill until std::lazy::OnceCell stabilizes
@@ -54,7 +54,7 @@ atomic-traits = "0.3.0" # PgAtomic and shmem init
 bitflags = "1.3.2" # BackgroundWorker
 bitvec = "1.0" # processing array nullbitmaps
 heapless = "0.7.16" # shmem and PgLwLock
-libc = "0.2.141" # FFI type compat
+libc = "0.2.142" # FFI type compat
 seahash = "4.1.0" # derive(PostgresHash)
 serde = { version = "1.0.160", features = [ "derive" ] } # impls on pub types
 serde_cbor = "0.11.2" # derive(PostgresType)


### PR DESCRIPTION
Welcome to pgrx v0.8.0 (formally known as pgx).  This release of pgrx comes with a number of bugfixes, features, and breaking API changes.


## Upgrading

When upgrading, you'll likely want to remove the old "pgx" from your system:

```bash
cargo pgx stop all                # from inside an extension crate still using pgx
cargo uninstall cargo-pgx
cargo install cargo-pgrx --locked
cargo pgrx init
```

This will remove the old `cargo-pgx` binary, install the new `cargo-pgrx` binary, and initialize it.  This means your development databases will be re-created in, by default, `~/.pgrx`.  


## What's Changed


### Breaking Changes

#### We Have a New Name


We're working on some exciting near-term plans for pgrx and in order to accomplish these goals it was necessary to rename the project.  The last thing we want is direct confusion with other open-source projects and corporations also operating in the PostgreSQL space.


 * Rename to pgrx by @eeeebbbbrrrr in https://github.com/tcdi/pgrx/pull/1107
 * `PgXactCallbackEvent` shouldn't have been renamed! by @eeeebbbbrrrr in https://github.com/tcdi/pgrx/pull/1108
 * Fix broken links to zombodb/pgrx by @syvb in https://github.com/tcdi/pgrx/pull/1109
 * Fix pgrx@crates.io link in CONTRIBUTING.md by @workingjubilee in https://github.com/tcdi/pgrx/pull/1110

#### UTF8 Support

Postgres supports numerous database encodings.  Rust only supports UTF8, which here in 2023 is generally what everyone uses in Postgres anyways. These commits cause pgrx to raise ERRORs in cases when it tries to convert a Postgres "string" into a Rust string and it's not valid UTF8.  Previously, pgrx blindly did this conversion which could have led to undefined behavior.  The detection is minimal-to-no overhead in the case where the database is UTF8 -- it's non-UTF8 encodings where we have to validate compatibility string-by-string.

 * Enforce UTF-8 correctness by @workingjubilee in https://github.com/tcdi/pgrx/pull/1094
 * Memoize DB encoding for faster validation by @workingjubilee in https://github.com/tcdi/pgrx/pull/1095

#### Arrays

The pgrx `Array` type has been drastically overhauled to be properly safe and nearly zero-copy.  This means that pgrx is now capable of directly decoding the binary Postgres array format without asking Postgres to deconstruct it into an array of Datums.  In the common cases of pass-by-value Datums (ie, `i32`, `f32`), `Array` is truly zero-copy.  For arrays of "varlena" types like `String`, Datum conversions still occur, but the general overhead is drastically reduced.

The various `Array` iterators take advantage of this as well.

 * Use zero-copy Arrays in `--release` by @workingjubilee in https://github.com/tcdi/pgrx/pull/1116
 * Fixup iterator impls for Array by @workingjubilee in https://github.com/tcdi/pgrx/pull/1115
 * Carry less usizes in Array by @workingjubilee in https://github.com/tcdi/pgrx/pull/1120
 * Make `Array::as_slice` unsafe by @thomcc in https://github.com/tcdi/pgrx/pull/1083
 * Remove `Array::as_slice` by @workingjubilee in https://github.com/tcdi/pgrx/pull/1119

#### `direct_function_call`

The `direct_function_call()` method now takes a slice for its argument `Option<Datum>` array instead of a `Vec<Option<Datum>>`.  This will avoid a heap allocation for every usage of this function, making it a little more lightweight.

 * Use a slice instead of a vec in direct_function_call and related functions by @thomcc in https://github.com/tcdi/pgrx/pull/1084


### New Things

#### `cargo-pgrx`

In their first contribution, @azam taught the various `cargo-pgrx` commands to understand the `lib.name` property from the extension's `Cargo.toml`.  If present, this will be used to name the resulting shared library.  There's an example for this in [`./pgrx-examples/custom_libname`](./pgrx-examples/custom_libname), but we're talking about, in `Cargo.toml`:

```toml
[lib]
crate-type = ["cdylib"]
name = "other_name"	# you can rename the extension with this
```
 * Support for library with different name than crate name by @azam in https://github.com/tcdi/pgrx/pull/1100


And @yrashk, in yet-another-great-contribution, has given `cargo-pgrx` an `info` command.  `cargo pgrx info` has a number of subcommands to report various information about the cargo-pgrx runtime like Postgres installation paths, `pg_config` paths, and version information.

 * Add `cargo pgrx info` command family by @yrashk in https://github.com/tcdi/pgrx/pull/1092


#### Spi

pgrx's Spi implementation will automatically/transparently use `read_only = false` statements when it detects the current transaction has previously been modified.  We used to handle this via a pair of transaction callback hooks, and its understanding of "has the current transaction been modified" was limited to what might have happened only in the pgrx extension.  We now better detect this, regardless of what modified the transaction, and also do it without transaction callback hooks.

 * No xact callback for spi mutability by @eeeebbbbrrrr in https://github.com/tcdi/pgrx/pull/1104


#### `#[pg_extern]`


`#[pg_extern]` now supports `security_invoker` and `security_definer` properties.  If neither is specified, `security_invoker` is the default, as per the `CREATE FUNCTION` specification.

 * Add support for explicitly specifying SECURITY INVOKER/DEFINER functions by @JohnHVancouver in https://github.com/tcdi/pgrx/pull/1097

#### `impl Sum/Default for AnyNumeric`

The `AnyNumeric` type is now able to be used by the `std::iter::Sum` trait to, for example, sum the values of an iterator of `AnyNumeric`s, perhaps coming from `Array<AnyNumeric>`.

 * impl `Sum` and `Default` for `AnyNumeric` by @eeeebbbbrrrr in https://github.com/tcdi/pgrx/pull/1117

#### More Headers

`catalog/objectaccess.h`, `commands/user.h`, `optimizer/plancat.h`, `plpgsql.h`, and `rewrite/rowsecurity.h` are now included as part of the pgrx Rust bindings.
 
 * pgrx-pg-sys: include more headers with hooks by @skyzh in https://github.com/tcdi/pgrx/pull/1077



#### QoL Improvements

* Allow `clippy::no_mangle_with_rust_abi` in the entity graph by @thomcc in https://github.com/tcdi/pgrx/pull/1080
* Bump openssl/openssl-sys by @thomcc in https://github.com/tcdi/pgrx/pull/1089
* Avoid some slow HashMap usage where possible by @thomcc in https://github.com/tcdi/pgrx/pull/1075
* An example of how to create a custom type from scratch. by @eeeebbbbrrrr in https://github.com/tcdi/pgrx/pull/1113
* Cleanup `build.rs` and friends issue #1111 by @eeeebbbbrrrr in https://github.com/tcdi/pgrx/pull/1112



### Misc Changes

* Discuss multithreading ergonomics by @workingjubilee in https://github.com/tcdi/pgrx/pull/1081
* Add links to recently published posts on tcdioss.tcdi.com by @rustprooflabs in https://github.com/tcdi/pgrx/pull/1088



## New Contributors

* @JohnHVancouver made their first contribution in https://github.com/tcdi/pgrx/pull/1097
* @azam made their first contribution in https://github.com/tcdi/pgrx/pull/1100

**Full Changelog**: https://github.com/tcdi/pgrx/compare/v0.7.4...v0.8.0