### PR TITLE
Add Array slice support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,7 @@ version = "0.1.0"
 dependencies = [
  "pgrx",
  "pgrx-tests",
+ "rand",
  "serde",
 ]
 

--- a/pgrx-examples/arrays/Cargo.toml
+++ b/pgrx-examples/arrays/Cargo.toml
@@ -18,6 +18,7 @@ pg_test = []
 [dependencies]
 pgrx = { path = "../../pgrx", default-features = false }
 serde = "1.0.163"
+rand = "*"
 
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }

--- a/pgrx-examples/arrays/src/lib.rs
+++ b/pgrx-examples/arrays/src/lib.rs
@@ -100,8 +100,74 @@ fn return_vec_of_customtype() -> Vec<SomeStruct> {
     vec![SomeStruct {}]
 }
 
+#[pg_schema]
+mod vectors {
+    use pgrx::prelude::*;
+
+    extension_sql!(
+        r#"
+            do $$ begin raise warning 'creating sample data in the table ''vectors.data''.'; end; $$;
+            create table vectors.data as select vectors.random_vector(768) v from generate_series(1, 100000);
+    "#,
+        name = "vectors_data",
+        requires = [random_vector]
+    );
+
+    #[pg_extern]
+    fn sum_vector_array(input: Array<f32>) -> f32 {
+        input.iter_deny_null().map(|v| v as f32).sum()
+    }
+
+    #[pg_extern]
+    fn sum_vector_vec(input: Vec<f32>) -> f32 {
+        input.into_iter().map(|v| v as f32).sum()
+    }
+
+    #[pg_extern]
+    fn sum_vector_slice(input: Array<f32>) -> Result<f32, ArrayError> {
+        Ok(input.as_slice()?.iter().map(|v| *v as f32).sum())
+    }
+
+    #[pg_extern]
+    pub fn sum_vector_simd(values: Array<f32>) -> Result<f32, ArrayError> {
+        // this comes directly from https://stackoverflow.com/questions/23100534/how-to-sum-the-values-in-an-array-slice-or-vec-in-rust/67191480#67191480
+        // and https://www.reddit.com/r/rust/comments/13q56bp/comment/jlgq2t6/?utm_source=share&utm_medium=web2x&context=3
+        //
+        // the expectation here is that the compiler will autovectorize this code using SIMD
+        use std::convert::TryInto;
+
+        const LANES: usize = 16;
+
+        let values = values.as_slice()?;
+        let chunks = values.chunks_exact(LANES);
+        let remainder = chunks.remainder();
+
+        let sum = chunks.fold([0.0f32; LANES], |mut acc, chunk| {
+            let chunk: [f32; LANES] = chunk.try_into().unwrap();
+            for i in 0..LANES {
+                acc[i] += chunk[i];
+            }
+            acc
+        });
+
+        let remainder: f32 = remainder.iter().copied().sum();
+
+        let mut reduced = 0.0f32;
+        for i in 0..LANES {
+            reduced += sum[i];
+        }
+        Ok(reduced + remainder)
+    }
+
+    #[pg_extern]
+    fn random_vector(len: i32) -> Vec<f32> {
+        (0..len).map(|_| rand::random()).collect()
+    }
+}
+
 #[cfg(test)]
 pub mod pg_test {
+    use pgrx::pg_schema;
 
     pub fn setup(_options: Vec<&str>) {
         // perform one-off initialization when the pg_test framework starts

--- a/pgrx-examples/arrays/src/lib.rs
+++ b/pgrx-examples/arrays/src/lib.rs
@@ -124,12 +124,12 @@ mod vectors {
     }
 
     #[pg_extern]
-    fn sum_vector_slice(input: Array<f32>) -> Result<f32, ArrayError> {
+    fn sum_vector_slice(input: Array<f32>) -> Result<f32, ArraySliceError> {
         Ok(input.as_slice()?.iter().map(|v| *v as f32).sum())
     }
 
     #[pg_extern]
-    pub fn sum_vector_simd(values: Array<f32>) -> Result<f32, ArrayError> {
+    pub fn sum_vector_simd(values: Array<f32>) -> Result<f32, ArraySliceError> {
         // this comes directly from https://stackoverflow.com/questions/23100534/how-to-sum-the-values-in-an-array-slice-or-vec-in-rust/67191480#67191480
         // and https://www.reddit.com/r/rust/comments/13q56bp/comment/jlgq2t6/?utm_source=share&utm_medium=web2x&context=3
         //

--- a/pgrx-tests/src/tests/array_tests.rs
+++ b/pgrx-tests/src/tests/array_tests.rs
@@ -427,7 +427,7 @@ mod tests {
     fn test_slice_with_null() -> Result<(), Box<dyn std::error::Error>> {
         let array = Spi::get_one::<Array<i16>>("SELECT ARRAY[1, 2, 3, NULL]::smallint[]")?
             .expect("datum was null");
-        assert_eq!(array.as_slice(), Err(ArrayError::ArrayContainsNulls));
+        assert_eq!(array.as_slice(), Err(ArraySliceError::ContainsNulls));
         Ok(())
     }
 }

--- a/pgrx-tests/src/tests/array_tests.rs
+++ b/pgrx-tests/src/tests/array_tests.rs
@@ -382,4 +382,52 @@ mod tests {
         assert_eq!(strings, true);
         Ok(())
     }
+
+    #[pg_test]
+    fn test_f64_slice() -> Result<(), Box<dyn std::error::Error>> {
+        let array = Spi::get_one::<Array<f64>>("SELECT ARRAY[1.0, 2.0, 3.0]::float8[]")?
+            .expect("datum was null");
+        assert_eq!(array.as_slice()?, &[1.0, 2.0, 3.0]);
+        Ok(())
+    }
+
+    #[pg_test]
+    fn test_f32_slice() -> Result<(), Box<dyn std::error::Error>> {
+        let array = Spi::get_one::<Array<f32>>("SELECT ARRAY[1.0, 2.0, 3.0]::float4[]")?
+            .expect("datum was null");
+        assert_eq!(array.as_slice()?, &[1.0, 2.0, 3.0]);
+        Ok(())
+    }
+
+    #[pg_test]
+    fn test_i64_slice() -> Result<(), Box<dyn std::error::Error>> {
+        let array =
+            Spi::get_one::<Array<i64>>("SELECT ARRAY[1, 2, 3]::bigint[]")?.expect("datum was null");
+        assert_eq!(array.as_slice()?, &[1, 2, 3]);
+        Ok(())
+    }
+
+    #[pg_test]
+    fn test_i32_slice() -> Result<(), Box<dyn std::error::Error>> {
+        let array = Spi::get_one::<Array<i32>>("SELECT ARRAY[1, 2, 3]::integer[]")?
+            .expect("datum was null");
+        assert_eq!(array.as_slice()?, &[1, 2, 3]);
+        Ok(())
+    }
+
+    #[pg_test]
+    fn test_i16_slice() -> Result<(), Box<dyn std::error::Error>> {
+        let array = Spi::get_one::<Array<i16>>("SELECT ARRAY[1, 2, 3]::smallint[]")?
+            .expect("datum was null");
+        assert_eq!(array.as_slice()?, &[1, 2, 3]);
+        Ok(())
+    }
+
+    #[pg_test]
+    fn test_slice_with_null() -> Result<(), Box<dyn std::error::Error>> {
+        let array = Spi::get_one::<Array<i16>>("SELECT ARRAY[1, 2, 3, NULL]::smallint[]")?
+            .expect("datum was null");
+        assert_eq!(array.as_slice(), Err(ArrayError::ArrayContainsNulls));
+        Ok(())
+    }
 }

--- a/pgrx/src/prelude.rs
+++ b/pgrx/src/prelude.rs
@@ -19,9 +19,9 @@ pub use crate::pgbox::{AllocatedByPostgres, AllocatedByRust, PgBox, WhoAllocated
 // However, reexporting them seems fine for now.
 
 pub use crate::datum::{
-    datetime_support::*, AnyNumeric, Array, Date, FromDatum, Interval, IntoDatum, Numeric,
-    PgVarlena, PostgresType, Range, RangeBound, RangeSubType, Time, TimeWithTimeZone, Timestamp,
-    TimestampWithTimeZone, VariadicArray,
+    datetime_support::*, AnyNumeric, Array, ArrayError, Date, FromDatum, Interval, IntoDatum,
+    Numeric, PgVarlena, PostgresType, Range, RangeBound, RangeSubType, Time, TimeWithTimeZone,
+    Timestamp, TimestampWithTimeZone, VariadicArray,
 };
 pub use crate::inoutfuncs::{InOutFuncs, JsonInOutFuncs, PgVarlenaInOutFuncs};
 

--- a/pgrx/src/prelude.rs
+++ b/pgrx/src/prelude.rs
@@ -19,7 +19,7 @@ pub use crate::pgbox::{AllocatedByPostgres, AllocatedByRust, PgBox, WhoAllocated
 // However, reexporting them seems fine for now.
 
 pub use crate::datum::{
-    datetime_support::*, AnyNumeric, Array, ArrayError, Date, FromDatum, Interval, IntoDatum,
+    datetime_support::*, AnyNumeric, Array, ArraySliceError, Date, FromDatum, Interval, IntoDatum,
     Numeric, PgVarlena, PostgresType, Range, RangeBound, RangeSubType, Time, TimeWithTimeZone,
     Timestamp, TimestampWithTimeZone, VariadicArray,
 };


### PR DESCRIPTION
Add support for getting a slice from an `Array<T>` where `T` is a one of these primitives:  i8, i16, i32, i64, f32, f64.  It's possible that we could support other fixed-size types as well, but this is a good place to start.

We also implement `IntoDatum` for `Array<T>`, add some tests, and expand the `arrays` example a little bit.