### PR TITLE
fix issue #1141:  immediately report FATAL and PANIC

### DIFF
--- a/pgrx-examples/bad_ideas/src/lib.rs
+++ b/pgrx-examples/bad_ideas/src/lib.rs
@@ -10,9 +10,46 @@ use pgrx::prelude::*;
 use pgrx::{check_for_interrupts, info, register_xact_callback, PgRelation, PgXactCallbackEvent};
 use std::fs::File;
 use std::io::Write;
+use std::panic::catch_unwind;
 use std::process::Command;
 
 pgrx::pg_module_magic!();
+
+#[pg_extern]
+fn panic(s: &str) -> bool {
+    catch_unwind(|| {
+        PANIC!("{}", s);
+    })
+    .ok();
+    true
+}
+
+#[pg_extern]
+fn fatal(s: &str) -> bool {
+    catch_unwind(|| {
+        FATAL!("{}", s);
+    })
+    .ok();
+    true
+}
+
+#[pg_extern]
+fn error(s: &str) -> bool {
+    catch_unwind(|| {
+        error!("{}", s);
+    })
+    .ok();
+    true
+}
+
+#[pg_extern]
+fn warning(s: &str) -> bool {
+    catch_unwind(|| {
+        warning!("{}", s);
+    })
+    .ok();
+    true
+}
 
 #[pg_extern]
 fn exec<'a>(


### PR DESCRIPTION
Errors reported at the FATAL or PANIC levels should immediately be reported to Postgres since they ultimately abort the transaction.

ERRORs continue to be converted into panics, and everything else is also immediately reported to Postgres but since they only emit messages, there's no change to flow control.

As a drive-by, I also added a few functions to the "bad_ideas" example to interactively test this change.  It's not really feasible for the test suite to somehow test that a test causes the backend, or the entire cluster, to crash, which is what PANIC and FATAL do.