### PR TITLE
Update version to 0.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e579a7752471abc2a8268df8b20005e3eadd975f585398f17efcfd8d4927371"
+checksum = "6342bd4f5a1205d7f41e94a41a901f5647c938cdfa96036338e8533c9d6c2450"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -82,9 +82,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcd8291a340dd8ac70e18878bc4501dd7b4ff970cfa21c207d36ece51ea88fd"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
 dependencies = [
  "anstyle",
  "windows-sys 0.48.0",
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-pgrx"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "atty",
  "cargo_metadata",
@@ -1344,9 +1344,9 @@ checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "openssl"
-version = "0.10.51"
+version = "0.10.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97ea2d98598bf9ada7ea6ee8a30fb74f9156b63bbe495d64ec2b87c269d2dda3"
+checksum = "01b8574602df80f7b85fdfc5392fa884a4e3b3f4f35402c070ab34c3d3f78d56"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1376,9 +1376,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.86"
+version = "0.9.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "992bac49bdbab4423199c654a5515bd2a6c6a23bf03f2dd3bdb7e5ae6259bc69"
+checksum = "8e17f59264b2809d77ae94f0e1ebabc434773f370d6ca667bd223ea10e06cc7e"
 dependencies = [
  "cc",
  "libc",
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "atomic-traits",
  "bitflags",
@@ -1503,7 +1503,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-macros"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "pgrx-sql-entity-graph",
  "proc-macro2",
@@ -1514,7 +1514,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-config"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "cargo_toml",
  "dirs",
@@ -1530,7 +1530,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-sys"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "bindgen",
  "eyre",
@@ -1550,7 +1550,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-sql-entity-graph"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "atty",
  "convert_case",
@@ -1566,7 +1566,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-tests"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "clap-cargo",
  "eyre",
@@ -2557,11 +2557,10 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "cf9cf6a813d3f40c88b0b6b6f29a5c95c6cdbf97c1f9cc53fb820200f5ad814d"
 dependencies = [
- "cfg-if",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2569,13 +2568,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
 ]
 
 [[package]]

--- a/cargo-pgrx/Cargo.toml
+++ b/cargo-pgrx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pgrx"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Cargo subcommand for 'pgrx' to make Postgres extension development easy"
@@ -23,8 +23,8 @@ semver = "1.0.17"
 owo-colors = { version = "3.5.0", features = [ "supports-colors" ] }
 env_proxy = "0.4.1"
 num_cpus = "1.15.0"
-pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.8.0" }
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.8.0" }
+pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.8.1" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.8.1" }
 prettyplease = "0.1.25"
 proc-macro2 = { version = "1.0.56", features = [ "span-locations" ] }
 quote = "1.0.26"
@@ -43,7 +43,7 @@ object = "0.30.3"
 once_cell = "1.17.1"
 eyre = "0.6.8"
 color-eyre = "0.6.2"
-tracing = "0.1.37"
+tracing = "0.1.38"
 tracing-error = "0.2.0"
 tracing-subscriber = { version = "0.3.17", features = [ "env-filter" ] }
 flate2 = { version = "1.0.25", default-features = false, features = ["rust_backend"] }

--- a/cargo-pgrx/src/templates/cargo_toml
+++ b/cargo-pgrx/src/templates/cargo_toml
@@ -16,10 +16,10 @@ pg15 = ["pgrx/pg15", "pgrx-tests/pg15" ]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.8.0"
+pgrx = "=0.8.1"
 
 [dev-dependencies]
-pgrx-tests = "=0.8.0"
+pgrx-tests = "=0.8.1"
 
 [profile.dev]
 panic = "unwind"

--- a/nix/templates/default/Cargo.toml
+++ b/nix/templates/default/Cargo.toml
@@ -16,10 +16,10 @@ pg15 = ["pgrx/pg15", "pgrx-tests/pg15" ]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.8.0"
+pgrx = "=0.8.1"
 
 [dev-dependencies]
-pgrx-tests = "=0.8.0"
+pgrx-tests = "=0.8.1"
 tempfile = "3.2.0"
 once_cell = "1.7.2"
 

--- a/pgrx-macros/Cargo.toml
+++ b/pgrx-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx-macros"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Proc Macros for 'pgrx'"
@@ -21,7 +21,7 @@ rustc-args = ["--cfg", "docsrs"]
 no-schema-generation = ["pgrx-sql-entity-graph/no-schema-generation"]
 
 [dependencies]
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.8.0" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.8.1" }
 proc-macro2 = "1.0.56"
 quote = "1.0.26"
 syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsing" ] }

