### PR TITLE
Fix: remove wrong comma in SQL output of PgAggregateEntity

### DIFF
--- a/pgrx-sql-entity-graph/src/aggregate/entity.rs
+++ b/pgrx-sql-entity-graph/src/aggregate/entity.rs
@@ -462,7 +462,7 @@ impl ToSql for PgAggregateEntity {
                     );
                     args.push(buf);
                 }
-                "\n".to_string() + &args.join("\n,") + "\n"
+                "\n".to_string() + &args.join("\n") + "\n"
             } else {
                 String::default()
             },


### PR DESCRIPTION
Bugfix: In SQL output of PgAggregateEntity's direct argument too much commas are emitted, leading to invalid SQL code.