### PR TITLE
Update version to 0.8.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-pgrx"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "atty",
  "cargo_metadata",
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "atomic-traits",
  "bitflags",
@@ -1503,7 +1503,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-macros"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "pgrx-sql-entity-graph",
  "proc-macro2",
@@ -1514,7 +1514,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-config"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "cargo_toml",
  "dirs",
@@ -1530,7 +1530,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-sys"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "bindgen",
  "eyre",
@@ -1550,7 +1550,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-sql-entity-graph"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "atty",
  "convert_case",
@@ -1566,7 +1566,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-tests"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "clap-cargo",
  "eyre",

--- a/cargo-pgrx/Cargo.toml
+++ b/cargo-pgrx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pgrx"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Cargo subcommand for 'pgrx' to make Postgres extension development easy"
@@ -23,8 +23,8 @@ semver = "1.0.17"
 owo-colors = { version = "3.5.0", features = [ "supports-colors" ] }
 env_proxy = "0.4.1"
 num_cpus = "1.15.0"
-pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.8.1" }
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.8.1" }
+pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.8.2" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.8.2" }
 prettyplease = "0.1.25"
 proc-macro2 = { version = "1.0.56", features = [ "span-locations" ] }
 quote = "1.0.26"

--- a/cargo-pgrx/src/templates/cargo_toml
+++ b/cargo-pgrx/src/templates/cargo_toml
@@ -16,10 +16,10 @@ pg15 = ["pgrx/pg15", "pgrx-tests/pg15" ]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.8.1"
+pgrx = "=0.8.2"
 
 [dev-dependencies]
-pgrx-tests = "=0.8.1"
+pgrx-tests = "=0.8.2"
 
 [profile.dev]
 panic = "unwind"

--- a/nix/templates/default/Cargo.toml
+++ b/nix/templates/default/Cargo.toml
@@ -16,10 +16,10 @@ pg15 = ["pgrx/pg15", "pgrx-tests/pg15" ]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.8.1"
+pgrx = "=0.8.2"
 
 [dev-dependencies]
-pgrx-tests = "=0.8.1"
+pgrx-tests = "=0.8.2"
 tempfile = "3.2.0"
 once_cell = "1.7.2"
 

--- a/pgrx-macros/Cargo.toml
+++ b/pgrx-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx-macros"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Proc Macros for 'pgrx'"
@@ -21,7 +21,7 @@ rustc-args = ["--cfg", "docsrs"]
 no-schema-generation = ["pgrx-sql-entity-graph/no-schema-generation"]
 
 [dependencies]
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.8.1" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.8.2" }
 proc-macro2 = "1.0.56"
 quote = "1.0.26"
 syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsing" ] }

--- a/pgrx-pg-config/Cargo.toml
+++ b/pgrx-pg-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx-pg-config"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "A Postgres pg_config wrapper for 'pgrx'"

--- a/pgrx-pg-sys/Cargo.toml
+++ b/pgrx-pg-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx-pg-sys"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Generated Rust bindings for Postgres internals, for use with 'pgrx'"
@@ -29,8 +29,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 memoffset = "0.8.0"
-pgrx-macros = { path = "../pgrx-macros/", version = "=0.8.1" }
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph/", version = "=0.8.1" }
+pgrx-macros = { path = "../pgrx-macros/", version = "=0.8.2" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph/", version = "=0.8.2" }
 serde = { version = "1.0.160", features = [ "derive" ] } # impls on pub types
 # polyfill until #![feature(strict_provenance)] stabilizes
 sptr = "0.3"
@@ -38,7 +38,7 @@ libc = "0.2"
 
 [build-dependencies]
 bindgen = { version = "0.60.1", default-features = false, features = ["runtime"] }
-pgrx-pg-config= { path = "../pgrx-pg-config/", version = "=0.8.1" }
+pgrx-pg-config= { path = "../pgrx-pg-config/", version = "=0.8.2" }
 proc-macro2 = "1.0.56"
 quote = "1.0.26"
 syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsing" ] }

--- a/pgrx-sql-entity-graph/Cargo.toml
+++ b/pgrx-sql-entity-graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx-sql-entity-graph"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Sql Entity Graph for `pgrx`"

--- a/pgrx-tests/Cargo.toml
+++ b/pgrx-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx-tests"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Test framework for 'pgrx'-based Postgres extensions"
@@ -37,8 +37,8 @@ clap-cargo = "0.10.0"
 owo-colors = "3.5.0"
 once_cell = "1.17.1"
 libc = "0.2.142"
-pgrx-macros = { path = "../pgrx-macros", version = "=0.8.1" }
-pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.8.1" }
+pgrx-macros = { path = "../pgrx-macros", version = "=0.8.2" }
+pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.8.2" }
 postgres = "0.19.5"
 regex = "1.8.1"
 serde = "1.0.160"
@@ -55,4 +55,4 @@ eyre = "0.6.8"  # testing functions that return `eyre::Result`
 path = "../pgrx"
 default-features = false
 features = [ "time-crate" ] # testing purposes
-version = "=0.8.1"
+version = "=0.8.2"

--- a/pgrx/Cargo.toml
+++ b/pgrx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "pgrx:  A Rust framework for creating Postgres extensions"
@@ -34,9 +34,9 @@ no-default-features = true
 rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-pgrx-macros = { path = "../pgrx-macros", version = "=0.8.1" }
-pgrx-pg-sys = { path = "../pgrx-pg-sys", version = "=0.8.1" }
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.8.1" }
+pgrx-macros = { path = "../pgrx-macros", version = "=0.8.2" }
+pgrx-pg-sys = { path = "../pgrx-pg-sys", version = "=0.8.2" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.8.2" }
 
 # used to internally impl things
 once_cell = "1.17.1" # polyfill until std::lazy::OnceCell stabilizes


### PR DESCRIPTION
pgrx v0.8.2 is a small bugfix release.

It fixes a bug decoding arrays of enums, and perhaps other pass-by-value datums, that could lead to reading past the end of the backing array structure along with fixing a regression regarding compilation speeds.

When upgrading, please make sure to run `cargo install cargo-pgrx --locked`.

## Changes

- PR #1125 - the `Array<T>` type can now properly decode T's that are enums annotated with `#[derive(PostgresEnum)]` and should also work properly with other pass-by-value datum types that require going through `FromDatum::from_datum()`.  This is a fairly important bugfix as with v0.8.0/1 it's possible for `Array<T>` to read past the end of the array.

- PR #1127 - due to no good deed going unpunished, and some over-zealousness in PR #1111, consecutive "cargo build" commands such as `cargo pgx run/test/install` would cause the `pgrx-pg-sys/build.rs` file to run again, causing a full rebuild of (at least) that crate.  This was an unintended side-effect and #1127 fixes it.

- PR #1128 - remove a few unused dependencies


**Full Changelog**: https://github.com/tcdi/pgrx/compare/v0.8.1...v0.8.2