### PR TITLE
fix bug with `impl<'a> FromDatum for &'a CStr`

### DIFF
--- a/pgrx-sql-entity-graph/src/metadata/sql_translatable.rs
+++ b/pgrx-sql-entity-graph/src/metadata/sql_translatable.rs
@@ -342,6 +342,16 @@ unsafe impl SqlTranslatable for f64 {
     }
 }
 
+extern crate alloc;
+unsafe impl SqlTranslatable for alloc::ffi::CString {
+    fn argument_sql() -> Result<SqlMapping, ArgumentError> {
+        Ok(SqlMapping::literal("cstring"))
+    }
+    fn return_sql() -> Result<Returns, ReturnsError> {
+        Ok(Returns::One(SqlMapping::literal("cstring")))
+    }
+}
+
 unsafe impl SqlTranslatable for core::ffi::CStr {
     fn argument_sql() -> Result<SqlMapping, ArgumentError> {
         Ok(SqlMapping::literal("cstring"))
@@ -351,7 +361,7 @@ unsafe impl SqlTranslatable for core::ffi::CStr {
     }
 }
 
-unsafe impl SqlTranslatable for &'static core::ffi::CStr {
+unsafe impl SqlTranslatable for &'_ core::ffi::CStr {
     fn argument_sql() -> Result<SqlMapping, ArgumentError> {
         Ok(SqlMapping::literal("cstring"))
     }


### PR DESCRIPTION
It needs to know how to copy itself into a different `MemoryContext`.

Also add a `impl SqlTranslatable for CString` and relax the lifetime bounds on the impl for `&CStr`