--- a/pgrx-pg-config/Cargo.toml
+++ b/pgrx-pg-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx-pg-config"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "A Postgres pg_config wrapper for 'pgrx'"

--- a/pgrx-pg-sys/Cargo.toml
+++ b/pgrx-pg-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx-pg-sys"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Generated Rust bindings for Postgres internals, for use with 'pgrx'"
@@ -29,8 +29,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 memoffset = "0.8.0"
-pgrx-macros = { path = "../pgrx-macros/", version = "=0.8.0" }
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph/", version = "=0.8.0" }
+pgrx-macros = { path = "../pgrx-macros/", version = "=0.8.1" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph/", version = "=0.8.1" }
 serde = { version = "1.0.160", features = [ "derive" ] } # impls on pub types
 # polyfill until #![feature(strict_provenance)] stabilizes
 sptr = "0.3"
@@ -38,7 +38,7 @@ libc = "0.2"
 
 [build-dependencies]
 bindgen = { version = "0.60.1", default-features = false, features = ["runtime"] }
-pgrx-pg-config= { path = "../pgrx-pg-config/", version = "=0.8.0" }
+pgrx-pg-config= { path = "../pgrx-pg-config/", version = "=0.8.1" }
 proc-macro2 = "1.0.56"
 quote = "1.0.26"
 syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsing" ] }

--- a/pgrx-sql-entity-graph/Cargo.toml
+++ b/pgrx-sql-entity-graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx-sql-entity-graph"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Sql Entity Graph for `pgrx`"

--- a/pgrx-tests/Cargo.toml
+++ b/pgrx-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx-tests"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Test framework for 'pgrx'-based Postgres extensions"
@@ -37,8 +37,8 @@ clap-cargo = "0.10.0"
 owo-colors = "3.5.0"
 once_cell = "1.17.1"
 libc = "0.2.142"
-pgrx-macros = { path = "../pgrx-macros", version = "=0.8.0" }
-pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.8.0" }
+pgrx-macros = { path = "../pgrx-macros", version = "=0.8.1" }
+pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.8.1" }
 postgres = "0.19.5"
 regex = "1.8.1"
 serde = "1.0.160"
@@ -55,4 +55,4 @@ eyre = "0.6.8"  # testing functions that return `eyre::Result`
 path = "../pgrx"
 default-features = false
 features = [ "time-crate" ] # testing purposes
-version = "=0.8.0"
+version = "=0.8.1"

--- a/pgrx/Cargo.toml
+++ b/pgrx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "pgrx:  A Rust framework for creating Postgres extensions"
@@ -34,9 +34,9 @@ no-default-features = true
 rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-pgrx-macros = { path = "../pgrx-macros", version = "=0.8.0" }
-pgrx-pg-sys = { path = "../pgrx-pg-sys", version = "=0.8.0" }
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.8.0" }
+pgrx-macros = { path = "../pgrx-macros", version = "=0.8.1" }
+pgrx-pg-sys = { path = "../pgrx-pg-sys", version = "=0.8.1" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.8.1" }
 
 # used to internally impl things
 once_cell = "1.17.1" # polyfill until std::lazy::OnceCell stabilizes
@@ -46,7 +46,7 @@ enum-map = "2.5.0"
 
 # error handling and logging
 thiserror = "1.0"
-tracing = "0.1.37"
+tracing = "0.1.38"
 tracing-error = "0.2.0"
 
 # exposed in public API


### PR DESCRIPTION
This is pgrx v0.8.1.  It fixes a UAF issue when working with `CStr` datums.

As usual, when upgrading, make sure to do `cargo install cargo-pgrx --locked`.

## What's Changed

* fix bug with `impl<'a> FromDatum for &'a CStr` by @eeeebbbbrrrr in https://github.com/tcdi/pgrx/pull/1123


**Full Changelog**: https://github.com/tcdi/pgrx/compare/v0.8.0...asdfasdf