### PR TITLE
Within the NUMERIC support code, stop comparing function pointers

### DIFF
--- a/pgrx/src/datum/numeric.rs
+++ b/pgrx/src/datum/numeric.rs
@@ -12,7 +12,7 @@ use core::fmt::{Debug, Display, Formatter};
 use std::fmt;
 use std::iter::Sum;
 
-use crate::numeric_support::convert::from_primitive_helper;
+use crate::numeric_support::convert::{from_primitive_helper, FromPrimitiveFunc};
 pub use crate::numeric_support::error::Error;
 use crate::{direct_function_call, pg_sys, varsize, PgMemoryContexts};
 
@@ -250,6 +250,6 @@ impl<const P: u32, const S: u32> Numeric<P, S> {
     pub fn rescale<const NEW_P: u32, const NEW_S: u32>(
         self,
     ) -> Result<Numeric<NEW_P, NEW_S>, Error> {
-        from_primitive_helper::<_, NEW_P, NEW_S>(self, pg_sys::numeric)
+        from_primitive_helper::<_, NEW_P, NEW_S>(self, FromPrimitiveFunc::Numeric)
     }
 }

--- a/pgrx/src/datum/numeric_support/convert.rs
+++ b/pgrx/src/datum/numeric_support/convert.rs
@@ -11,31 +11,57 @@ use crate::{
 pub use super::convert_anynumeric::*;
 pub use super::convert_numeric::*;
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub(crate) enum FromPrimitiveFunc {
+    NumericIn,
+    Numeric,
+    Float4Numeric,
+    Float8Numeric,
+    Int2Numeric,
+    Int4Numeric,
+    Int8Numeric,
+}
+
+impl From<FromPrimitiveFunc> for unsafe fn(pg_sys::FunctionCallInfo) -> pg_sys::Datum {
+    fn from(value: FromPrimitiveFunc) -> Self {
+        match value {
+            FromPrimitiveFunc::NumericIn => pg_sys::numeric_in,
+            FromPrimitiveFunc::Numeric => pg_sys::numeric,
+            FromPrimitiveFunc::Float4Numeric => pg_sys::float4_numeric,
+            FromPrimitiveFunc::Float8Numeric => pg_sys::float8_numeric,
+            FromPrimitiveFunc::Int2Numeric => pg_sys::int2_numeric,
+            FromPrimitiveFunc::Int4Numeric => pg_sys::int4_numeric,
+            FromPrimitiveFunc::Int8Numeric => pg_sys::int8_numeric,
+        }
+    }
+}
+
 pub(crate) fn from_primitive_helper<I: IntoDatum, const P: u32, const S: u32>(
     value: I,
-    func: unsafe fn(pg_sys::FunctionCallInfo) -> pg_sys::Datum,
+    func: FromPrimitiveFunc,
 ) -> Result<Numeric<P, S>, Error> {
     let datum = value.into_datum();
     let materialize_numeric_datum = move || unsafe {
-        if func == pg_sys::numeric_in {
+        if func == FromPrimitiveFunc::NumericIn {
             debug_assert_eq!(I::type_oid(), pg_sys::CSTRINGOID);
             direct_function_call(
                 pg_sys::numeric_in,
                 &[datum, pg_sys::InvalidOid.into_datum(), make_typmod(P, S).into_datum()],
             )
-        } else if func == pg_sys::numeric {
+        } else if func == FromPrimitiveFunc::Numeric {
             debug_assert_eq!(I::type_oid(), pg_sys::NUMERICOID);
             direct_function_call(pg_sys::numeric, &[datum, make_typmod(P, S).into_datum()])
         } else {
-            debug_assert!(
-                func == pg_sys::float4_numeric
-                    || func == pg_sys::float8_numeric
-                    || func == pg_sys::int2_numeric
-                    || func == pg_sys::int4_numeric
-                    || func == pg_sys::int8_numeric
-            );
+            debug_assert!(matches!(
+                func,
+                FromPrimitiveFunc::Float4Numeric
+                    | FromPrimitiveFunc::Float8Numeric
+                    | FromPrimitiveFunc::Int2Numeric
+                    | FromPrimitiveFunc::Int4Numeric
+                    | FromPrimitiveFunc::Int8Numeric
+            ));
             // use the user-provided `func` to make a Numeric from some primitive type
-            let numeric_datum = direct_function_call_as_datum(func, &[datum]);
+            let numeric_datum = direct_function_call_as_datum(func.into(), &[datum]);
 
             if P != 0 || S != 0 {
                 // and if it has a precision or a scale, try to coerce it into those constraints


### PR DESCRIPTION
It seems this isn't a thing Rust does predictably and was causing some bizarre test failures in a different WIP branch.