### PR TITLE
Update version to 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,7 +314,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-pgrx"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "atty",
  "cargo_metadata",
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "atomic-traits",
  "bitflags 2.3.1",
@@ -1551,7 +1551,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-macros"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "pgrx-sql-entity-graph",
  "proc-macro2",
@@ -1562,7 +1562,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-config"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "cargo_toml",
  "dirs",
@@ -1578,7 +1578,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-sys"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "bindgen",
  "eyre",
@@ -1598,7 +1598,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-sql-entity-graph"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "atty",
  "convert_case",
@@ -1614,7 +1614,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-tests"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "clap-cargo",
  "eyre",

--- a/cargo-pgrx/Cargo.toml
+++ b/cargo-pgrx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pgrx"
-version = "0.8.4"
+version = "0.9.0"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Cargo subcommand for 'pgrx' to make Postgres extension development easy"
@@ -23,8 +23,8 @@ semver = "1.0.17"
 owo-colors = { version = "3.5.0", features = [ "supports-colors" ] }
 env_proxy = "0.4.1"
 num_cpus = "1.15.0"
-pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.8.4" }
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.8.4" }
+pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.9.0" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.9.0" }
 prettyplease = "0.2.6"
 proc-macro2 = { version = "1.0.59", features = [ "span-locations" ] }
 quote = "1.0.28"

--- a/cargo-pgrx/src/templates/cargo_toml
+++ b/cargo-pgrx/src/templates/cargo_toml
@@ -16,10 +16,10 @@ pg15 = ["pgrx/pg15", "pgrx-tests/pg15" ]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.8.4"
+pgrx = "=0.9.0"
 
 [dev-dependencies]
-pgrx-tests = "=0.8.4"
+pgrx-tests = "=0.9.0"
 
 [profile.dev]
 panic = "unwind"

--- a/nix/templates/default/Cargo.toml
+++ b/nix/templates/default/Cargo.toml
@@ -16,10 +16,10 @@ pg15 = ["pgrx/pg15", "pgrx-tests/pg15" ]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.8.4"
+pgrx = "=0.9.0"
 
 [dev-dependencies]
-pgrx-tests = "=0.8.4"
+pgrx-tests = "=0.9.0"
 tempfile = "3.2.0"
 once_cell = "1.7.2"
 

--- a/pgrx-macros/Cargo.toml
+++ b/pgrx-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx-macros"
-version = "0.8.4"
+version = "0.9.0"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Proc Macros for 'pgrx'"
@@ -21,7 +21,7 @@ rustc-args = ["--cfg", "docsrs"]
 no-schema-generation = ["pgrx-sql-entity-graph/no-schema-generation"]
 
 [dependencies]
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.8.4" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.9.0" }
 proc-macro2 = "1.0.59"
 quote = "1.0.28"
 syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsing" ] }

--- a/pgrx-pg-config/Cargo.toml
+++ b/pgrx-pg-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx-pg-config"
-version = "0.8.4"
+version = "0.9.0"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "A Postgres pg_config wrapper for 'pgrx'"

--- a/pgrx-pg-sys/Cargo.toml
+++ b/pgrx-pg-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx-pg-sys"
-version = "0.8.4"
+version = "0.9.0"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Generated Rust bindings for Postgres internals, for use with 'pgrx'"
@@ -29,8 +29,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 memoffset = "0.9.0"
-pgrx-macros = { path = "../pgrx-macros/", version = "=0.8.4" }
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph/", version = "=0.8.4" }
+pgrx-macros = { path = "../pgrx-macros/", version = "=0.9.0" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph/", version = "=0.9.0" }
 serde = { version = "1.0.163", features = [ "derive" ] } # impls on pub types
 # polyfill until #![feature(strict_provenance)] stabilizes
 sptr = "0.3"
@@ -38,7 +38,7 @@ libc = "0.2"
 
 [build-dependencies]
 bindgen = { version = "0.65.1", default-features = false, features = ["runtime"] }
-pgrx-pg-config= { path = "../pgrx-pg-config/", version = "=0.8.4" }
+pgrx-pg-config= { path = "../pgrx-pg-config/", version = "=0.9.0" }
 proc-macro2 = "1.0.59"
 quote = "1.0.28"
 syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsing" ] }

--- a/pgrx-pg-sys/src/pg11.rs
+++ b/pgrx-pg-sys/src/pg11.rs
@@ -1947,20 +1947,6 @@ pub const PG_WAIT_IPC: u32 = 134217728;
 pub const PG_WAIT_TIMEOUT: u32 = 150994944;
 pub const PG_WAIT_IO: u32 = 167772160;
 pub const PGSTAT_NUM_PROGRESS_PARAM: u32 = 10;
-pub const GIN_COMPARE_PROC: u32 = 1;
-pub const GIN_EXTRACTVALUE_PROC: u32 = 2;
-pub const GIN_EXTRACTQUERY_PROC: u32 = 3;
-pub const GIN_CONSISTENT_PROC: u32 = 4;
-pub const GIN_COMPARE_PARTIAL_PROC: u32 = 5;
-pub const GIN_TRICONSISTENT_PROC: u32 = 6;
-pub const GINNProcs: u32 = 6;
-pub const GIN_SEARCH_MODE_DEFAULT: u32 = 0;
-pub const GIN_SEARCH_MODE_INCLUDE_EMPTY: u32 = 1;
-pub const GIN_SEARCH_MODE_ALL: u32 = 2;
-pub const GIN_SEARCH_MODE_EVERYTHING: u32 = 3;
-pub const GIN_FALSE: u32 = 0;
-pub const GIN_TRUE: u32 = 1;
-pub const GIN_MAYBE: u32 = 2;
 pub const XLR_NORMAL_MAX_BLOCK_ID: u32 = 4;
 pub const XLR_NORMAL_RDATAS: u32 = 20;
 pub const REGBUF_FORCE_IMAGE: u32 = 1;
@@ -1988,6 +1974,155 @@ pub const BACKUP_LABEL_FILE: &[u8; 13usize] = b"backup_label\0";
 pub const BACKUP_LABEL_OLD: &[u8; 17usize] = b"backup_label.old\0";
 pub const TABLESPACE_MAP: &[u8; 15usize] = b"tablespace_map\0";
 pub const TABLESPACE_MAP_OLD: &[u8; 19usize] = b"tablespace_map.old\0";
+pub const XLOG_PAGE_MAGIC: u32 = 53400;
+pub const XLP_FIRST_IS_CONTRECORD: u32 = 1;
+pub const XLP_LONG_HEADER: u32 = 2;
+pub const XLP_BKP_REMOVABLE: u32 = 4;
+pub const XLP_FIRST_IS_OVERWRITE_CONTRECORD: u32 = 8;
+pub const XLP_ALL_FLAGS: u32 = 15;
+pub const WalSegMinSize: u32 = 1048576;
+pub const WalSegMaxSize: u32 = 1073741824;
+pub const DEFAULT_MIN_WAL_SEGS: u32 = 5;
+pub const DEFAULT_MAX_WAL_SEGS: u32 = 64;
+pub const XLOGDIR: &[u8; 7usize] = b"pg_wal\0";
+pub const XLOG_CONTROL_FILE: &[u8; 18usize] = b"global/pg_control\0";
+pub const MAXFNAMELEN: u32 = 64;
+pub const XLOG_FNAME_LEN: u32 = 24;
+pub const RelationRelationId: Oid = Oid(1259);
+pub const RelationRelation_Rowtype_Id: u32 = 83;
+pub const Anum_pg_class_relname: u32 = 1;
+pub const Anum_pg_class_relnamespace: u32 = 2;
+pub const Anum_pg_class_reltype: u32 = 3;
+pub const Anum_pg_class_reloftype: u32 = 4;
+pub const Anum_pg_class_relowner: u32 = 5;
+pub const Anum_pg_class_relam: u32 = 6;
+pub const Anum_pg_class_relfilenode: u32 = 7;
+pub const Anum_pg_class_reltablespace: u32 = 8;
+pub const Anum_pg_class_relpages: u32 = 9;
+pub const Anum_pg_class_reltuples: u32 = 10;
+pub const Anum_pg_class_relallvisible: u32 = 11;
+pub const Anum_pg_class_reltoastrelid: u32 = 12;
+pub const Anum_pg_class_relhasindex: u32 = 13;
+pub const Anum_pg_class_relisshared: u32 = 14;
+pub const Anum_pg_class_relpersistence: u32 = 15;
+pub const Anum_pg_class_relkind: u32 = 16;
+pub const Anum_pg_class_relnatts: u32 = 17;
+pub const Anum_pg_class_relchecks: u32 = 18;
+pub const Anum_pg_class_relhasoids: u32 = 19;
+pub const Anum_pg_class_relhasrules: u32 = 20;
+pub const Anum_pg_class_relhastriggers: u32 = 21;
+pub const Anum_pg_class_relhassubclass: u32 = 22;
+pub const Anum_pg_class_relrowsecurity: u32 = 23;
+pub const Anum_pg_class_relforcerowsecurity: u32 = 24;
+pub const Anum_pg_class_relispopulated: u32 = 25;
+pub const Anum_pg_class_relreplident: u32 = 26;
+pub const Anum_pg_class_relispartition: u32 = 27;
+pub const Anum_pg_class_relrewrite: u32 = 28;
+pub const Anum_pg_class_relfrozenxid: u32 = 29;
+pub const Anum_pg_class_relminmxid: u32 = 30;
+pub const Anum_pg_class_relacl: u32 = 31;
+pub const Anum_pg_class_reloptions: u32 = 32;
+pub const Anum_pg_class_relpartbound: u32 = 33;
+pub const Natts_pg_class: u32 = 33;
+pub const RELKIND_RELATION: u8 = 114u8;
+pub const RELKIND_INDEX: u8 = 105u8;
+pub const RELKIND_SEQUENCE: u8 = 83u8;
+pub const RELKIND_TOASTVALUE: u8 = 116u8;
+pub const RELKIND_VIEW: u8 = 118u8;
+pub const RELKIND_MATVIEW: u8 = 109u8;
+pub const RELKIND_COMPOSITE_TYPE: u8 = 99u8;
+pub const RELKIND_FOREIGN_TABLE: u8 = 102u8;
+pub const RELKIND_PARTITIONED_TABLE: u8 = 112u8;
+pub const RELKIND_PARTITIONED_INDEX: u8 = 73u8;
+pub const RELPERSISTENCE_PERMANENT: u8 = 112u8;
+pub const RELPERSISTENCE_UNLOGGED: u8 = 117u8;
+pub const RELPERSISTENCE_TEMP: u8 = 116u8;
+pub const REPLICA_IDENTITY_DEFAULT: u8 = 100u8;
+pub const REPLICA_IDENTITY_NOTHING: u8 = 110u8;
+pub const REPLICA_IDENTITY_FULL: u8 = 102u8;
+pub const REPLICA_IDENTITY_INDEX: u8 = 105u8;
+pub const IndexRelationId: Oid = Oid(2610);
+pub const Anum_pg_index_indexrelid: u32 = 1;
+pub const Anum_pg_index_indrelid: u32 = 2;
+pub const Anum_pg_index_indnatts: u32 = 3;
+pub const Anum_pg_index_indnkeyatts: u32 = 4;
+pub const Anum_pg_index_indisunique: u32 = 5;
+pub const Anum_pg_index_indisprimary: u32 = 6;
+pub const Anum_pg_index_indisexclusion: u32 = 7;
+pub const Anum_pg_index_indimmediate: u32 = 8;
+pub const Anum_pg_index_indisclustered: u32 = 9;
+pub const Anum_pg_index_indisvalid: u32 = 10;
+pub const Anum_pg_index_indcheckxmin: u32 = 11;
+pub const Anum_pg_index_indisready: u32 = 12;
+pub const Anum_pg_index_indislive: u32 = 13;
+pub const Anum_pg_index_indisreplident: u32 = 14;
+pub const Anum_pg_index_indkey: u32 = 15;
+pub const Anum_pg_index_indcollation: u32 = 16;
+pub const Anum_pg_index_indclass: u32 = 17;
+pub const Anum_pg_index_indoption: u32 = 18;
+pub const Anum_pg_index_indexprs: u32 = 19;
+pub const Anum_pg_index_indpred: u32 = 20;
+pub const Natts_pg_index: u32 = 20;
+pub const INDOPTION_DESC: u32 = 1;
+pub const INDOPTION_NULLS_FIRST: u32 = 2;
+pub const PublicationRelationId: Oid = Oid(6104);
+pub const Anum_pg_publication_pubname: u32 = 1;
+pub const Anum_pg_publication_pubowner: u32 = 2;
+pub const Anum_pg_publication_puballtables: u32 = 3;
+pub const Anum_pg_publication_pubinsert: u32 = 4;
+pub const Anum_pg_publication_pubupdate: u32 = 5;
+pub const Anum_pg_publication_pubdelete: u32 = 6;
+pub const Anum_pg_publication_pubtruncate: u32 = 7;
+pub const Natts_pg_publication: u32 = 7;
+pub const EOH_HEADER_MAGIC: i32 = -1;
+pub const EA_MAGIC: u32 = 689375833;
+pub const ACL_ID_PUBLIC: u32 = 0;
+pub const ACL_MODECHG_ADD: u32 = 1;
+pub const ACL_MODECHG_DEL: u32 = 2;
+pub const ACL_MODECHG_EQL: u32 = 3;
+pub const ACL_INSERT_CHR: u8 = 97u8;
+pub const ACL_SELECT_CHR: u8 = 114u8;
+pub const ACL_UPDATE_CHR: u8 = 119u8;
+pub const ACL_DELETE_CHR: u8 = 100u8;
+pub const ACL_TRUNCATE_CHR: u8 = 68u8;
+pub const ACL_REFERENCES_CHR: u8 = 120u8;
+pub const ACL_TRIGGER_CHR: u8 = 116u8;
+pub const ACL_EXECUTE_CHR: u8 = 88u8;
+pub const ACL_USAGE_CHR: u8 = 85u8;
+pub const ACL_CREATE_CHR: u8 = 67u8;
+pub const ACL_CREATE_TEMP_CHR: u8 = 84u8;
+pub const ACL_CONNECT_CHR: u8 = 99u8;
+pub const ACL_ALL_RIGHTS_STR: &[u8; 13usize] = b"arwdDxtXUCTc\0";
+pub const ACL_ALL_RIGHTS_COLUMN: u32 = 39;
+pub const ACL_ALL_RIGHTS_RELATION: u32 = 127;
+pub const ACL_ALL_RIGHTS_SEQUENCE: u32 = 262;
+pub const ACL_ALL_RIGHTS_DATABASE: u32 = 3584;
+pub const ACL_ALL_RIGHTS_FDW: u32 = 256;
+pub const ACL_ALL_RIGHTS_FOREIGN_SERVER: u32 = 256;
+pub const ACL_ALL_RIGHTS_FUNCTION: u32 = 128;
+pub const ACL_ALL_RIGHTS_LANGUAGE: u32 = 256;
+pub const ACL_ALL_RIGHTS_LARGEOBJECT: u32 = 6;
+pub const ACL_ALL_RIGHTS_SCHEMA: u32 = 768;
+pub const ACL_ALL_RIGHTS_TABLESPACE: u32 = 512;
+pub const ACL_ALL_RIGHTS_TYPE: u32 = 256;
+pub const HEAP_MIN_FILLFACTOR: u32 = 10;
+pub const HEAP_DEFAULT_FILLFACTOR: u32 = 100;
+pub const MAX_GENERIC_XLOG_PAGES: u32 = 4;
+pub const GENERIC_XLOG_FULL_IMAGE: u32 = 1;
+pub const GIN_COMPARE_PROC: u32 = 1;
+pub const GIN_EXTRACTVALUE_PROC: u32 = 2;
+pub const GIN_EXTRACTQUERY_PROC: u32 = 3;
+pub const GIN_CONSISTENT_PROC: u32 = 4;
+pub const GIN_COMPARE_PARTIAL_PROC: u32 = 5;
+pub const GIN_TRICONSISTENT_PROC: u32 = 6;
+pub const GINNProcs: u32 = 6;
+pub const GIN_SEARCH_MODE_DEFAULT: u32 = 0;
+pub const GIN_SEARCH_MODE_INCLUDE_EMPTY: u32 = 1;
+pub const GIN_SEARCH_MODE_ALL: u32 = 2;
+pub const GIN_SEARCH_MODE_EVERYTHING: u32 = 3;
+pub const GIN_FALSE: u32 = 0;
+pub const GIN_TRUE: u32 = 1;
+pub const GIN_MAYBE: u32 = 2;
 pub const GIST_CONSISTENT_PROC: u32 = 1;
 pub const GIST_UNION_PROC: u32 = 2;
 pub const GIST_COMPRESS_PROC: u32 = 3;
@@ -2195,37 +2330,6 @@ pub const XACT_XINFO_HAS_GID: u32 = 128;
 pub const XACT_COMPLETION_APPLY_FEEDBACK: u32 = 536870912;
 pub const XACT_COMPLETION_UPDATE_RELCACHE_FILE: u32 = 1073741824;
 pub const XACT_COMPLETION_FORCE_SYNC_COMMIT: u32 = 2147483648;
-pub const EOH_HEADER_MAGIC: i32 = -1;
-pub const EA_MAGIC: u32 = 689375833;
-pub const ACL_ID_PUBLIC: u32 = 0;
-pub const ACL_MODECHG_ADD: u32 = 1;
-pub const ACL_MODECHG_DEL: u32 = 2;
-pub const ACL_MODECHG_EQL: u32 = 3;
-pub const ACL_INSERT_CHR: u8 = 97u8;
-pub const ACL_SELECT_CHR: u8 = 114u8;
-pub const ACL_UPDATE_CHR: u8 = 119u8;
-pub const ACL_DELETE_CHR: u8 = 100u8;
-pub const ACL_TRUNCATE_CHR: u8 = 68u8;
-pub const ACL_REFERENCES_CHR: u8 = 120u8;
-pub const ACL_TRIGGER_CHR: u8 = 116u8;
-pub const ACL_EXECUTE_CHR: u8 = 88u8;
-pub const ACL_USAGE_CHR: u8 = 85u8;
-pub const ACL_CREATE_CHR: u8 = 67u8;
-pub const ACL_CREATE_TEMP_CHR: u8 = 84u8;
-pub const ACL_CONNECT_CHR: u8 = 99u8;
-pub const ACL_ALL_RIGHTS_STR: &[u8; 13usize] = b"arwdDxtXUCTc\0";
-pub const ACL_ALL_RIGHTS_COLUMN: u32 = 39;
-pub const ACL_ALL_RIGHTS_RELATION: u32 = 127;
-pub const ACL_ALL_RIGHTS_SEQUENCE: u32 = 262;
-pub const ACL_ALL_RIGHTS_DATABASE: u32 = 3584;
-pub const ACL_ALL_RIGHTS_FDW: u32 = 256;
-pub const ACL_ALL_RIGHTS_FOREIGN_SERVER: u32 = 256;
-pub const ACL_ALL_RIGHTS_FUNCTION: u32 = 128;
-pub const ACL_ALL_RIGHTS_LANGUAGE: u32 = 256;
-pub const ACL_ALL_RIGHTS_LARGEOBJECT: u32 = 6;
-pub const ACL_ALL_RIGHTS_SCHEMA: u32 = 768;
-pub const ACL_ALL_RIGHTS_TABLESPACE: u32 = 512;
-pub const ACL_ALL_RIGHTS_TYPE: u32 = 256;
 pub const PERFORM_DELETION_INTERNAL: u32 = 1;
 pub const PERFORM_DELETION_CONCURRENTLY: u32 = 2;
 pub const PERFORM_DELETION_QUIETLY: u32 = 4;
@@ -2388,59 +2492,6 @@ pub const DEFAULT_ROLE_READ_SERVER_FILES: u32 = 4569;
 pub const DEFAULT_ROLE_WRITE_SERVER_FILES: u32 = 4570;
 pub const DEFAULT_ROLE_EXECUTE_SERVER_PROGRAM: u32 = 4571;
 pub const DEFAULT_ROLE_SIGNAL_BACKENDID: u32 = 4200;
-pub const RelationRelationId: Oid = Oid(1259);
-pub const RelationRelation_Rowtype_Id: u32 = 83;
-pub const Anum_pg_class_relname: u32 = 1;
-pub const Anum_pg_class_relnamespace: u32 = 2;
-pub const Anum_pg_class_reltype: u32 = 3;
-pub const Anum_pg_class_reloftype: u32 = 4;
-pub const Anum_pg_class_relowner: u32 = 5;
-pub const Anum_pg_class_relam: u32 = 6;
-pub const Anum_pg_class_relfilenode: u32 = 7;
-pub const Anum_pg_class_reltablespace: u32 = 8;
-pub const Anum_pg_class_relpages: u32 = 9;
-pub const Anum_pg_class_reltuples: u32 = 10;
-pub const Anum_pg_class_relallvisible: u32 = 11;
-pub const Anum_pg_class_reltoastrelid: u32 = 12;
-pub const Anum_pg_class_relhasindex: u32 = 13;
-pub const Anum_pg_class_relisshared: u32 = 14;
-pub const Anum_pg_class_relpersistence: u32 = 15;
-pub const Anum_pg_class_relkind: u32 = 16;
-pub const Anum_pg_class_relnatts: u32 = 17;
-pub const Anum_pg_class_relchecks: u32 = 18;
-pub const Anum_pg_class_relhasoids: u32 = 19;
-pub const Anum_pg_class_relhasrules: u32 = 20;
-pub const Anum_pg_class_relhastriggers: u32 = 21;
-pub const Anum_pg_class_relhassubclass: u32 = 22;
-pub const Anum_pg_class_relrowsecurity: u32 = 23;
-pub const Anum_pg_class_relforcerowsecurity: u32 = 24;
-pub const Anum_pg_class_relispopulated: u32 = 25;
-pub const Anum_pg_class_relreplident: u32 = 26;
-pub const Anum_pg_class_relispartition: u32 = 27;
-pub const Anum_pg_class_relrewrite: u32 = 28;
-pub const Anum_pg_class_relfrozenxid: u32 = 29;
-pub const Anum_pg_class_relminmxid: u32 = 30;
-pub const Anum_pg_class_relacl: u32 = 31;
-pub const Anum_pg_class_reloptions: u32 = 32;
-pub const Anum_pg_class_relpartbound: u32 = 33;
-pub const Natts_pg_class: u32 = 33;
-pub const RELKIND_RELATION: u8 = 114u8;
-pub const RELKIND_INDEX: u8 = 105u8;
-pub const RELKIND_SEQUENCE: u8 = 83u8;
-pub const RELKIND_TOASTVALUE: u8 = 116u8;
-pub const RELKIND_VIEW: u8 = 118u8;
-pub const RELKIND_MATVIEW: u8 = 109u8;
-pub const RELKIND_COMPOSITE_TYPE: u8 = 99u8;
-pub const RELKIND_FOREIGN_TABLE: u8 = 102u8;
-pub const RELKIND_PARTITIONED_TABLE: u8 = 112u8;
-pub const RELKIND_PARTITIONED_INDEX: u8 = 73u8;
-pub const RELPERSISTENCE_PERMANENT: u8 = 112u8;
-pub const RELPERSISTENCE_UNLOGGED: u8 = 117u8;
-pub const RELPERSISTENCE_TEMP: u8 = 116u8;
-pub const REPLICA_IDENTITY_DEFAULT: u8 = 100u8;
-pub const REPLICA_IDENTITY_NOTHING: u8 = 110u8;
-pub const REPLICA_IDENTITY_FULL: u8 = 102u8;
-pub const REPLICA_IDENTITY_INDEX: u8 = 105u8;
 pub const DatabaseRelationId: Oid = Oid(1262);
 pub const DatabaseRelation_Rowtype_Id: u32 = 1248;
 pub const Anum_pg_database_datname: u32 = 1;
@@ -3170,41 +3221,6 @@ pub const JB_FOBJECT: u32 = 536870912;
 pub const JB_FARRAY: u32 = 1073741824;
 pub const ATTSTATSSLOT_VALUES: u32 = 1;
 pub const ATTSTATSSLOT_NUMBERS: u32 = 2;
-pub const IndexRelationId: Oid = Oid(2610);
-pub const Anum_pg_index_indexrelid: u32 = 1;
-pub const Anum_pg_index_indrelid: u32 = 2;
-pub const Anum_pg_index_indnatts: u32 = 3;
-pub const Anum_pg_index_indnkeyatts: u32 = 4;
-pub const Anum_pg_index_indisunique: u32 = 5;
-pub const Anum_pg_index_indisprimary: u32 = 6;
-pub const Anum_pg_index_indisexclusion: u32 = 7;
-pub const Anum_pg_index_indimmediate: u32 = 8;
-pub const Anum_pg_index_indisclustered: u32 = 9;
-pub const Anum_pg_index_indisvalid: u32 = 10;
-pub const Anum_pg_index_indcheckxmin: u32 = 11;
-pub const Anum_pg_index_indisready: u32 = 12;
-pub const Anum_pg_index_indislive: u32 = 13;
-pub const Anum_pg_index_indisreplident: u32 = 14;
-pub const Anum_pg_index_indkey: u32 = 15;
-pub const Anum_pg_index_indcollation: u32 = 16;
-pub const Anum_pg_index_indclass: u32 = 17;
-pub const Anum_pg_index_indoption: u32 = 18;
-pub const Anum_pg_index_indexprs: u32 = 19;
-pub const Anum_pg_index_indpred: u32 = 20;
-pub const Natts_pg_index: u32 = 20;
-pub const INDOPTION_DESC: u32 = 1;
-pub const INDOPTION_NULLS_FIRST: u32 = 2;
-pub const PublicationRelationId: Oid = Oid(6104);
-pub const Anum_pg_publication_pubname: u32 = 1;
-pub const Anum_pg_publication_pubowner: u32 = 2;
-pub const Anum_pg_publication_puballtables: u32 = 3;
-pub const Anum_pg_publication_pubinsert: u32 = 4;
-pub const Anum_pg_publication_pubupdate: u32 = 5;
-pub const Anum_pg_publication_pubdelete: u32 = 6;
-pub const Anum_pg_publication_pubtruncate: u32 = 7;
-pub const Natts_pg_publication: u32 = 7;
-pub const HEAP_MIN_FILLFACTOR: u32 = 10;
-pub const HEAP_DEFAULT_FILLFACTOR: u32 = 100;
 pub const DEFAULT_EQ_SEL: f64 = 0.005;
 pub const DEFAULT_INEQ_SEL: f64 = 0.3333333333333333;
 pub const DEFAULT_RANGE_INEQ_SEL: f64 = 0.005;
@@ -4060,7 +4076,7 @@ extern "C" {
         errorType: *const ::std::os::raw::c_char,
         fileName: *const ::std::os::raw::c_char,
         lineNumber: ::std::os::raw::c_int,
-    );
+    ) -> !;
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -6055,7 +6071,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn ReThrowError(edata: *mut ErrorData);
+    pub fn ReThrowError(edata: *mut ErrorData) -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -15597,11 +15613,7 @@ impl Default for Query {
         }
     }
 }
-#[doc = "\tSupporting data structures for Parse Trees"]
-#[doc = ""]
-#[doc = "\tMost of these node types appear in raw parsetrees output by the grammar,"]
-#[doc = "\tand get transformed to something else by the analyzer.  A few of them"]
-#[doc = "\tare used as-is in transformed querytrees."]
+#[doc = "\tSupporting data structures for Parse Trees\n\n\tMost of these node types appear in raw parsetrees output by the grammar,\n\tand get transformed to something else by the analyzer.  A few of them\n\tare used as-is in transformed querytrees."]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct TypeName {
@@ -16744,17 +16756,7 @@ pub const ObjectType_OBJECT_TSTEMPLATE: ObjectType = 46;
 pub const ObjectType_OBJECT_TYPE: ObjectType = 47;
 pub const ObjectType_OBJECT_USER_MAPPING: ObjectType = 48;
 pub const ObjectType_OBJECT_VIEW: ObjectType = 49;
-#[doc = "\t\tOther Statements (no optimizations required)"]
-#[doc = ""]
-#[doc = "\t\tThese are not touched by parser/analyze.c except to put them into"]
-#[doc = "\t\tthe utilityStmt field of a Query.  This is eventually passed to"]
-#[doc = "\t\tProcessUtility (by-passing rewriting and planning).  Some of the"]
-#[doc = "\t\tstatements do need attention from parse analysis, and this is"]
-#[doc = "\t\tdone by routines in parser/parse_utilcmd.c after ProcessUtility"]
-#[doc = "\t\treceives the command for execution."]
-#[doc = "\t\tDECLARE CURSOR, EXPLAIN, and CREATE TABLE AS are special cases:"]
-#[doc = "\t\tthey contain optimizable statements, which get processed normally"]
-#[doc = "\t\tby parser/analyze.c."]
+#[doc = "\t\tOther Statements (no optimizations required)\n\n\t\tThese are not touched by parser/analyze.c except to put them into\n\t\tthe utilityStmt field of a Query.  This is eventually passed to\n\t\tProcessUtility (by-passing rewriting and planning).  Some of the\n\t\tstatements do need attention from parse analysis, and this is\n\t\tdone by routines in parser/parse_utilcmd.c after ProcessUtility\n\t\treceives the command for execution.\n\t\tDECLARE CURSOR, EXPLAIN, and CREATE TABLE AS are special cases:\n\t\tthey contain optimizable statements, which get processed normally\n\t\tby parser/analyze.c."]
 pub type ObjectType = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -22398,56 +22400,7 @@ extern "C" {
     pub fn pg_tzenumerate_end(dir: *mut pg_tzenum);
 }
 extern "C" {
-    #[doc = "\t  System interrupt and critical section handling"]
-    #[doc = ""]
-    #[doc = " There are two types of interrupts that a running backend needs to accept"]
-    #[doc = " without messing up its state: QueryCancel (SIGINT) and ProcDie (SIGTERM)."]
-    #[doc = " In both cases, we need to be able to clean up the current transaction"]
-    #[doc = " gracefully, so we can't respond to the interrupt instantaneously ---"]
-    #[doc = " there's no guarantee that internal data structures would be self-consistent"]
-    #[doc = " if the code is interrupted at an arbitrary instant.  Instead, the signal"]
-    #[doc = " handlers set flags that are checked periodically during execution."]
-    #[doc = ""]
-    #[doc = " The CHECK_FOR_INTERRUPTS() macro is called at strategically located spots"]
-    #[doc = " where it is normally safe to accept a cancel or die interrupt.  In some"]
-    #[doc = " cases, we invoke CHECK_FOR_INTERRUPTS() inside low-level subroutines that"]
-    #[doc = " might sometimes be called in contexts that do *not* want to allow a cancel"]
-    #[doc = " or die interrupt.  The HOLD_INTERRUPTS() and RESUME_INTERRUPTS() macros"]
-    #[doc = " allow code to ensure that no cancel or die interrupt will be accepted,"]
-    #[doc = " even if CHECK_FOR_INTERRUPTS() gets called in a subroutine.  The interrupt"]
-    #[doc = " will be held off until CHECK_FOR_INTERRUPTS() is done outside any"]
-    #[doc = " HOLD_INTERRUPTS() ... RESUME_INTERRUPTS() section."]
-    #[doc = ""]
-    #[doc = " There is also a mechanism to prevent query cancel interrupts, while still"]
-    #[doc = " allowing die interrupts: HOLD_CANCEL_INTERRUPTS() and"]
-    #[doc = " RESUME_CANCEL_INTERRUPTS()."]
-    #[doc = ""]
-    #[doc = " Note that ProcessInterrupts() has also acquired a number of tasks that"]
-    #[doc = " do not necessarily cause a query-cancel-or-die response.  Hence, it's"]
-    #[doc = " possible that it will just clear InterruptPending and return."]
-    #[doc = ""]
-    #[doc = " INTERRUPTS_PENDING_CONDITION() can be checked to see whether an"]
-    #[doc = " interrupt needs to be serviced, without trying to do so immediately."]
-    #[doc = " Some callers are also interested in INTERRUPTS_CAN_BE_PROCESSED(),"]
-    #[doc = " which tells whether ProcessInterrupts is sure to clear the interrupt."]
-    #[doc = ""]
-    #[doc = " Special mechanisms are used to let an interrupt be accepted when we are"]
-    #[doc = " waiting for a lock or when we are waiting for command input (but, of"]
-    #[doc = " course, only if the interrupt holdoff counter is zero).  See the"]
-    #[doc = " related code for details."]
-    #[doc = ""]
-    #[doc = " A lost connection is handled similarly, although the loss of connection"]
-    #[doc = " does not raise a signal, but is detected when we fail to write to the"]
-    #[doc = " socket. If there was a signal for a broken connection, we could make use of"]
-    #[doc = " it by setting ClientConnectionLost in the signal handler."]
-    #[doc = ""]
-    #[doc = " A related, but conceptually distinct, mechanism is the \"critical section\""]
-    #[doc = " mechanism.  A critical section not only holds off cancel/die interrupts,"]
-    #[doc = " but causes any ereport(ERROR) or ereport(FATAL) to become ereport(PANIC)"]
-    #[doc = " --- that is, a system-wide reset is forced.  Needless to say, only really"]
-    #[doc = " *critical* code should be marked as a critical section!\tCurrently, this"]
-    #[doc = " mechanism is only used for XLOG-related code."]
-    #[doc = ""]
+    #[doc = "\t  System interrupt and critical section handling\n\n There are two types of interrupts that a running backend needs to accept\n without messing up its state: QueryCancel (SIGINT) and ProcDie (SIGTERM).\n In both cases, we need to be able to clean up the current transaction\n gracefully, so we can't respond to the interrupt instantaneously ---\n there's no guarantee that internal data structures would be self-consistent\n if the code is interrupted at an arbitrary instant.  Instead, the signal\n handlers set flags that are checked periodically during execution.\n\n The CHECK_FOR_INTERRUPTS() macro is called at strategically located spots\n where it is normally safe to accept a cancel or die interrupt.  In some\n cases, we invoke CHECK_FOR_INTERRUPTS() inside low-level subroutines that\n might sometimes be called in contexts that do *not* want to allow a cancel\n or die interrupt.  The HOLD_INTERRUPTS() and RESUME_INTERRUPTS() macros\n allow code to ensure that no cancel or die interrupt will be accepted,\n even if CHECK_FOR_INTERRUPTS() gets called in a subroutine.  The interrupt\n will be held off until CHECK_FOR_INTERRUPTS() is done outside any\n HOLD_INTERRUPTS() ... RESUME_INTERRUPTS() section.\n\n There is also a mechanism to prevent query cancel interrupts, while still\n allowing die interrupts: HOLD_CANCEL_INTERRUPTS() and\n RESUME_CANCEL_INTERRUPTS().\n\n Note that ProcessInterrupts() has also acquired a number of tasks that\n do not necessarily cause a query-cancel-or-die response.  Hence, it's\n possible that it will just clear InterruptPending and return.\n\n INTERRUPTS_PENDING_CONDITION() can be checked to see whether an\n interrupt needs to be serviced, without trying to do so immediately.\n Some callers are also interested in INTERRUPTS_CAN_BE_PROCESSED(),\n which tells whether ProcessInterrupts is sure to clear the interrupt.\n\n Special mechanisms are used to let an interrupt be accepted when we are\n waiting for a lock or when we are waiting for command input (but, of\n course, only if the interrupt holdoff counter is zero).  See the\n related code for details.\n\n A lost connection is handled similarly, although the loss of connection\n does not raise a signal, but is detected when we fail to write to the\n socket. If there was a signal for a broken connection, we could make use of\n it by setting ClientConnectionLost in the signal handler.\n\n A related, but conceptually distinct, mechanism is the \"critical section\"\n mechanism.  A critical section not only holds off cancel/die interrupts,\n but causes any ereport(ERROR) or ereport(FATAL) to become ereport(PANIC)\n --- that is, a system-wide reset is forced.  Needless to say, only really\n *critical* code should be marked as a critical section!\tCurrently, this\n mechanism is only used for XLOG-related code.\n"]
     pub static mut InterruptPending: bool;
 }
 extern "C" {
@@ -22767,8 +22720,7 @@ extern "C" {
 pub const ProcessingMode_BootstrapProcessing: ProcessingMode = 0;
 pub const ProcessingMode_InitProcessing: ProcessingMode = 1;
 pub const ProcessingMode_NormalProcessing: ProcessingMode = 2;
-#[doc = "\t  pmod.h --\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t *"]
-#[doc = "\t\t\tPOSTGRES processing mode definitions.                            *"]
+#[doc = "\t  pmod.h --\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t *\n\t\t\tPOSTGRES processing mode definitions.                            *"]
 pub type ProcessingMode = ::std::os::raw::c_uint;
 extern "C" {
     pub static mut Mode: ProcessingMode;
@@ -22788,8 +22740,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    #[doc = "\t  pinit.h --\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t *"]
-    #[doc = "\t\t\tPOSTGRES initialization and cleanup definitions.                 *"]
+    #[doc = "\t  pinit.h --\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t *\n\t\t\tPOSTGRES initialization and cleanup definitions.                 *"]
     pub fn pg_split_opts(
         argv: *mut *mut ::std::os::raw::c_char,
         argcp: *mut ::std::os::raw::c_int,
@@ -23010,7 +22961,7 @@ pub const ForkNumber_VISIBILITYMAP_FORKNUM: ForkNumber = 2;
 pub const ForkNumber_INIT_FORKNUM: ForkNumber = 3;
 pub type ForkNumber = ::std::os::raw::c_int;
 extern "C" {
-    pub static mut forkNames: [*const ::std::os::raw::c_char; 0usize];
+    pub static forkNames: [*const ::std::os::raw::c_char; 0usize];
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -23967,7 +23918,7 @@ pub const LockTagType_LOCKTAG_ADVISORY: LockTagType = 9;
 pub const LockTagType_LOCKTAG_DATABASE_FROZEN_IDS: LockTagType = 10;
 pub type LockTagType = ::std::os::raw::c_uint;
 extern "C" {
-    pub static mut LockTagTypeNames: [*const ::std::os::raw::c_char; 0usize];
+    pub static LockTagTypeNames: [*const ::std::os::raw::c_char; 0usize];
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -24325,7 +24276,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn DeadLockReport();
+    pub fn DeadLockReport() -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -25962,31 +25913,6 @@ extern "C" {
 extern "C" {
     pub fn GetIndexAmRoutineByAmId(amoid: Oid, noerror: bool) -> *mut IndexAmRoutine;
 }
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct GinStatsData {
-    pub nPendingPages: BlockNumber,
-    pub nTotalPages: BlockNumber,
-    pub nEntryPages: BlockNumber,
-    pub nDataPages: BlockNumber,
-    pub nEntries: int64,
-    pub ginVersion: int32,
-}
-pub type GinTernaryValue = ::std::os::raw::c_char;
-extern "C" {
-    pub static mut GinFuzzySearchLimit: ::std::os::raw::c_int;
-}
-extern "C" {
-    pub static mut gin_pending_list_limit: ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn ginGetStats(index: Relation, stats: *mut GinStatsData);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn ginUpdateStats(index: Relation, stats: *const GinStatsData);
-}
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn XLogBeginInsert();
@@ -26190,11 +26116,6 @@ pub struct CheckpointStatsData {
 }
 extern "C" {
     pub static mut CheckpointStats: CheckpointStatsData;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct XLogRecData {
-    _unused: [u8; 0],
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -26473,89 +26394,43 @@ extern "C" {
 extern "C" {
     pub fn get_backup_status() -> SessionBackupState;
 }
-pub type GistNSN = XLogRecPtr;
-pub type PageGistNSN = PageXLogRecPtr;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct GISTPageOpaqueData {
-    pub nsn: PageGistNSN,
-    pub rightlink: BlockNumber,
-    pub flags: uint16,
-    pub gist_page_id: uint16,
+pub struct XLogPageHeaderData {
+    pub xlp_magic: uint16,
+    pub xlp_info: uint16,
+    pub xlp_tli: TimeLineID,
+    pub xlp_pageaddr: XLogRecPtr,
+    pub xlp_rem_len: uint32,
 }
-pub type GISTPageOpaque = *mut GISTPageOpaqueData;
+pub type XLogPageHeader = *mut XLogPageHeaderData;
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct GIST_SPLITVEC {
-    pub spl_left: *mut OffsetNumber,
-    pub spl_nleft: ::std::os::raw::c_int,
-    pub spl_ldatum: Datum,
-    pub spl_ldatum_exists: bool,
-    pub spl_right: *mut OffsetNumber,
-    pub spl_nright: ::std::os::raw::c_int,
-    pub spl_rdatum: Datum,
-    pub spl_rdatum_exists: bool,
+#[derive(Debug, Default, Copy, Clone)]
+pub struct XLogLongPageHeaderData {
+    pub std: XLogPageHeaderData,
+    pub xlp_sysid: uint64,
+    pub xlp_seg_size: uint32,
+    pub xlp_xlog_blcksz: uint32,
 }
-impl Default for GIST_SPLITVEC {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
+pub type XLogLongPageHeader = *mut XLogLongPageHeaderData;
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct GISTENTRY {
-    pub key: Datum,
-    pub rel: Relation,
-    pub page: Page,
-    pub offset: OffsetNumber,
-    pub leafkey: bool,
-}
-impl Default for GISTENTRY {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct GistEntryVector {
-    pub n: int32,
-    pub vector: __IncompleteArrayField<GISTENTRY>,
-}
-impl Default for GistEntryVector {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
+#[derive(Debug, Default, Copy, Clone)]
+pub struct xl_parameter_change {
+    pub MaxConnections: ::std::os::raw::c_int,
+    pub max_worker_processes: ::std::os::raw::c_int,
+    pub max_prepared_xacts: ::std::os::raw::c_int,
+    pub max_locks_per_xact: ::std::os::raw::c_int,
+    pub wal_level: ::std::os::raw::c_int,
+    pub wal_log_hints: bool,
+    pub track_commit_timestamp: bool,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct VariableCacheData {
-    pub nextOid: Oid,
-    pub oidCount: uint32,
-    pub nextXid: TransactionId,
-    pub oldestXid: TransactionId,
-    pub xidVacLimit: TransactionId,
-    pub xidWarnLimit: TransactionId,
-    pub xidStopLimit: TransactionId,
-    pub xidWrapLimit: TransactionId,
-    pub oldestXidDB: Oid,
-    pub oldestCommitTsXid: TransactionId,
-    pub newestCommitTsXid: TransactionId,
-    pub latestCompletedXid: TransactionId,
-    pub oldestClogXid: TransactionId,
+pub struct xl_restore_point {
+    pub rp_time: TimestampTz,
+    pub rp_name: [::std::os::raw::c_char; 64usize],
 }
-impl Default for VariableCacheData {
+impl Default for xl_restore_point {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -26563,147 +26438,28 @@ impl Default for VariableCacheData {
             s.assume_init()
         }
     }
-}
-pub type VariableCache = *mut VariableCacheData;
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn TransactionStartedDuringRecovery() -> bool;
-}
-extern "C" {
-    pub static mut ShmemVariableCache: VariableCache;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn TransactionIdDidCommit(transactionId: TransactionId) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn TransactionIdDidAbort(transactionId: TransactionId) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn TransactionIdIsKnownCompleted(transactionId: TransactionId) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn TransactionIdAbort(transactionId: TransactionId);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn TransactionIdCommitTree(
-        xid: TransactionId,
-        nxids: ::std::os::raw::c_int,
-        xids: *mut TransactionId,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn TransactionIdAsyncCommitTree(
-        xid: TransactionId,
-        nxids: ::std::os::raw::c_int,
-        xids: *mut TransactionId,
-        lsn: XLogRecPtr,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn TransactionIdAbortTree(
-        xid: TransactionId,
-        nxids: ::std::os::raw::c_int,
-        xids: *mut TransactionId,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn TransactionIdPrecedes(id1: TransactionId, id2: TransactionId) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn TransactionIdPrecedesOrEquals(id1: TransactionId, id2: TransactionId) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn TransactionIdFollows(id1: TransactionId, id2: TransactionId) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn TransactionIdFollowsOrEquals(id1: TransactionId, id2: TransactionId) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn TransactionIdLatest(
-        mainxid: TransactionId,
-        nxids: ::std::os::raw::c_int,
-        xids: *const TransactionId,
-    ) -> TransactionId;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn TransactionIdGetCommitLSN(xid: TransactionId) -> XLogRecPtr;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetNewTransactionId(isSubXact: bool) -> TransactionId;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn ReadNewTransactionId() -> TransactionId;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn SetTransactionIdLimit(oldest_datfrozenxid: TransactionId, oldest_datoid: Oid);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn AdvanceOldestClogXid(oldest_datfrozenxid: TransactionId);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn ForceTransactionIdLimitUpdate() -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetNewObjectId() -> Oid;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
-pub struct HeapTupleFields {
-    pub t_xmin: TransactionId,
-    pub t_xmax: TransactionId,
-    pub t_field3: HeapTupleFields__bindgen_ty_1,
+#[derive(Debug, Default, Copy, Clone)]
+pub struct xl_overwrite_contrecord {
+    pub overwritten_lsn: XLogRecPtr,
+    pub overwrite_time: TimestampTz,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
-pub union HeapTupleFields__bindgen_ty_1 {
-    pub t_cid: CommandId,
-    pub t_xvac: TransactionId,
-}
-impl Default for HeapTupleFields__bindgen_ty_1 {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-impl Default for HeapTupleFields {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
+#[derive(Debug, Default, Copy, Clone)]
+pub struct xl_end_of_recovery {
+    pub end_time: TimestampTz,
+    pub ThisTimeLineID: TimeLineID,
+    pub PrevTimeLineID: TimeLineID,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct DatumTupleFields {
-    pub datum_len_: int32,
-    pub datum_typmod: int32,
-    pub datum_typeid: Oid,
+pub struct XLogRecData {
+    pub next: *mut XLogRecData,
+    pub data: *mut ::std::os::raw::c_char,
+    pub len: uint32,
 }
-impl Default for DatumTupleFields {
+impl Default for XLogRecData {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -26712,22 +26468,26 @@ impl Default for DatumTupleFields {
         }
     }
 }
+pub const RecoveryTargetAction_RECOVERY_TARGET_ACTION_PAUSE: RecoveryTargetAction = 0;
+pub const RecoveryTargetAction_RECOVERY_TARGET_ACTION_PROMOTE: RecoveryTargetAction = 1;
+pub const RecoveryTargetAction_RECOVERY_TARGET_ACTION_SHUTDOWN: RecoveryTargetAction = 2;
+pub type RecoveryTargetAction = ::std::os::raw::c_uint;
 #[repr(C)]
-pub struct HeapTupleHeaderData {
-    pub t_choice: HeapTupleHeaderData__bindgen_ty_1,
-    pub t_ctid: ItemPointerData,
-    pub t_infomask2: uint16,
-    pub t_infomask: uint16,
-    pub t_hoff: uint8,
-    pub t_bits: __IncompleteArrayField<bits8>,
+#[derive(Debug, Copy, Clone)]
+pub struct RmgrData {
+    pub rm_name: *const ::std::os::raw::c_char,
+    pub rm_redo: ::std::option::Option<unsafe extern "C" fn(record: *mut XLogReaderState)>,
+    pub rm_desc:
+        ::std::option::Option<unsafe extern "C" fn(buf: StringInfo, record: *mut XLogReaderState)>,
+    pub rm_identify:
+        ::std::option::Option<unsafe extern "C" fn(info: uint8) -> *const ::std::os::raw::c_char>,
+    pub rm_startup: ::std::option::Option<unsafe extern "C" fn()>,
+    pub rm_cleanup: ::std::option::Option<unsafe extern "C" fn()>,
+    pub rm_mask: ::std::option::Option<
+        unsafe extern "C" fn(pagedata: *mut ::std::os::raw::c_char, blkno: BlockNumber),
+    >,
 }
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union HeapTupleHeaderData__bindgen_ty_1 {
-    pub t_heap: HeapTupleFields,
-    pub t_datum: DatumTupleFields,
-}
-impl Default for HeapTupleHeaderData__bindgen_ty_1 {
+impl Default for RmgrData {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -26736,468 +26496,154 @@ impl Default for HeapTupleHeaderData__bindgen_ty_1 {
         }
     }
 }
-impl Default for HeapTupleHeaderData {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default)]
-pub struct MinimalTupleData {
-    pub t_len: uint32,
-    pub mt_padding: [::std::os::raw::c_char; 6usize],
-    pub t_infomask2: uint16,
-    pub t_infomask: uint16,
-    pub t_hoff: uint8,
-    pub t_bits: __IncompleteArrayField<bits8>,
+extern "C" {
+    pub static RmgrTable: [RmgrData; 0usize];
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn heap_compute_data_size(
-        tupleDesc: TupleDesc,
-        values: *mut Datum,
-        isnull: *mut bool,
-    ) -> Size;
+    pub fn GetLastSegSwitchData(lastSwitchLSN: *mut XLogRecPtr) -> pg_time_t;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn heap_fill_tuple(
-        tupleDesc: TupleDesc,
-        values: *mut Datum,
-        isnull: *mut bool,
-        data: *mut ::std::os::raw::c_char,
-        data_size: Size,
-        infomask: *mut uint16,
-        bit: *mut bits8,
-    );
+    pub fn RequestXLogSwitch(mark_unimportant: bool) -> XLogRecPtr;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn heap_attisnull(
-        tup: HeapTuple,
-        attnum: ::std::os::raw::c_int,
-        tupleDesc: TupleDesc,
+    pub fn GetOldestRestartPoint(oldrecptr: *mut XLogRecPtr, oldtli: *mut TimeLineID);
+}
+extern "C" {
+    pub static mut ArchiveRecoveryRequested: bool;
+}
+extern "C" {
+    pub static mut InArchiveRecovery: bool;
+}
+extern "C" {
+    pub static mut StandbyMode: bool;
+}
+extern "C" {
+    pub static mut recoveryRestoreCommand: *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RestoreArchivedFile(
+        path: *mut ::std::os::raw::c_char,
+        xlogfname: *const ::std::os::raw::c_char,
+        recovername: *const ::std::os::raw::c_char,
+        expectedSize: off_t,
+        cleanupEnabled: bool,
     ) -> bool;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn nocachegetattr(tup: HeapTuple, attnum: ::std::os::raw::c_int, att: TupleDesc) -> Datum;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn heap_getsysattr(
-        tup: HeapTuple,
-        attnum: ::std::os::raw::c_int,
-        tupleDesc: TupleDesc,
-        isnull: *mut bool,
-    ) -> Datum;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn getmissingattr(
-        tupleDesc: TupleDesc,
-        attnum: ::std::os::raw::c_int,
-        isnull: *mut bool,
-    ) -> Datum;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn heap_copytuple(tuple: HeapTuple) -> HeapTuple;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn heap_copytuple_with_tuple(src: HeapTuple, dest: HeapTuple);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn heap_copy_tuple_as_datum(tuple: HeapTuple, tupleDesc: TupleDesc) -> Datum;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn heap_form_tuple(
-        tupleDescriptor: TupleDesc,
-        values: *mut Datum,
-        isnull: *mut bool,
-    ) -> HeapTuple;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn heap_modify_tuple(
-        tuple: HeapTuple,
-        tupleDesc: TupleDesc,
-        replValues: *mut Datum,
-        replIsnull: *mut bool,
-        doReplace: *mut bool,
-    ) -> HeapTuple;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn heap_modify_tuple_by_cols(
-        tuple: HeapTuple,
-        tupleDesc: TupleDesc,
-        nCols: ::std::os::raw::c_int,
-        replCols: *mut ::std::os::raw::c_int,
-        replValues: *mut Datum,
-        replIsnull: *mut bool,
-    ) -> HeapTuple;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn heap_deform_tuple(
-        tuple: HeapTuple,
-        tupleDesc: TupleDesc,
-        values: *mut Datum,
-        isnull: *mut bool,
+    pub fn ExecuteRecoveryCommand(
+        command: *const ::std::os::raw::c_char,
+        commandName: *const ::std::os::raw::c_char,
+        failOnerror: bool,
     );
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn heap_freetuple(htup: HeapTuple);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn heap_form_minimal_tuple(
-        tupleDescriptor: TupleDesc,
-        values: *mut Datum,
-        isnull: *mut bool,
-    ) -> MinimalTuple;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn heap_free_minimal_tuple(mtup: MinimalTuple);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn heap_copy_minimal_tuple(mtup: MinimalTuple) -> MinimalTuple;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn heap_tuple_from_minimal_tuple(mtup: MinimalTuple) -> HeapTuple;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn minimal_tuple_from_heap_tuple(htup: HeapTuple) -> MinimalTuple;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn heap_expand_tuple(sourceTuple: HeapTuple, tupleDesc: TupleDesc) -> HeapTuple;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn minimal_expand_tuple(sourceTuple: HeapTuple, tupleDesc: TupleDesc) -> MinimalTuple;
-}
-pub const relopt_type_RELOPT_TYPE_BOOL: relopt_type = 0;
-pub const relopt_type_RELOPT_TYPE_INT: relopt_type = 1;
-pub const relopt_type_RELOPT_TYPE_REAL: relopt_type = 2;
-pub const relopt_type_RELOPT_TYPE_STRING: relopt_type = 3;
-pub type relopt_type = ::std::os::raw::c_uint;
-pub const relopt_kind_RELOPT_KIND_HEAP: relopt_kind = 1;
-pub const relopt_kind_RELOPT_KIND_TOAST: relopt_kind = 2;
-pub const relopt_kind_RELOPT_KIND_BTREE: relopt_kind = 4;
-pub const relopt_kind_RELOPT_KIND_HASH: relopt_kind = 8;
-pub const relopt_kind_RELOPT_KIND_GIN: relopt_kind = 16;
-pub const relopt_kind_RELOPT_KIND_GIST: relopt_kind = 32;
-pub const relopt_kind_RELOPT_KIND_ATTRIBUTE: relopt_kind = 64;
-pub const relopt_kind_RELOPT_KIND_TABLESPACE: relopt_kind = 128;
-pub const relopt_kind_RELOPT_KIND_SPGIST: relopt_kind = 256;
-pub const relopt_kind_RELOPT_KIND_VIEW: relopt_kind = 512;
-pub const relopt_kind_RELOPT_KIND_BRIN: relopt_kind = 1024;
-pub const relopt_kind_RELOPT_KIND_PARTITIONED: relopt_kind = 2048;
-pub const relopt_kind_RELOPT_KIND_LAST_DEFAULT: relopt_kind = 2048;
-pub const relopt_kind_RELOPT_KIND_INDEX: relopt_kind = 284;
-pub const relopt_kind_RELOPT_KIND_MAX: relopt_kind = 1073741824;
-pub type relopt_kind = ::std::os::raw::c_uint;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct relopt_gen {
-    pub name: *const ::std::os::raw::c_char,
-    pub desc: *const ::std::os::raw::c_char,
-    pub kinds: bits32,
-    pub lockmode: LOCKMODE,
-    pub namelen: ::std::os::raw::c_int,
-    pub type_: relopt_type,
-}
-impl Default for relopt_gen {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct relopt_value {
-    pub gen: *mut relopt_gen,
-    pub isset: bool,
-    pub values: relopt_value__bindgen_ty_1,
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union relopt_value__bindgen_ty_1 {
-    pub bool_val: bool,
-    pub int_val: ::std::os::raw::c_int,
-    pub real_val: f64,
-    pub string_val: *mut ::std::os::raw::c_char,
-}
-impl Default for relopt_value__bindgen_ty_1 {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-impl Default for relopt_value {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct relopt_bool {
-    pub gen: relopt_gen,
-    pub default_val: bool,
-}
-impl Default for relopt_bool {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct relopt_int {
-    pub gen: relopt_gen,
-    pub default_val: ::std::os::raw::c_int,
-    pub min: ::std::os::raw::c_int,
-    pub max: ::std::os::raw::c_int,
-}
-impl Default for relopt_int {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct relopt_real {
-    pub gen: relopt_gen,
-    pub default_val: f64,
-    pub min: f64,
-    pub max: f64,
-}
-impl Default for relopt_real {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type validate_string_relopt =
-    ::std::option::Option<unsafe extern "C" fn(value: *const ::std::os::raw::c_char)>;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct relopt_string {
-    pub gen: relopt_gen,
-    pub default_len: ::std::os::raw::c_int,
-    pub default_isnull: bool,
-    pub validate_cb: validate_string_relopt,
-    pub default_val: *mut ::std::os::raw::c_char,
-}
-impl Default for relopt_string {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct relopt_parse_elt {
-    pub optname: *const ::std::os::raw::c_char,
-    pub opttype: relopt_type,
-    pub offset: ::std::os::raw::c_int,
-}
-impl Default for relopt_parse_elt {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn add_reloption_kind() -> relopt_kind;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn add_bool_reloption(
-        kinds: bits32,
-        name: *const ::std::os::raw::c_char,
-        desc: *const ::std::os::raw::c_char,
-        default_val: bool,
+    pub fn KeepFileRestoredFromArchive(
+        path: *const ::std::os::raw::c_char,
+        xlogfname: *const ::std::os::raw::c_char,
     );
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn add_int_reloption(
-        kinds: bits32,
-        name: *const ::std::os::raw::c_char,
-        desc: *const ::std::os::raw::c_char,
-        default_val: ::std::os::raw::c_int,
-        min_val: ::std::os::raw::c_int,
-        max_val: ::std::os::raw::c_int,
-    );
+    pub fn XLogArchiveNotify(xlog: *const ::std::os::raw::c_char);
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn add_real_reloption(
-        kinds: bits32,
-        name: *const ::std::os::raw::c_char,
-        desc: *const ::std::os::raw::c_char,
-        default_val: f64,
-        min_val: f64,
-        max_val: f64,
-    );
+    pub fn XLogArchiveNotifySeg(segno: XLogSegNo);
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn add_string_reloption(
-        kinds: bits32,
-        name: *const ::std::os::raw::c_char,
-        desc: *const ::std::os::raw::c_char,
-        default_val: *const ::std::os::raw::c_char,
-        validator: validate_string_relopt,
-    );
+    pub fn XLogArchiveForceDone(xlog: *const ::std::os::raw::c_char);
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn transformRelOptions(
-        oldOptions: Datum,
-        defList: *mut List,
-        namspace: *const ::std::os::raw::c_char,
-        validnsps: *mut *mut ::std::os::raw::c_char,
-        ignoreOids: bool,
-        isReset: bool,
-    ) -> Datum;
+    pub fn XLogArchiveCheckDone(xlog: *const ::std::os::raw::c_char) -> bool;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn untransformRelOptions(options: Datum) -> *mut List;
+    pub fn XLogArchiveIsBusy(xlog: *const ::std::os::raw::c_char) -> bool;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn extractRelOptions(
-        tuple: HeapTuple,
-        tupdesc: TupleDesc,
-        amoptions: amoptions_function,
-    ) -> *mut bytea;
+    pub fn XLogArchiveIsReady(xlog: *const ::std::os::raw::c_char) -> bool;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn parseRelOptions(
-        options: Datum,
-        validate: bool,
-        kind: relopt_kind,
-        numrelopts: *mut ::std::os::raw::c_int,
-    ) -> *mut relopt_value;
+    pub fn XLogArchiveIsReadyOrDone(xlog: *const ::std::os::raw::c_char) -> bool;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn allocateReloptStruct(
-        base: Size,
-        options: *mut relopt_value,
-        numoptions: ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_void;
+    pub fn XLogArchiveCleanup(xlog: *const ::std::os::raw::c_char);
 }
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn fillRelOptions(
-        rdopts: *mut ::std::os::raw::c_void,
-        basesize: Size,
-        options: *mut relopt_value,
-        numoptions: ::std::os::raw::c_int,
-        validate: bool,
-        elems: *const relopt_parse_elt,
-        nelems: ::std::os::raw::c_int,
-    );
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct FormData_pg_class {
+    pub relname: NameData,
+    pub relnamespace: Oid,
+    pub reltype: Oid,
+    pub reloftype: Oid,
+    pub relowner: Oid,
+    pub relam: Oid,
+    pub relfilenode: Oid,
+    pub reltablespace: Oid,
+    pub relpages: int32,
+    pub reltuples: float4,
+    pub relallvisible: int32,
+    pub reltoastrelid: Oid,
+    pub relhasindex: bool,
+    pub relisshared: bool,
+    pub relpersistence: ::std::os::raw::c_char,
+    pub relkind: ::std::os::raw::c_char,
+    pub relnatts: int16,
+    pub relchecks: int16,
+    pub relhasoids: bool,
+    pub relhasrules: bool,
+    pub relhastriggers: bool,
+    pub relhassubclass: bool,
+    pub relrowsecurity: bool,
+    pub relforcerowsecurity: bool,
+    pub relispopulated: bool,
+    pub relreplident: ::std::os::raw::c_char,
+    pub relispartition: bool,
+    pub relrewrite: Oid,
+    pub relfrozenxid: TransactionId,
+    pub relminmxid: TransactionId,
 }
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn default_reloptions(reloptions: Datum, validate: bool, kind: relopt_kind) -> *mut bytea;
+impl Default for FormData_pg_class {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn heap_reloptions(
-        relkind: ::std::os::raw::c_char,
-        reloptions: Datum,
-        validate: bool,
-    ) -> *mut bytea;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn view_reloptions(reloptions: Datum, validate: bool) -> *mut bytea;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn index_reloptions(
-        amoptions: amoptions_function,
-        reloptions: Datum,
-        validate: bool,
-    ) -> *mut bytea;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn index_generic_reloptions(reloptions: Datum, validate: bool) -> *mut bytea;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn attribute_reloptions(reloptions: Datum, validate: bool) -> *mut bytea;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn tablespace_reloptions(reloptions: Datum, validate: bool) -> *mut bytea;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn AlterTableGetRelOptionsLockLevel(defList: *mut List) -> LOCKMODE;
-}
+pub type Form_pg_class = *mut FormData_pg_class;
 #[repr(C)]
 #[derive(Debug)]
-pub struct ParallelHeapScanDescData {
-    pub phs_relid: Oid,
-    pub phs_syncscan: bool,
-    pub phs_nblocks: BlockNumber,
-    pub phs_mutex: slock_t,
-    pub phs_startblock: BlockNumber,
-    pub phs_nallocated: pg_atomic_uint64,
-    pub phs_snapshot_any: bool,
-    pub phs_snapshot_data: __IncompleteArrayField<::std::os::raw::c_char>,
+pub struct FormData_pg_index {
+    pub indexrelid: Oid,
+    pub indrelid: Oid,
+    pub indnatts: int16,
+    pub indnkeyatts: int16,
+    pub indisunique: bool,
+    pub indisprimary: bool,
+    pub indisexclusion: bool,
+    pub indimmediate: bool,
+    pub indisclustered: bool,
+    pub indisvalid: bool,
+    pub indcheckxmin: bool,
+    pub indisready: bool,
+    pub indislive: bool,
+    pub indisreplident: bool,
+    pub indkey: int2vector,
 }
-impl Default for ParallelHeapScanDescData {
+impl Default for FormData_pg_index {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -27206,1177 +26652,7 @@ impl Default for ParallelHeapScanDescData {
         }
     }
 }
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct HeapScanDescData {
-    pub rs_rd: Relation,
-    pub rs_snapshot: Snapshot,
-    pub rs_nkeys: ::std::os::raw::c_int,
-    pub rs_key: ScanKey,
-    pub rs_bitmapscan: bool,
-    pub rs_samplescan: bool,
-    pub rs_pageatatime: bool,
-    pub rs_allow_strat: bool,
-    pub rs_allow_sync: bool,
-    pub rs_temp_snap: bool,
-    pub rs_nblocks: BlockNumber,
-    pub rs_startblock: BlockNumber,
-    pub rs_numblocks: BlockNumber,
-    pub rs_strategy: BufferAccessStrategy,
-    pub rs_syncscan: bool,
-    pub rs_inited: bool,
-    pub rs_ctup: HeapTupleData,
-    pub rs_cblock: BlockNumber,
-    pub rs_cbuf: Buffer,
-    pub rs_parallel: ParallelHeapScanDesc,
-    pub rs_cindex: ::std::os::raw::c_int,
-    pub rs_ntuples: ::std::os::raw::c_int,
-    pub rs_vistuples: [OffsetNumber; 291usize],
-}
-impl Default for HeapScanDescData {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct IndexScanDescData {
-    pub heapRelation: Relation,
-    pub indexRelation: Relation,
-    pub xs_snapshot: Snapshot,
-    pub numberOfKeys: ::std::os::raw::c_int,
-    pub numberOfOrderBys: ::std::os::raw::c_int,
-    pub keyData: ScanKey,
-    pub orderByData: ScanKey,
-    pub xs_want_itup: bool,
-    pub xs_temp_snap: bool,
-    pub kill_prior_tuple: bool,
-    pub ignore_killed_tuples: bool,
-    pub xactStartedInRecovery: bool,
-    pub opaque: *mut ::std::os::raw::c_void,
-    pub xs_itup: IndexTuple,
-    pub xs_itupdesc: TupleDesc,
-    pub xs_hitup: HeapTuple,
-    pub xs_hitupdesc: TupleDesc,
-    pub xs_ctup: HeapTupleData,
-    pub xs_cbuf: Buffer,
-    pub xs_recheck: bool,
-    pub xs_orderbyvals: *mut Datum,
-    pub xs_orderbynulls: *mut bool,
-    pub xs_recheckorderby: bool,
-    pub xs_continue_hot: bool,
-    pub parallel_scan: ParallelIndexScanDesc,
-}
-impl Default for IndexScanDescData {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct ParallelIndexScanDescData {
-    pub ps_relid: Oid,
-    pub ps_indexid: Oid,
-    pub ps_offset: Size,
-    pub ps_snapshot_data: __IncompleteArrayField<::std::os::raw::c_char>,
-}
-impl Default for ParallelIndexScanDescData {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct SysScanDescData {
-    pub heap_rel: Relation,
-    pub irel: Relation,
-    pub scan: HeapScanDesc,
-    pub iscan: IndexScanDesc,
-    pub snapshot: Snapshot,
-}
-impl Default for SysScanDescData {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct SharedInvalCatcacheMsg {
-    pub id: int8,
-    pub dbId: Oid,
-    pub hashValue: uint32,
-}
-impl Default for SharedInvalCatcacheMsg {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct SharedInvalCatalogMsg {
-    pub id: int8,
-    pub dbId: Oid,
-    pub catId: Oid,
-}
-impl Default for SharedInvalCatalogMsg {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct SharedInvalRelcacheMsg {
-    pub id: int8,
-    pub dbId: Oid,
-    pub relId: Oid,
-}
-impl Default for SharedInvalRelcacheMsg {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct SharedInvalSmgrMsg {
-    pub id: int8,
-    pub backend_hi: int8,
-    pub backend_lo: uint16,
-    pub rnode: RelFileNode,
-}
-impl Default for SharedInvalSmgrMsg {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct SharedInvalRelmapMsg {
-    pub id: int8,
-    pub dbId: Oid,
-}
-impl Default for SharedInvalRelmapMsg {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct SharedInvalSnapshotMsg {
-    pub id: int8,
-    pub dbId: Oid,
-    pub relId: Oid,
-}
-impl Default for SharedInvalSnapshotMsg {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union SharedInvalidationMessage {
-    pub id: int8,
-    pub cc: SharedInvalCatcacheMsg,
-    pub cat: SharedInvalCatalogMsg,
-    pub rc: SharedInvalRelcacheMsg,
-    pub sm: SharedInvalSmgrMsg,
-    pub rm: SharedInvalRelmapMsg,
-    pub sn: SharedInvalSnapshotMsg,
-}
-impl Default for SharedInvalidationMessage {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-extern "C" {
-    pub static mut SharedInvalidMessageCounter: uint64;
-}
-extern "C" {
-    pub static mut catchupInterruptPending: sig_atomic_t;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn SendSharedInvalidMessages(
-        msgs: *const SharedInvalidationMessage,
-        n: ::std::os::raw::c_int,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn ReceiveSharedInvalidMessages(
-        invalFunction: ::std::option::Option<
-            unsafe extern "C" fn(msg: *mut SharedInvalidationMessage),
-        >,
-        resetFunction: ::std::option::Option<unsafe extern "C" fn()>,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn HandleCatchupInterrupt();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn ProcessCatchupInterrupt();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn xactGetCommittedInvalidationMessages(
-        msgs: *mut *mut SharedInvalidationMessage,
-        RelcacheInitFileInval: *mut bool,
-    ) -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn ProcessCommittedInvalidationMessages(
-        msgs: *mut SharedInvalidationMessage,
-        nmsgs: ::std::os::raw::c_int,
-        RelcacheInitFileInval: bool,
-        dbid: Oid,
-        tsid: Oid,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn LocalExecuteInvalidationMessage(msg: *mut SharedInvalidationMessage);
-}
-extern "C" {
-    pub static mut PgStartTime: TimestampTz;
-}
-extern "C" {
-    pub static mut PgReloadTime: TimestampTz;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn anytimestamp_typmod_check(istz: bool, typmod: int32) -> int32;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetCurrentTimestamp() -> TimestampTz;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetSQLCurrentTimestamp(typmod: int32) -> TimestampTz;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetSQLLocalTimestamp(typmod: int32) -> Timestamp;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn TimestampDifference(
-        start_time: TimestampTz,
-        stop_time: TimestampTz,
-        secs: *mut ::std::os::raw::c_long,
-        microsecs: *mut ::std::os::raw::c_int,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn TimestampDifferenceMilliseconds(
-        start_time: TimestampTz,
-        stop_time: TimestampTz,
-    ) -> ::std::os::raw::c_long;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn TimestampDifferenceExceeds(
-        start_time: TimestampTz,
-        stop_time: TimestampTz,
-        msec: ::std::os::raw::c_int,
-    ) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn time_t_to_timestamptz(tm: pg_time_t) -> TimestampTz;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn timestamptz_to_time_t(t: TimestampTz) -> pg_time_t;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn timestamptz_to_str(t: TimestampTz) -> *const ::std::os::raw::c_char;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn tm2timestamp(
-        tm: *mut pg_tm,
-        fsec: fsec_t,
-        tzp: *mut ::std::os::raw::c_int,
-        dt: *mut Timestamp,
-    ) -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn timestamp2tm(
-        dt: Timestamp,
-        tzp: *mut ::std::os::raw::c_int,
-        tm: *mut pg_tm,
-        fsec: *mut fsec_t,
-        tzn: *mut *const ::std::os::raw::c_char,
-        attimezone: *mut pg_tz,
-    ) -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn dt2time(
-        dt: Timestamp,
-        hour: *mut ::std::os::raw::c_int,
-        min: *mut ::std::os::raw::c_int,
-        sec: *mut ::std::os::raw::c_int,
-        fsec: *mut fsec_t,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn interval2tm(span: Interval, tm: *mut pg_tm, fsec: *mut fsec_t) -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn tm2interval(tm: *mut pg_tm, fsec: fsec_t, span: *mut Interval) -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn SetEpochTimestamp() -> Timestamp;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetEpochTime(tm: *mut pg_tm);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn timestamp_cmp_internal(dt1: Timestamp, dt2: Timestamp) -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn isoweek2j(
-        year: ::std::os::raw::c_int,
-        week: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn isoweek2date(
-        woy: ::std::os::raw::c_int,
-        year: *mut ::std::os::raw::c_int,
-        mon: *mut ::std::os::raw::c_int,
-        mday: *mut ::std::os::raw::c_int,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn isoweekdate2date(
-        isoweek: ::std::os::raw::c_int,
-        wday: ::std::os::raw::c_int,
-        year: *mut ::std::os::raw::c_int,
-        mon: *mut ::std::os::raw::c_int,
-        mday: *mut ::std::os::raw::c_int,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn date2isoweek(
-        year: ::std::os::raw::c_int,
-        mon: ::std::os::raw::c_int,
-        mday: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn date2isoyear(
-        year: ::std::os::raw::c_int,
-        mon: ::std::os::raw::c_int,
-        mday: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn date2isoyearday(
-        year: ::std::os::raw::c_int,
-        mon: ::std::os::raw::c_int,
-        mday: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct tzEntry {
-    _unused: [u8; 0],
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct datetkn {
-    pub token: [::std::os::raw::c_char; 11usize],
-    pub type_: ::std::os::raw::c_char,
-    pub value: int32,
-}
-#[repr(C)]
-#[derive(Debug, Default)]
-pub struct TimeZoneAbbrevTable {
-    pub tblsize: Size,
-    pub numabbrevs: ::std::os::raw::c_int,
-    pub abbrevs: __IncompleteArrayField<datetkn>,
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct DynamicZoneAbbrev {
-    pub tz: *mut pg_tz,
-    pub zone: __IncompleteArrayField<::std::os::raw::c_char>,
-}
-impl Default for DynamicZoneAbbrev {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-extern "C" {
-    pub static mut months: [*const ::std::os::raw::c_char; 0usize];
-}
-extern "C" {
-    pub static mut days: [*const ::std::os::raw::c_char; 0usize];
-}
-extern "C" {
-    pub static mut day_tab: [[::std::os::raw::c_int; 13usize]; 2usize];
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetCurrentDateTime(tm: *mut pg_tm);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetCurrentTimeUsec(tm: *mut pg_tm, fsec: *mut fsec_t, tzp: *mut ::std::os::raw::c_int);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn j2date(
-        jd: ::std::os::raw::c_int,
-        year: *mut ::std::os::raw::c_int,
-        month: *mut ::std::os::raw::c_int,
-        day: *mut ::std::os::raw::c_int,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn date2j(
-        year: ::std::os::raw::c_int,
-        month: ::std::os::raw::c_int,
-        day: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn ParseDateTime(
-        timestr: *const ::std::os::raw::c_char,
-        workbuf: *mut ::std::os::raw::c_char,
-        buflen: usize,
-        field: *mut *mut ::std::os::raw::c_char,
-        ftype: *mut ::std::os::raw::c_int,
-        maxfields: ::std::os::raw::c_int,
-        numfields: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn DecodeDateTime(
-        field: *mut *mut ::std::os::raw::c_char,
-        ftype: *mut ::std::os::raw::c_int,
-        nf: ::std::os::raw::c_int,
-        dtype: *mut ::std::os::raw::c_int,
-        tm: *mut pg_tm,
-        fsec: *mut fsec_t,
-        tzp: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn DecodeTimezone(
-        str_: *mut ::std::os::raw::c_char,
-        tzp: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn DecodeTimeOnly(
-        field: *mut *mut ::std::os::raw::c_char,
-        ftype: *mut ::std::os::raw::c_int,
-        nf: ::std::os::raw::c_int,
-        dtype: *mut ::std::os::raw::c_int,
-        tm: *mut pg_tm,
-        fsec: *mut fsec_t,
-        tzp: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn DecodeInterval(
-        field: *mut *mut ::std::os::raw::c_char,
-        ftype: *mut ::std::os::raw::c_int,
-        nf: ::std::os::raw::c_int,
-        range: ::std::os::raw::c_int,
-        dtype: *mut ::std::os::raw::c_int,
-        tm: *mut pg_tm,
-        fsec: *mut fsec_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn DecodeISO8601Interval(
-        str_: *mut ::std::os::raw::c_char,
-        dtype: *mut ::std::os::raw::c_int,
-        tm: *mut pg_tm,
-        fsec: *mut fsec_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn DateTimeParseError(
-        dterr: ::std::os::raw::c_int,
-        str_: *const ::std::os::raw::c_char,
-        datatype: *const ::std::os::raw::c_char,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn DetermineTimeZoneOffset(tm: *mut pg_tm, tzp: *mut pg_tz) -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn DetermineTimeZoneAbbrevOffset(
-        tm: *mut pg_tm,
-        abbr: *const ::std::os::raw::c_char,
-        tzp: *mut pg_tz,
-    ) -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn DetermineTimeZoneAbbrevOffsetTS(
-        ts: TimestampTz,
-        abbr: *const ::std::os::raw::c_char,
-        tzp: *mut pg_tz,
-        isdst: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn EncodeDateOnly(
-        tm: *mut pg_tm,
-        style: ::std::os::raw::c_int,
-        str_: *mut ::std::os::raw::c_char,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn EncodeTimeOnly(
-        tm: *mut pg_tm,
-        fsec: fsec_t,
-        print_tz: bool,
-        tz: ::std::os::raw::c_int,
-        style: ::std::os::raw::c_int,
-        str_: *mut ::std::os::raw::c_char,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn EncodeDateTime(
-        tm: *mut pg_tm,
-        fsec: fsec_t,
-        print_tz: bool,
-        tz: ::std::os::raw::c_int,
-        tzn: *const ::std::os::raw::c_char,
-        style: ::std::os::raw::c_int,
-        str_: *mut ::std::os::raw::c_char,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn EncodeInterval(
-        tm: *mut pg_tm,
-        fsec: fsec_t,
-        style: ::std::os::raw::c_int,
-        str_: *mut ::std::os::raw::c_char,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn EncodeSpecialTimestamp(dt: Timestamp, str_: *mut ::std::os::raw::c_char);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn ValidateDate(
-        fmask: ::std::os::raw::c_int,
-        isjulian: bool,
-        is2digits: bool,
-        bc: bool,
-        tm: *mut pg_tm,
-    ) -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn DecodeTimezoneAbbrev(
-        field: ::std::os::raw::c_int,
-        lowtoken: *mut ::std::os::raw::c_char,
-        offset: *mut ::std::os::raw::c_int,
-        tz: *mut *mut pg_tz,
-    ) -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn DecodeSpecial(
-        field: ::std::os::raw::c_int,
-        lowtoken: *mut ::std::os::raw::c_char,
-        val: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn DecodeUnits(
-        field: ::std::os::raw::c_int,
-        lowtoken: *mut ::std::os::raw::c_char,
-        val: *mut ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn j2day(jd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn TemporalTransform(max_precis: int32, node: *mut Node) -> *mut Node;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn CheckDateTokenTables() -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn ConvertTimeZoneAbbrevs(
-        abbrevs: *mut tzEntry,
-        n: ::std::os::raw::c_int,
-    ) -> *mut TimeZoneAbbrevTable;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn InstallTimeZoneAbbrevs(tbl: *mut TimeZoneAbbrevTable);
-}
-extern "C" {
-    pub static mut DefaultXactIsoLevel: ::std::os::raw::c_int;
-}
-extern "C" {
-    pub static mut XactIsoLevel: ::std::os::raw::c_int;
-}
-extern "C" {
-    pub static mut DefaultXactReadOnly: bool;
-}
-extern "C" {
-    pub static mut XactReadOnly: bool;
-}
-extern "C" {
-    pub static mut DefaultXactDeferrable: bool;
-}
-extern "C" {
-    pub static mut XactDeferrable: bool;
-}
-pub const SyncCommitLevel_SYNCHRONOUS_COMMIT_OFF: SyncCommitLevel = 0;
-pub const SyncCommitLevel_SYNCHRONOUS_COMMIT_LOCAL_FLUSH: SyncCommitLevel = 1;
-pub const SyncCommitLevel_SYNCHRONOUS_COMMIT_REMOTE_WRITE: SyncCommitLevel = 2;
-pub const SyncCommitLevel_SYNCHRONOUS_COMMIT_REMOTE_FLUSH: SyncCommitLevel = 3;
-pub const SyncCommitLevel_SYNCHRONOUS_COMMIT_REMOTE_APPLY: SyncCommitLevel = 4;
-pub type SyncCommitLevel = ::std::os::raw::c_uint;
-extern "C" {
-    pub static mut synchronous_commit: ::std::os::raw::c_int;
-}
-extern "C" {
-    pub static mut MyXactFlags: ::std::os::raw::c_int;
-}
-pub const XactEvent_XACT_EVENT_COMMIT: XactEvent = 0;
-pub const XactEvent_XACT_EVENT_PARALLEL_COMMIT: XactEvent = 1;
-pub const XactEvent_XACT_EVENT_ABORT: XactEvent = 2;
-pub const XactEvent_XACT_EVENT_PARALLEL_ABORT: XactEvent = 3;
-pub const XactEvent_XACT_EVENT_PREPARE: XactEvent = 4;
-pub const XactEvent_XACT_EVENT_PRE_COMMIT: XactEvent = 5;
-pub const XactEvent_XACT_EVENT_PARALLEL_PRE_COMMIT: XactEvent = 6;
-pub const XactEvent_XACT_EVENT_PRE_PREPARE: XactEvent = 7;
-pub type XactEvent = ::std::os::raw::c_uint;
-pub type XactCallback =
-    ::std::option::Option<unsafe extern "C" fn(event: XactEvent, arg: *mut ::std::os::raw::c_void)>;
-pub const SubXactEvent_SUBXACT_EVENT_START_SUB: SubXactEvent = 0;
-pub const SubXactEvent_SUBXACT_EVENT_COMMIT_SUB: SubXactEvent = 1;
-pub const SubXactEvent_SUBXACT_EVENT_ABORT_SUB: SubXactEvent = 2;
-pub const SubXactEvent_SUBXACT_EVENT_PRE_COMMIT_SUB: SubXactEvent = 3;
-pub type SubXactEvent = ::std::os::raw::c_uint;
-pub type SubXactCallback = ::std::option::Option<
-    unsafe extern "C" fn(
-        event: SubXactEvent,
-        mySubid: SubTransactionId,
-        parentSubid: SubTransactionId,
-        arg: *mut ::std::os::raw::c_void,
-    ),
->;
-#[repr(C)]
-#[derive(Debug, Default)]
-pub struct xl_xact_assignment {
-    pub xtop: TransactionId,
-    pub nsubxacts: ::std::os::raw::c_int,
-    pub xsub: __IncompleteArrayField<TransactionId>,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct xl_xact_xinfo {
-    pub xinfo: uint32,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct xl_xact_dbinfo {
-    pub dbId: Oid,
-    pub tsId: Oid,
-}
-impl Default for xl_xact_dbinfo {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default)]
-pub struct xl_xact_subxacts {
-    pub nsubxacts: ::std::os::raw::c_int,
-    pub subxacts: __IncompleteArrayField<TransactionId>,
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct xl_xact_relfilenodes {
-    pub nrels: ::std::os::raw::c_int,
-    pub xnodes: __IncompleteArrayField<RelFileNode>,
-}
-impl Default for xl_xact_relfilenodes {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-pub struct xl_xact_invals {
-    pub nmsgs: ::std::os::raw::c_int,
-    pub msgs: __IncompleteArrayField<SharedInvalidationMessage>,
-}
-impl Default for xl_xact_invals {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct xl_xact_twophase {
-    pub xid: TransactionId,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct xl_xact_origin {
-    pub origin_lsn: XLogRecPtr,
-    pub origin_timestamp: TimestampTz,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct xl_xact_commit {
-    pub xact_time: TimestampTz,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct xl_xact_abort {
-    pub xact_time: TimestampTz,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct xl_xact_parsed_commit {
-    pub xact_time: TimestampTz,
-    pub xinfo: uint32,
-    pub dbId: Oid,
-    pub tsId: Oid,
-    pub nsubxacts: ::std::os::raw::c_int,
-    pub subxacts: *mut TransactionId,
-    pub nrels: ::std::os::raw::c_int,
-    pub xnodes: *mut RelFileNode,
-    pub nmsgs: ::std::os::raw::c_int,
-    pub msgs: *mut SharedInvalidationMessage,
-    pub twophase_xid: TransactionId,
-    pub twophase_gid: [::std::os::raw::c_char; 200usize],
-    pub nabortrels: ::std::os::raw::c_int,
-    pub abortnodes: *mut RelFileNode,
-    pub origin_lsn: XLogRecPtr,
-    pub origin_timestamp: TimestampTz,
-}
-impl Default for xl_xact_parsed_commit {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type xl_xact_parsed_prepare = xl_xact_parsed_commit;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct xl_xact_parsed_abort {
-    pub xact_time: TimestampTz,
-    pub xinfo: uint32,
-    pub dbId: Oid,
-    pub tsId: Oid,
-    pub nsubxacts: ::std::os::raw::c_int,
-    pub subxacts: *mut TransactionId,
-    pub nrels: ::std::os::raw::c_int,
-    pub xnodes: *mut RelFileNode,
-    pub twophase_xid: TransactionId,
-    pub twophase_gid: [::std::os::raw::c_char; 200usize],
-    pub origin_lsn: XLogRecPtr,
-    pub origin_timestamp: TimestampTz,
-}
-impl Default for xl_xact_parsed_abort {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn IsTransactionState() -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn IsAbortedTransactionBlockState() -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetTopTransactionId() -> TransactionId;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetTopTransactionIdIfAny() -> TransactionId;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetCurrentTransactionId() -> TransactionId;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetCurrentTransactionIdIfAny() -> TransactionId;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetStableLatestTransactionId() -> TransactionId;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetCurrentSubTransactionId() -> SubTransactionId;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn MarkCurrentTransactionIdLoggedIfAny();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn SubTransactionIsActive(subxid: SubTransactionId) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetCurrentCommandId(used: bool) -> CommandId;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn SetParallelStartTimestamps(xact_ts: TimestampTz, stmt_ts: TimestampTz);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetCurrentTransactionStartTimestamp() -> TimestampTz;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetCurrentStatementStartTimestamp() -> TimestampTz;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetCurrentTransactionStopTimestamp() -> TimestampTz;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn SetCurrentStatementStartTimestamp();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetCurrentTransactionNestLevel() -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn TransactionIdIsCurrentTransactionId(xid: TransactionId) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn CommandCounterIncrement();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn ForceSyncCommit();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn StartTransactionCommand();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn CommitTransactionCommand();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn AbortCurrentTransaction();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn BeginTransactionBlock();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn EndTransactionBlock() -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn PrepareTransactionBlock(gid: *const ::std::os::raw::c_char) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn UserAbortTransactionBlock();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn BeginImplicitTransactionBlock();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn EndImplicitTransactionBlock();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn ReleaseSavepoint(name: *const ::std::os::raw::c_char);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn DefineSavepoint(name: *const ::std::os::raw::c_char);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn RollbackToSavepoint(name: *const ::std::os::raw::c_char);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn BeginInternalSubTransaction(name: *const ::std::os::raw::c_char);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn ReleaseCurrentSubTransaction();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn RollbackAndReleaseCurrentSubTransaction();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn IsSubTransaction() -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn EstimateTransactionStateSpace() -> Size;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn SerializeTransactionState(maxsize: Size, start_address: *mut ::std::os::raw::c_char);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn StartParallelWorkerTransaction(tstatespace: *mut ::std::os::raw::c_char);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn EndParallelWorkerTransaction();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn IsTransactionBlock() -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn IsTransactionOrTransactionBlock() -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn TransactionBlockStatusCode() -> ::std::os::raw::c_char;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn AbortOutOfAnyTransaction();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn PreventInTransactionBlock(isTopLevel: bool, stmtType: *const ::std::os::raw::c_char);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn RequireTransactionBlock(isTopLevel: bool, stmtType: *const ::std::os::raw::c_char);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn WarnNoTransactionBlock(isTopLevel: bool, stmtType: *const ::std::os::raw::c_char);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn IsInTransactionBlock(isTopLevel: bool) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn RegisterXactCallback(callback: XactCallback, arg: *mut ::std::os::raw::c_void);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn UnregisterXactCallback(callback: XactCallback, arg: *mut ::std::os::raw::c_void);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn RegisterSubXactCallback(callback: SubXactCallback, arg: *mut ::std::os::raw::c_void);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn UnregisterSubXactCallback(callback: SubXactCallback, arg: *mut ::std::os::raw::c_void);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn xactGetCommittedChildren(ptr: *mut *mut TransactionId) -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn XactLogCommitRecord(
-        commit_time: TimestampTz,
-        nsubxacts: ::std::os::raw::c_int,
-        subxacts: *mut TransactionId,
-        nrels: ::std::os::raw::c_int,
-        rels: *mut RelFileNode,
-        nmsgs: ::std::os::raw::c_int,
-        msgs: *mut SharedInvalidationMessage,
-        relcacheInval: bool,
-        forceSync: bool,
-        xactflags: ::std::os::raw::c_int,
-        twophase_xid: TransactionId,
-        twophase_gid: *const ::std::os::raw::c_char,
-    ) -> XLogRecPtr;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn XactLogAbortRecord(
-        abort_time: TimestampTz,
-        nsubxacts: ::std::os::raw::c_int,
-        subxacts: *mut TransactionId,
-        nrels: ::std::os::raw::c_int,
-        rels: *mut RelFileNode,
-        xactflags: ::std::os::raw::c_int,
-        twophase_xid: TransactionId,
-        twophase_gid: *const ::std::os::raw::c_char,
-    ) -> XLogRecPtr;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn xact_redo(record: *mut XLogReaderState);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn xact_desc(buf: StringInfo, record: *mut XLogReaderState);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn xact_identify(info: uint8) -> *const ::std::os::raw::c_char;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn ParseCommitRecord(
-        info: uint8,
-        xlrec: *mut xl_xact_commit,
-        parsed: *mut xl_xact_parsed_commit,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn ParseAbortRecord(
-        info: uint8,
-        xlrec: *mut xl_xact_abort,
-        parsed: *mut xl_xact_parsed_abort,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn EnterParallelMode();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn ExitParallelMode();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn IsInParallelMode() -> bool;
-}
+pub type Form_pg_index = *mut FormData_pg_index;
 pub const ParseExprKind_EXPR_KIND_NONE: ParseExprKind = 0;
 pub const ParseExprKind_EXPR_KIND_OTHER: ParseExprKind = 1;
 pub const ParseExprKind_EXPR_KIND_JOIN_ON: ParseExprKind = 2;
@@ -29769,6 +28045,2537 @@ extern "C" {
 extern "C" {
     pub fn get_relkind_objtype(relkind: ::std::os::raw::c_char) -> ObjectType;
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct FormData_pg_publication {
+    pub pubname: NameData,
+    pub pubowner: Oid,
+    pub puballtables: bool,
+    pub pubinsert: bool,
+    pub pubupdate: bool,
+    pub pubdelete: bool,
+    pub pubtruncate: bool,
+}
+impl Default for FormData_pg_publication {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type Form_pg_publication = *mut FormData_pg_publication;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct PublicationActions {
+    pub pubinsert: bool,
+    pub pubupdate: bool,
+    pub pubdelete: bool,
+    pub pubtruncate: bool,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct Publication {
+    pub oid: Oid,
+    pub name: *mut ::std::os::raw::c_char,
+    pub alltables: bool,
+    pub pubactions: PublicationActions,
+}
+impl Default for Publication {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetPublication(pubid: Oid) -> *mut Publication;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetPublicationByName(
+        pubname: *const ::std::os::raw::c_char,
+        missing_ok: bool,
+    ) -> *mut Publication;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetRelationPublications(relid: Oid) -> *mut List;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetPublicationRelations(pubid: Oid) -> *mut List;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetAllTablesPublications() -> *mut List;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetAllTablesPublicationRelations() -> *mut List;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn is_publishable_relation(rel: Relation) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn publication_add_relation(
+        pubid: Oid,
+        targetrel: Relation,
+        if_not_exists: bool,
+    ) -> ObjectAddress;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_publication_oid(pubname: *const ::std::os::raw::c_char, missing_ok: bool) -> Oid;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_publication_name(pubid: Oid) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn pg_get_publication_tables(fcinfo: FunctionCallInfo) -> Datum;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct RewriteRule {
+    pub ruleId: Oid,
+    pub event: CmdType,
+    pub qual: *mut Node,
+    pub actions: *mut List,
+    pub enabled: ::std::os::raw::c_char,
+    pub isInstead: bool,
+}
+impl Default for RewriteRule {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct RuleLock {
+    pub numLocks: ::std::os::raw::c_int,
+    pub rules: *mut *mut RewriteRule,
+}
+impl Default for RuleLock {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct SMgrRelationData {
+    pub smgr_rnode: RelFileNodeBackend,
+    pub smgr_owner: *mut *mut SMgrRelationData,
+    pub smgr_targblock: BlockNumber,
+    pub smgr_fsm_nblocks: BlockNumber,
+    pub smgr_vm_nblocks: BlockNumber,
+    pub smgr_which: ::std::os::raw::c_int,
+    pub md_num_open_segs: [::std::os::raw::c_int; 4usize],
+    pub md_seg_fds: [*mut _MdfdVec; 4usize],
+    pub node: dlist_node,
+}
+impl Default for SMgrRelationData {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type SMgrRelation = *mut SMgrRelationData;
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrinit();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgropen(rnode: RelFileNode, backend: BackendId) -> SMgrRelation;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrexists(reln: SMgrRelation, forknum: ForkNumber) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrsetowner(owner: *mut SMgrRelation, reln: SMgrRelation);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrclearowner(owner: *mut SMgrRelation, reln: SMgrRelation);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrclose(reln: SMgrRelation);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrcloseall();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrclosenode(rnode: RelFileNodeBackend);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrcreate(reln: SMgrRelation, forknum: ForkNumber, isRedo: bool);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrdounlink(reln: SMgrRelation, isRedo: bool);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrdounlinkall(rels: *mut SMgrRelation, nrels: ::std::os::raw::c_int, isRedo: bool);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrdounlinkfork(reln: SMgrRelation, forknum: ForkNumber, isRedo: bool);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrextend(
+        reln: SMgrRelation,
+        forknum: ForkNumber,
+        blocknum: BlockNumber,
+        buffer: *mut ::std::os::raw::c_char,
+        skipFsync: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrprefetch(reln: SMgrRelation, forknum: ForkNumber, blocknum: BlockNumber);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrread(
+        reln: SMgrRelation,
+        forknum: ForkNumber,
+        blocknum: BlockNumber,
+        buffer: *mut ::std::os::raw::c_char,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrwrite(
+        reln: SMgrRelation,
+        forknum: ForkNumber,
+        blocknum: BlockNumber,
+        buffer: *mut ::std::os::raw::c_char,
+        skipFsync: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrwriteback(
+        reln: SMgrRelation,
+        forknum: ForkNumber,
+        blocknum: BlockNumber,
+        nblocks: BlockNumber,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrnblocks(reln: SMgrRelation, forknum: ForkNumber) -> BlockNumber;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrtruncate(reln: SMgrRelation, forknum: ForkNumber, nblocks: BlockNumber);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrimmedsync(reln: SMgrRelation, forknum: ForkNumber);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrpreckpt();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrsync();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrpostckpt();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn AtEOXact_SMgr();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn mdinit();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn mdclose(reln: SMgrRelation, forknum: ForkNumber);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn mdcreate(reln: SMgrRelation, forknum: ForkNumber, isRedo: bool);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn mdexists(reln: SMgrRelation, forknum: ForkNumber) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn mdunlink(rnode: RelFileNodeBackend, forknum: ForkNumber, isRedo: bool);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn mdextend(
+        reln: SMgrRelation,
+        forknum: ForkNumber,
+        blocknum: BlockNumber,
+        buffer: *mut ::std::os::raw::c_char,
+        skipFsync: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn mdprefetch(reln: SMgrRelation, forknum: ForkNumber, blocknum: BlockNumber);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn mdread(
+        reln: SMgrRelation,
+        forknum: ForkNumber,
+        blocknum: BlockNumber,
+        buffer: *mut ::std::os::raw::c_char,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn mdwrite(
+        reln: SMgrRelation,
+        forknum: ForkNumber,
+        blocknum: BlockNumber,
+        buffer: *mut ::std::os::raw::c_char,
+        skipFsync: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn mdwriteback(
+        reln: SMgrRelation,
+        forknum: ForkNumber,
+        blocknum: BlockNumber,
+        nblocks: BlockNumber,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn mdnblocks(reln: SMgrRelation, forknum: ForkNumber) -> BlockNumber;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn mdtruncate(reln: SMgrRelation, forknum: ForkNumber, nblocks: BlockNumber);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn mdimmedsync(reln: SMgrRelation, forknum: ForkNumber);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn mdpreckpt();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn mdsync();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn mdpostckpt();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SetForwardFsyncRequests();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RememberFsyncRequest(rnode: RelFileNode, forknum: ForkNumber, segno: BlockNumber);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ForgetRelationFsyncRequests(rnode: RelFileNode, forknum: ForkNumber);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ForgetDatabaseFsyncRequests(dbid: Oid);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DropRelationFiles(
+        delrels: *mut RelFileNode,
+        ndelrels: ::std::os::raw::c_int,
+        isRedo: bool,
+    );
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct LockRelId {
+    pub relId: Oid,
+    pub dbId: Oid,
+}
+impl Default for LockRelId {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct LockInfoData {
+    pub lockRelId: LockRelId,
+}
+impl Default for LockInfoData {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type LockInfo = *mut LockInfoData;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct RelationData {
+    pub rd_node: RelFileNode,
+    pub rd_smgr: SMgrRelation,
+    pub rd_refcnt: ::std::os::raw::c_int,
+    pub rd_backend: BackendId,
+    pub rd_islocaltemp: bool,
+    pub rd_isnailed: bool,
+    pub rd_isvalid: bool,
+    pub rd_indexvalid: ::std::os::raw::c_char,
+    pub rd_statvalid: bool,
+    pub rd_createSubid: SubTransactionId,
+    pub rd_newRelfilenodeSubid: SubTransactionId,
+    pub rd_rel: Form_pg_class,
+    pub rd_att: TupleDesc,
+    pub rd_id: Oid,
+    pub rd_lockInfo: LockInfoData,
+    pub rd_rules: *mut RuleLock,
+    pub rd_rulescxt: MemoryContext,
+    pub trigdesc: *mut TriggerDesc,
+    pub rd_rsdesc: *mut RowSecurityDesc,
+    pub rd_fkeylist: *mut List,
+    pub rd_fkeyvalid: bool,
+    pub rd_partkeycxt: MemoryContext,
+    pub rd_partkey: *mut PartitionKeyData,
+    pub rd_pdcxt: MemoryContext,
+    pub rd_partdesc: *mut PartitionDescData,
+    pub rd_partcheck: *mut List,
+    pub rd_indexlist: *mut List,
+    pub rd_oidindex: Oid,
+    pub rd_pkindex: Oid,
+    pub rd_replidindex: Oid,
+    pub rd_statlist: *mut List,
+    pub rd_indexattr: *mut Bitmapset,
+    pub rd_projindexattr: *mut Bitmapset,
+    pub rd_keyattr: *mut Bitmapset,
+    pub rd_pkattr: *mut Bitmapset,
+    pub rd_idattr: *mut Bitmapset,
+    pub rd_projidx: *mut Bitmapset,
+    pub rd_pubactions: *mut PublicationActions,
+    pub rd_options: *mut bytea,
+    pub rd_index: Form_pg_index,
+    pub rd_indextuple: *mut HeapTupleData,
+    pub rd_amhandler: Oid,
+    pub rd_indexcxt: MemoryContext,
+    pub rd_amroutine: *mut IndexAmRoutine,
+    pub rd_opfamily: *mut Oid,
+    pub rd_opcintype: *mut Oid,
+    pub rd_support: *mut RegProcedure,
+    pub rd_supportinfo: *mut FmgrInfo,
+    pub rd_indoption: *mut int16,
+    pub rd_indexprs: *mut List,
+    pub rd_indpred: *mut List,
+    pub rd_exclops: *mut Oid,
+    pub rd_exclprocs: *mut Oid,
+    pub rd_exclstrats: *mut uint16,
+    pub rd_amcache: *mut ::std::os::raw::c_void,
+    pub rd_indcollation: *mut Oid,
+    pub rd_fdwroutine: *mut FdwRoutine,
+    pub rd_toastoid: Oid,
+    pub pgstat_info: *mut PgStat_TableStatus,
+    pub rd_partcheckvalid: bool,
+    pub rd_partcheckcxt: MemoryContext,
+}
+impl Default for RelationData {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ForeignKeyCacheInfo {
+    pub type_: NodeTag,
+    pub conoid: Oid,
+    pub conrelid: Oid,
+    pub confrelid: Oid,
+    pub nkeys: ::std::os::raw::c_int,
+    pub conkey: [AttrNumber; 32usize],
+    pub confkey: [AttrNumber; 32usize],
+    pub conpfeqop: [Oid; 32usize],
+}
+impl Default for ForeignKeyCacheInfo {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct GenericIndexOpts {
+    pub vl_len_: int32,
+    pub recheck_on_update: bool,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct AutoVacOpts {
+    pub enabled: bool,
+    pub vacuum_threshold: ::std::os::raw::c_int,
+    pub analyze_threshold: ::std::os::raw::c_int,
+    pub vacuum_cost_delay: ::std::os::raw::c_int,
+    pub vacuum_cost_limit: ::std::os::raw::c_int,
+    pub freeze_min_age: ::std::os::raw::c_int,
+    pub freeze_max_age: ::std::os::raw::c_int,
+    pub freeze_table_age: ::std::os::raw::c_int,
+    pub multixact_freeze_min_age: ::std::os::raw::c_int,
+    pub multixact_freeze_max_age: ::std::os::raw::c_int,
+    pub multixact_freeze_table_age: ::std::os::raw::c_int,
+    pub log_min_duration: ::std::os::raw::c_int,
+    pub vacuum_scale_factor: float8,
+    pub analyze_scale_factor: float8,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct StdRdOptions {
+    pub vl_len_: int32,
+    pub fillfactor: ::std::os::raw::c_int,
+    pub vacuum_cleanup_index_scale_factor: float8,
+    pub toast_tuple_target: ::std::os::raw::c_int,
+    pub autovacuum: AutoVacOpts,
+    pub user_catalog_table: bool,
+    pub parallel_workers: ::std::os::raw::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ViewOptions {
+    pub vl_len_: int32,
+    pub security_barrier: bool,
+    pub check_option_offset: ::std::os::raw::c_int,
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RelationIncrementReferenceCount(rel: Relation);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RelationDecrementReferenceCount(rel: Relation);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RelationGetRepsetList(rel: Relation) -> *mut List;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct GenericXLogState {
+    _unused: [u8; 0],
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GenericXLogStart(relation: Relation) -> *mut GenericXLogState;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GenericXLogRegisterBuffer(
+        state: *mut GenericXLogState,
+        buffer: Buffer,
+        flags: ::std::os::raw::c_int,
+    ) -> Page;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GenericXLogFinish(state: *mut GenericXLogState) -> XLogRecPtr;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GenericXLogAbort(state: *mut GenericXLogState);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn generic_redo(record: *mut XLogReaderState);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn generic_identify(info: uint8) -> *const ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn generic_desc(buf: StringInfo, record: *mut XLogReaderState);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn generic_mask(pagedata: *mut ::std::os::raw::c_char, blkno: BlockNumber);
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct GinStatsData {
+    pub nPendingPages: BlockNumber,
+    pub nTotalPages: BlockNumber,
+    pub nEntryPages: BlockNumber,
+    pub nDataPages: BlockNumber,
+    pub nEntries: int64,
+    pub ginVersion: int32,
+}
+pub type GinTernaryValue = ::std::os::raw::c_char;
+extern "C" {
+    pub static mut GinFuzzySearchLimit: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut gin_pending_list_limit: ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ginGetStats(index: Relation, stats: *mut GinStatsData);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ginUpdateStats(index: Relation, stats: *const GinStatsData);
+}
+pub type GistNSN = XLogRecPtr;
+pub type PageGistNSN = PageXLogRecPtr;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct GISTPageOpaqueData {
+    pub nsn: PageGistNSN,
+    pub rightlink: BlockNumber,
+    pub flags: uint16,
+    pub gist_page_id: uint16,
+}
+pub type GISTPageOpaque = *mut GISTPageOpaqueData;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct GIST_SPLITVEC {
+    pub spl_left: *mut OffsetNumber,
+    pub spl_nleft: ::std::os::raw::c_int,
+    pub spl_ldatum: Datum,
+    pub spl_ldatum_exists: bool,
+    pub spl_right: *mut OffsetNumber,
+    pub spl_nright: ::std::os::raw::c_int,
+    pub spl_rdatum: Datum,
+    pub spl_rdatum_exists: bool,
+}
+impl Default for GIST_SPLITVEC {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct GISTENTRY {
+    pub key: Datum,
+    pub rel: Relation,
+    pub page: Page,
+    pub offset: OffsetNumber,
+    pub leafkey: bool,
+}
+impl Default for GISTENTRY {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct GistEntryVector {
+    pub n: int32,
+    pub vector: __IncompleteArrayField<GISTENTRY>,
+}
+impl Default for GistEntryVector {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct VariableCacheData {
+    pub nextOid: Oid,
+    pub oidCount: uint32,
+    pub nextXid: TransactionId,
+    pub oldestXid: TransactionId,
+    pub xidVacLimit: TransactionId,
+    pub xidWarnLimit: TransactionId,
+    pub xidStopLimit: TransactionId,
+    pub xidWrapLimit: TransactionId,
+    pub oldestXidDB: Oid,
+    pub oldestCommitTsXid: TransactionId,
+    pub newestCommitTsXid: TransactionId,
+    pub latestCompletedXid: TransactionId,
+    pub oldestClogXid: TransactionId,
+}
+impl Default for VariableCacheData {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type VariableCache = *mut VariableCacheData;
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn TransactionStartedDuringRecovery() -> bool;
+}
+extern "C" {
+    pub static mut ShmemVariableCache: VariableCache;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn TransactionIdDidCommit(transactionId: TransactionId) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn TransactionIdDidAbort(transactionId: TransactionId) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn TransactionIdIsKnownCompleted(transactionId: TransactionId) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn TransactionIdAbort(transactionId: TransactionId);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn TransactionIdCommitTree(
+        xid: TransactionId,
+        nxids: ::std::os::raw::c_int,
+        xids: *mut TransactionId,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn TransactionIdAsyncCommitTree(
+        xid: TransactionId,
+        nxids: ::std::os::raw::c_int,
+        xids: *mut TransactionId,
+        lsn: XLogRecPtr,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn TransactionIdAbortTree(
+        xid: TransactionId,
+        nxids: ::std::os::raw::c_int,
+        xids: *mut TransactionId,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn TransactionIdPrecedes(id1: TransactionId, id2: TransactionId) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn TransactionIdPrecedesOrEquals(id1: TransactionId, id2: TransactionId) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn TransactionIdFollows(id1: TransactionId, id2: TransactionId) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn TransactionIdFollowsOrEquals(id1: TransactionId, id2: TransactionId) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn TransactionIdLatest(
+        mainxid: TransactionId,
+        nxids: ::std::os::raw::c_int,
+        xids: *const TransactionId,
+    ) -> TransactionId;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn TransactionIdGetCommitLSN(xid: TransactionId) -> XLogRecPtr;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetNewTransactionId(isSubXact: bool) -> TransactionId;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ReadNewTransactionId() -> TransactionId;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SetTransactionIdLimit(oldest_datfrozenxid: TransactionId, oldest_datoid: Oid);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn AdvanceOldestClogXid(oldest_datfrozenxid: TransactionId);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ForceTransactionIdLimitUpdate() -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetNewObjectId() -> Oid;
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct HeapTupleFields {
+    pub t_xmin: TransactionId,
+    pub t_xmax: TransactionId,
+    pub t_field3: HeapTupleFields__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union HeapTupleFields__bindgen_ty_1 {
+    pub t_cid: CommandId,
+    pub t_xvac: TransactionId,
+}
+impl Default for HeapTupleFields__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl Default for HeapTupleFields {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct DatumTupleFields {
+    pub datum_len_: int32,
+    pub datum_typmod: int32,
+    pub datum_typeid: Oid,
+}
+impl Default for DatumTupleFields {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+pub struct HeapTupleHeaderData {
+    pub t_choice: HeapTupleHeaderData__bindgen_ty_1,
+    pub t_ctid: ItemPointerData,
+    pub t_infomask2: uint16,
+    pub t_infomask: uint16,
+    pub t_hoff: uint8,
+    pub t_bits: __IncompleteArrayField<bits8>,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union HeapTupleHeaderData__bindgen_ty_1 {
+    pub t_heap: HeapTupleFields,
+    pub t_datum: DatumTupleFields,
+}
+impl Default for HeapTupleHeaderData__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl Default for HeapTupleHeaderData {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default)]
+pub struct MinimalTupleData {
+    pub t_len: uint32,
+    pub mt_padding: [::std::os::raw::c_char; 6usize],
+    pub t_infomask2: uint16,
+    pub t_infomask: uint16,
+    pub t_hoff: uint8,
+    pub t_bits: __IncompleteArrayField<bits8>,
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn heap_compute_data_size(
+        tupleDesc: TupleDesc,
+        values: *mut Datum,
+        isnull: *mut bool,
+    ) -> Size;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn heap_fill_tuple(
+        tupleDesc: TupleDesc,
+        values: *mut Datum,
+        isnull: *mut bool,
+        data: *mut ::std::os::raw::c_char,
+        data_size: Size,
+        infomask: *mut uint16,
+        bit: *mut bits8,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn heap_attisnull(
+        tup: HeapTuple,
+        attnum: ::std::os::raw::c_int,
+        tupleDesc: TupleDesc,
+    ) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn nocachegetattr(tup: HeapTuple, attnum: ::std::os::raw::c_int, att: TupleDesc) -> Datum;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn heap_getsysattr(
+        tup: HeapTuple,
+        attnum: ::std::os::raw::c_int,
+        tupleDesc: TupleDesc,
+        isnull: *mut bool,
+    ) -> Datum;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn getmissingattr(
+        tupleDesc: TupleDesc,
+        attnum: ::std::os::raw::c_int,
+        isnull: *mut bool,
+    ) -> Datum;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn heap_copytuple(tuple: HeapTuple) -> HeapTuple;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn heap_copytuple_with_tuple(src: HeapTuple, dest: HeapTuple);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn heap_copy_tuple_as_datum(tuple: HeapTuple, tupleDesc: TupleDesc) -> Datum;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn heap_form_tuple(
+        tupleDescriptor: TupleDesc,
+        values: *mut Datum,
+        isnull: *mut bool,
+    ) -> HeapTuple;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn heap_modify_tuple(
+        tuple: HeapTuple,
+        tupleDesc: TupleDesc,
+        replValues: *mut Datum,
+        replIsnull: *mut bool,
+        doReplace: *mut bool,
+    ) -> HeapTuple;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn heap_modify_tuple_by_cols(
+        tuple: HeapTuple,
+        tupleDesc: TupleDesc,
+        nCols: ::std::os::raw::c_int,
+        replCols: *mut ::std::os::raw::c_int,
+        replValues: *mut Datum,
+        replIsnull: *mut bool,
+    ) -> HeapTuple;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn heap_deform_tuple(
+        tuple: HeapTuple,
+        tupleDesc: TupleDesc,
+        values: *mut Datum,
+        isnull: *mut bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn heap_freetuple(htup: HeapTuple);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn heap_form_minimal_tuple(
+        tupleDescriptor: TupleDesc,
+        values: *mut Datum,
+        isnull: *mut bool,
+    ) -> MinimalTuple;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn heap_free_minimal_tuple(mtup: MinimalTuple);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn heap_copy_minimal_tuple(mtup: MinimalTuple) -> MinimalTuple;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn heap_tuple_from_minimal_tuple(mtup: MinimalTuple) -> HeapTuple;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn minimal_tuple_from_heap_tuple(htup: HeapTuple) -> MinimalTuple;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn heap_expand_tuple(sourceTuple: HeapTuple, tupleDesc: TupleDesc) -> HeapTuple;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn minimal_expand_tuple(sourceTuple: HeapTuple, tupleDesc: TupleDesc) -> MinimalTuple;
+}
+pub const relopt_type_RELOPT_TYPE_BOOL: relopt_type = 0;
+pub const relopt_type_RELOPT_TYPE_INT: relopt_type = 1;
+pub const relopt_type_RELOPT_TYPE_REAL: relopt_type = 2;
+pub const relopt_type_RELOPT_TYPE_STRING: relopt_type = 3;
+pub type relopt_type = ::std::os::raw::c_uint;
+pub const relopt_kind_RELOPT_KIND_HEAP: relopt_kind = 1;
+pub const relopt_kind_RELOPT_KIND_TOAST: relopt_kind = 2;
+pub const relopt_kind_RELOPT_KIND_BTREE: relopt_kind = 4;
+pub const relopt_kind_RELOPT_KIND_HASH: relopt_kind = 8;
+pub const relopt_kind_RELOPT_KIND_GIN: relopt_kind = 16;
+pub const relopt_kind_RELOPT_KIND_GIST: relopt_kind = 32;
+pub const relopt_kind_RELOPT_KIND_ATTRIBUTE: relopt_kind = 64;
+pub const relopt_kind_RELOPT_KIND_TABLESPACE: relopt_kind = 128;
+pub const relopt_kind_RELOPT_KIND_SPGIST: relopt_kind = 256;
+pub const relopt_kind_RELOPT_KIND_VIEW: relopt_kind = 512;
+pub const relopt_kind_RELOPT_KIND_BRIN: relopt_kind = 1024;
+pub const relopt_kind_RELOPT_KIND_PARTITIONED: relopt_kind = 2048;
+pub const relopt_kind_RELOPT_KIND_LAST_DEFAULT: relopt_kind = 2048;
+pub const relopt_kind_RELOPT_KIND_INDEX: relopt_kind = 284;
+pub const relopt_kind_RELOPT_KIND_MAX: relopt_kind = 1073741824;
+pub type relopt_kind = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct relopt_gen {
+    pub name: *const ::std::os::raw::c_char,
+    pub desc: *const ::std::os::raw::c_char,
+    pub kinds: bits32,
+    pub lockmode: LOCKMODE,
+    pub namelen: ::std::os::raw::c_int,
+    pub type_: relopt_type,
+}
+impl Default for relopt_gen {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct relopt_value {
+    pub gen: *mut relopt_gen,
+    pub isset: bool,
+    pub values: relopt_value__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union relopt_value__bindgen_ty_1 {
+    pub bool_val: bool,
+    pub int_val: ::std::os::raw::c_int,
+    pub real_val: f64,
+    pub string_val: *mut ::std::os::raw::c_char,
+}
+impl Default for relopt_value__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl Default for relopt_value {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct relopt_bool {
+    pub gen: relopt_gen,
+    pub default_val: bool,
+}
+impl Default for relopt_bool {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct relopt_int {
+    pub gen: relopt_gen,
+    pub default_val: ::std::os::raw::c_int,
+    pub min: ::std::os::raw::c_int,
+    pub max: ::std::os::raw::c_int,
+}
+impl Default for relopt_int {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct relopt_real {
+    pub gen: relopt_gen,
+    pub default_val: f64,
+    pub min: f64,
+    pub max: f64,
+}
+impl Default for relopt_real {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type validate_string_relopt =
+    ::std::option::Option<unsafe extern "C" fn(value: *const ::std::os::raw::c_char)>;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct relopt_string {
+    pub gen: relopt_gen,
+    pub default_len: ::std::os::raw::c_int,
+    pub default_isnull: bool,
+    pub validate_cb: validate_string_relopt,
+    pub default_val: *mut ::std::os::raw::c_char,
+}
+impl Default for relopt_string {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct relopt_parse_elt {
+    pub optname: *const ::std::os::raw::c_char,
+    pub opttype: relopt_type,
+    pub offset: ::std::os::raw::c_int,
+}
+impl Default for relopt_parse_elt {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn add_reloption_kind() -> relopt_kind;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn add_bool_reloption(
+        kinds: bits32,
+        name: *const ::std::os::raw::c_char,
+        desc: *const ::std::os::raw::c_char,
+        default_val: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn add_int_reloption(
+        kinds: bits32,
+        name: *const ::std::os::raw::c_char,
+        desc: *const ::std::os::raw::c_char,
+        default_val: ::std::os::raw::c_int,
+        min_val: ::std::os::raw::c_int,
+        max_val: ::std::os::raw::c_int,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn add_real_reloption(
+        kinds: bits32,
+        name: *const ::std::os::raw::c_char,
+        desc: *const ::std::os::raw::c_char,
+        default_val: f64,
+        min_val: f64,
+        max_val: f64,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn add_string_reloption(
+        kinds: bits32,
+        name: *const ::std::os::raw::c_char,
+        desc: *const ::std::os::raw::c_char,
+        default_val: *const ::std::os::raw::c_char,
+        validator: validate_string_relopt,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn transformRelOptions(
+        oldOptions: Datum,
+        defList: *mut List,
+        namspace: *const ::std::os::raw::c_char,
+        validnsps: *mut *mut ::std::os::raw::c_char,
+        ignoreOids: bool,
+        isReset: bool,
+    ) -> Datum;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn untransformRelOptions(options: Datum) -> *mut List;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn extractRelOptions(
+        tuple: HeapTuple,
+        tupdesc: TupleDesc,
+        amoptions: amoptions_function,
+    ) -> *mut bytea;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn parseRelOptions(
+        options: Datum,
+        validate: bool,
+        kind: relopt_kind,
+        numrelopts: *mut ::std::os::raw::c_int,
+    ) -> *mut relopt_value;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn allocateReloptStruct(
+        base: Size,
+        options: *mut relopt_value,
+        numoptions: ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_void;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn fillRelOptions(
+        rdopts: *mut ::std::os::raw::c_void,
+        basesize: Size,
+        options: *mut relopt_value,
+        numoptions: ::std::os::raw::c_int,
+        validate: bool,
+        elems: *const relopt_parse_elt,
+        nelems: ::std::os::raw::c_int,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn default_reloptions(reloptions: Datum, validate: bool, kind: relopt_kind) -> *mut bytea;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn heap_reloptions(
+        relkind: ::std::os::raw::c_char,
+        reloptions: Datum,
+        validate: bool,
+    ) -> *mut bytea;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn view_reloptions(reloptions: Datum, validate: bool) -> *mut bytea;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn index_reloptions(
+        amoptions: amoptions_function,
+        reloptions: Datum,
+        validate: bool,
+    ) -> *mut bytea;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn index_generic_reloptions(reloptions: Datum, validate: bool) -> *mut bytea;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn attribute_reloptions(reloptions: Datum, validate: bool) -> *mut bytea;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn tablespace_reloptions(reloptions: Datum, validate: bool) -> *mut bytea;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn AlterTableGetRelOptionsLockLevel(defList: *mut List) -> LOCKMODE;
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct ParallelHeapScanDescData {
+    pub phs_relid: Oid,
+    pub phs_syncscan: bool,
+    pub phs_nblocks: BlockNumber,
+    pub phs_mutex: slock_t,
+    pub phs_startblock: BlockNumber,
+    pub phs_nallocated: pg_atomic_uint64,
+    pub phs_snapshot_any: bool,
+    pub phs_snapshot_data: __IncompleteArrayField<::std::os::raw::c_char>,
+}
+impl Default for ParallelHeapScanDescData {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct HeapScanDescData {
+    pub rs_rd: Relation,
+    pub rs_snapshot: Snapshot,
+    pub rs_nkeys: ::std::os::raw::c_int,
+    pub rs_key: ScanKey,
+    pub rs_bitmapscan: bool,
+    pub rs_samplescan: bool,
+    pub rs_pageatatime: bool,
+    pub rs_allow_strat: bool,
+    pub rs_allow_sync: bool,
+    pub rs_temp_snap: bool,
+    pub rs_nblocks: BlockNumber,
+    pub rs_startblock: BlockNumber,
+    pub rs_numblocks: BlockNumber,
+    pub rs_strategy: BufferAccessStrategy,
+    pub rs_syncscan: bool,
+    pub rs_inited: bool,
+    pub rs_ctup: HeapTupleData,
+    pub rs_cblock: BlockNumber,
+    pub rs_cbuf: Buffer,
+    pub rs_parallel: ParallelHeapScanDesc,
+    pub rs_cindex: ::std::os::raw::c_int,
+    pub rs_ntuples: ::std::os::raw::c_int,
+    pub rs_vistuples: [OffsetNumber; 291usize],
+}
+impl Default for HeapScanDescData {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct IndexScanDescData {
+    pub heapRelation: Relation,
+    pub indexRelation: Relation,
+    pub xs_snapshot: Snapshot,
+    pub numberOfKeys: ::std::os::raw::c_int,
+    pub numberOfOrderBys: ::std::os::raw::c_int,
+    pub keyData: ScanKey,
+    pub orderByData: ScanKey,
+    pub xs_want_itup: bool,
+    pub xs_temp_snap: bool,
+    pub kill_prior_tuple: bool,
+    pub ignore_killed_tuples: bool,
+    pub xactStartedInRecovery: bool,
+    pub opaque: *mut ::std::os::raw::c_void,
+    pub xs_itup: IndexTuple,
+    pub xs_itupdesc: TupleDesc,
+    pub xs_hitup: HeapTuple,
+    pub xs_hitupdesc: TupleDesc,
+    pub xs_ctup: HeapTupleData,
+    pub xs_cbuf: Buffer,
+    pub xs_recheck: bool,
+    pub xs_orderbyvals: *mut Datum,
+    pub xs_orderbynulls: *mut bool,
+    pub xs_recheckorderby: bool,
+    pub xs_continue_hot: bool,
+    pub parallel_scan: ParallelIndexScanDesc,
+}
+impl Default for IndexScanDescData {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct ParallelIndexScanDescData {
+    pub ps_relid: Oid,
+    pub ps_indexid: Oid,
+    pub ps_offset: Size,
+    pub ps_snapshot_data: __IncompleteArrayField<::std::os::raw::c_char>,
+}
+impl Default for ParallelIndexScanDescData {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct SysScanDescData {
+    pub heap_rel: Relation,
+    pub irel: Relation,
+    pub scan: HeapScanDesc,
+    pub iscan: IndexScanDesc,
+    pub snapshot: Snapshot,
+}
+impl Default for SysScanDescData {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct SharedInvalCatcacheMsg {
+    pub id: int8,
+    pub dbId: Oid,
+    pub hashValue: uint32,
+}
+impl Default for SharedInvalCatcacheMsg {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct SharedInvalCatalogMsg {
+    pub id: int8,
+    pub dbId: Oid,
+    pub catId: Oid,
+}
+impl Default for SharedInvalCatalogMsg {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct SharedInvalRelcacheMsg {
+    pub id: int8,
+    pub dbId: Oid,
+    pub relId: Oid,
+}
+impl Default for SharedInvalRelcacheMsg {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct SharedInvalSmgrMsg {
+    pub id: int8,
+    pub backend_hi: int8,
+    pub backend_lo: uint16,
+    pub rnode: RelFileNode,
+}
+impl Default for SharedInvalSmgrMsg {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct SharedInvalRelmapMsg {
+    pub id: int8,
+    pub dbId: Oid,
+}
+impl Default for SharedInvalRelmapMsg {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct SharedInvalSnapshotMsg {
+    pub id: int8,
+    pub dbId: Oid,
+    pub relId: Oid,
+}
+impl Default for SharedInvalSnapshotMsg {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union SharedInvalidationMessage {
+    pub id: int8,
+    pub cc: SharedInvalCatcacheMsg,
+    pub cat: SharedInvalCatalogMsg,
+    pub rc: SharedInvalRelcacheMsg,
+    pub sm: SharedInvalSmgrMsg,
+    pub rm: SharedInvalRelmapMsg,
+    pub sn: SharedInvalSnapshotMsg,
+}
+impl Default for SharedInvalidationMessage {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+extern "C" {
+    pub static mut SharedInvalidMessageCounter: uint64;
+}
+extern "C" {
+    pub static mut catchupInterruptPending: sig_atomic_t;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SendSharedInvalidMessages(
+        msgs: *const SharedInvalidationMessage,
+        n: ::std::os::raw::c_int,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ReceiveSharedInvalidMessages(
+        invalFunction: ::std::option::Option<
+            unsafe extern "C" fn(msg: *mut SharedInvalidationMessage),
+        >,
+        resetFunction: ::std::option::Option<unsafe extern "C" fn()>,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn HandleCatchupInterrupt();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ProcessCatchupInterrupt();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn xactGetCommittedInvalidationMessages(
+        msgs: *mut *mut SharedInvalidationMessage,
+        RelcacheInitFileInval: *mut bool,
+    ) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ProcessCommittedInvalidationMessages(
+        msgs: *mut SharedInvalidationMessage,
+        nmsgs: ::std::os::raw::c_int,
+        RelcacheInitFileInval: bool,
+        dbid: Oid,
+        tsid: Oid,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LocalExecuteInvalidationMessage(msg: *mut SharedInvalidationMessage);
+}
+extern "C" {
+    pub static mut PgStartTime: TimestampTz;
+}
+extern "C" {
+    pub static mut PgReloadTime: TimestampTz;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn anytimestamp_typmod_check(istz: bool, typmod: int32) -> int32;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetCurrentTimestamp() -> TimestampTz;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetSQLCurrentTimestamp(typmod: int32) -> TimestampTz;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetSQLLocalTimestamp(typmod: int32) -> Timestamp;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn TimestampDifference(
+        start_time: TimestampTz,
+        stop_time: TimestampTz,
+        secs: *mut ::std::os::raw::c_long,
+        microsecs: *mut ::std::os::raw::c_int,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn TimestampDifferenceMilliseconds(
+        start_time: TimestampTz,
+        stop_time: TimestampTz,
+    ) -> ::std::os::raw::c_long;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn TimestampDifferenceExceeds(
+        start_time: TimestampTz,
+        stop_time: TimestampTz,
+        msec: ::std::os::raw::c_int,
+    ) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn time_t_to_timestamptz(tm: pg_time_t) -> TimestampTz;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn timestamptz_to_time_t(t: TimestampTz) -> pg_time_t;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn timestamptz_to_str(t: TimestampTz) -> *const ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn tm2timestamp(
+        tm: *mut pg_tm,
+        fsec: fsec_t,
+        tzp: *mut ::std::os::raw::c_int,
+        dt: *mut Timestamp,
+    ) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn timestamp2tm(
+        dt: Timestamp,
+        tzp: *mut ::std::os::raw::c_int,
+        tm: *mut pg_tm,
+        fsec: *mut fsec_t,
+        tzn: *mut *const ::std::os::raw::c_char,
+        attimezone: *mut pg_tz,
+    ) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn dt2time(
+        dt: Timestamp,
+        hour: *mut ::std::os::raw::c_int,
+        min: *mut ::std::os::raw::c_int,
+        sec: *mut ::std::os::raw::c_int,
+        fsec: *mut fsec_t,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn interval2tm(span: Interval, tm: *mut pg_tm, fsec: *mut fsec_t) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn tm2interval(tm: *mut pg_tm, fsec: fsec_t, span: *mut Interval) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SetEpochTimestamp() -> Timestamp;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetEpochTime(tm: *mut pg_tm);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn timestamp_cmp_internal(dt1: Timestamp, dt2: Timestamp) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn isoweek2j(
+        year: ::std::os::raw::c_int,
+        week: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn isoweek2date(
+        woy: ::std::os::raw::c_int,
+        year: *mut ::std::os::raw::c_int,
+        mon: *mut ::std::os::raw::c_int,
+        mday: *mut ::std::os::raw::c_int,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn isoweekdate2date(
+        isoweek: ::std::os::raw::c_int,
+        wday: ::std::os::raw::c_int,
+        year: *mut ::std::os::raw::c_int,
+        mon: *mut ::std::os::raw::c_int,
+        mday: *mut ::std::os::raw::c_int,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn date2isoweek(
+        year: ::std::os::raw::c_int,
+        mon: ::std::os::raw::c_int,
+        mday: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn date2isoyear(
+        year: ::std::os::raw::c_int,
+        mon: ::std::os::raw::c_int,
+        mday: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn date2isoyearday(
+        year: ::std::os::raw::c_int,
+        mon: ::std::os::raw::c_int,
+        mday: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct tzEntry {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct datetkn {
+    pub token: [::std::os::raw::c_char; 11usize],
+    pub type_: ::std::os::raw::c_char,
+    pub value: int32,
+}
+#[repr(C)]
+#[derive(Debug, Default)]
+pub struct TimeZoneAbbrevTable {
+    pub tblsize: Size,
+    pub numabbrevs: ::std::os::raw::c_int,
+    pub abbrevs: __IncompleteArrayField<datetkn>,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct DynamicZoneAbbrev {
+    pub tz: *mut pg_tz,
+    pub zone: __IncompleteArrayField<::std::os::raw::c_char>,
+}
+impl Default for DynamicZoneAbbrev {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+extern "C" {
+    pub static months: [*const ::std::os::raw::c_char; 0usize];
+}
+extern "C" {
+    pub static days: [*const ::std::os::raw::c_char; 0usize];
+}
+extern "C" {
+    pub static mut day_tab: [[::std::os::raw::c_int; 13usize]; 2usize];
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetCurrentDateTime(tm: *mut pg_tm);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetCurrentTimeUsec(tm: *mut pg_tm, fsec: *mut fsec_t, tzp: *mut ::std::os::raw::c_int);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn j2date(
+        jd: ::std::os::raw::c_int,
+        year: *mut ::std::os::raw::c_int,
+        month: *mut ::std::os::raw::c_int,
+        day: *mut ::std::os::raw::c_int,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn date2j(
+        year: ::std::os::raw::c_int,
+        month: ::std::os::raw::c_int,
+        day: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ParseDateTime(
+        timestr: *const ::std::os::raw::c_char,
+        workbuf: *mut ::std::os::raw::c_char,
+        buflen: usize,
+        field: *mut *mut ::std::os::raw::c_char,
+        ftype: *mut ::std::os::raw::c_int,
+        maxfields: ::std::os::raw::c_int,
+        numfields: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DecodeDateTime(
+        field: *mut *mut ::std::os::raw::c_char,
+        ftype: *mut ::std::os::raw::c_int,
+        nf: ::std::os::raw::c_int,
+        dtype: *mut ::std::os::raw::c_int,
+        tm: *mut pg_tm,
+        fsec: *mut fsec_t,
+        tzp: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DecodeTimezone(
+        str_: *mut ::std::os::raw::c_char,
+        tzp: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DecodeTimeOnly(
+        field: *mut *mut ::std::os::raw::c_char,
+        ftype: *mut ::std::os::raw::c_int,
+        nf: ::std::os::raw::c_int,
+        dtype: *mut ::std::os::raw::c_int,
+        tm: *mut pg_tm,
+        fsec: *mut fsec_t,
+        tzp: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DecodeInterval(
+        field: *mut *mut ::std::os::raw::c_char,
+        ftype: *mut ::std::os::raw::c_int,
+        nf: ::std::os::raw::c_int,
+        range: ::std::os::raw::c_int,
+        dtype: *mut ::std::os::raw::c_int,
+        tm: *mut pg_tm,
+        fsec: *mut fsec_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DecodeISO8601Interval(
+        str_: *mut ::std::os::raw::c_char,
+        dtype: *mut ::std::os::raw::c_int,
+        tm: *mut pg_tm,
+        fsec: *mut fsec_t,
+    ) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DateTimeParseError(
+        dterr: ::std::os::raw::c_int,
+        str_: *const ::std::os::raw::c_char,
+        datatype: *const ::std::os::raw::c_char,
+    ) -> !;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DetermineTimeZoneOffset(tm: *mut pg_tm, tzp: *mut pg_tz) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DetermineTimeZoneAbbrevOffset(
+        tm: *mut pg_tm,
+        abbr: *const ::std::os::raw::c_char,
+        tzp: *mut pg_tz,
+    ) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DetermineTimeZoneAbbrevOffsetTS(
+        ts: TimestampTz,
+        abbr: *const ::std::os::raw::c_char,
+        tzp: *mut pg_tz,
+        isdst: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn EncodeDateOnly(
+        tm: *mut pg_tm,
+        style: ::std::os::raw::c_int,
+        str_: *mut ::std::os::raw::c_char,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn EncodeTimeOnly(
+        tm: *mut pg_tm,
+        fsec: fsec_t,
+        print_tz: bool,
+        tz: ::std::os::raw::c_int,
+        style: ::std::os::raw::c_int,
+        str_: *mut ::std::os::raw::c_char,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn EncodeDateTime(
+        tm: *mut pg_tm,
+        fsec: fsec_t,
+        print_tz: bool,
+        tz: ::std::os::raw::c_int,
+        tzn: *const ::std::os::raw::c_char,
+        style: ::std::os::raw::c_int,
+        str_: *mut ::std::os::raw::c_char,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn EncodeInterval(
+        tm: *mut pg_tm,
+        fsec: fsec_t,
+        style: ::std::os::raw::c_int,
+        str_: *mut ::std::os::raw::c_char,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn EncodeSpecialTimestamp(dt: Timestamp, str_: *mut ::std::os::raw::c_char);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ValidateDate(
+        fmask: ::std::os::raw::c_int,
+        isjulian: bool,
+        is2digits: bool,
+        bc: bool,
+        tm: *mut pg_tm,
+    ) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DecodeTimezoneAbbrev(
+        field: ::std::os::raw::c_int,
+        lowtoken: *mut ::std::os::raw::c_char,
+        offset: *mut ::std::os::raw::c_int,
+        tz: *mut *mut pg_tz,
+    ) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DecodeSpecial(
+        field: ::std::os::raw::c_int,
+        lowtoken: *mut ::std::os::raw::c_char,
+        val: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DecodeUnits(
+        field: ::std::os::raw::c_int,
+        lowtoken: *mut ::std::os::raw::c_char,
+        val: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn j2day(jd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn TemporalTransform(max_precis: int32, node: *mut Node) -> *mut Node;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn CheckDateTokenTables() -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ConvertTimeZoneAbbrevs(
+        abbrevs: *mut tzEntry,
+        n: ::std::os::raw::c_int,
+    ) -> *mut TimeZoneAbbrevTable;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn InstallTimeZoneAbbrevs(tbl: *mut TimeZoneAbbrevTable);
+}
+extern "C" {
+    pub static mut DefaultXactIsoLevel: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut XactIsoLevel: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut DefaultXactReadOnly: bool;
+}
+extern "C" {
+    pub static mut XactReadOnly: bool;
+}
+extern "C" {
+    pub static mut DefaultXactDeferrable: bool;
+}
+extern "C" {
+    pub static mut XactDeferrable: bool;
+}
+pub const SyncCommitLevel_SYNCHRONOUS_COMMIT_OFF: SyncCommitLevel = 0;
+pub const SyncCommitLevel_SYNCHRONOUS_COMMIT_LOCAL_FLUSH: SyncCommitLevel = 1;
+pub const SyncCommitLevel_SYNCHRONOUS_COMMIT_REMOTE_WRITE: SyncCommitLevel = 2;
+pub const SyncCommitLevel_SYNCHRONOUS_COMMIT_REMOTE_FLUSH: SyncCommitLevel = 3;
+pub const SyncCommitLevel_SYNCHRONOUS_COMMIT_REMOTE_APPLY: SyncCommitLevel = 4;
+pub type SyncCommitLevel = ::std::os::raw::c_uint;
+extern "C" {
+    pub static mut synchronous_commit: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut MyXactFlags: ::std::os::raw::c_int;
+}
+pub const XactEvent_XACT_EVENT_COMMIT: XactEvent = 0;
+pub const XactEvent_XACT_EVENT_PARALLEL_COMMIT: XactEvent = 1;
+pub const XactEvent_XACT_EVENT_ABORT: XactEvent = 2;
+pub const XactEvent_XACT_EVENT_PARALLEL_ABORT: XactEvent = 3;
+pub const XactEvent_XACT_EVENT_PREPARE: XactEvent = 4;
+pub const XactEvent_XACT_EVENT_PRE_COMMIT: XactEvent = 5;
+pub const XactEvent_XACT_EVENT_PARALLEL_PRE_COMMIT: XactEvent = 6;
+pub const XactEvent_XACT_EVENT_PRE_PREPARE: XactEvent = 7;
+pub type XactEvent = ::std::os::raw::c_uint;
+pub type XactCallback =
+    ::std::option::Option<unsafe extern "C" fn(event: XactEvent, arg: *mut ::std::os::raw::c_void)>;
+pub const SubXactEvent_SUBXACT_EVENT_START_SUB: SubXactEvent = 0;
+pub const SubXactEvent_SUBXACT_EVENT_COMMIT_SUB: SubXactEvent = 1;
+pub const SubXactEvent_SUBXACT_EVENT_ABORT_SUB: SubXactEvent = 2;
+pub const SubXactEvent_SUBXACT_EVENT_PRE_COMMIT_SUB: SubXactEvent = 3;
+pub type SubXactEvent = ::std::os::raw::c_uint;
+pub type SubXactCallback = ::std::option::Option<
+    unsafe extern "C" fn(
+        event: SubXactEvent,
+        mySubid: SubTransactionId,
+        parentSubid: SubTransactionId,
+        arg: *mut ::std::os::raw::c_void,
+    ),
+>;
+#[repr(C)]
+#[derive(Debug, Default)]
+pub struct xl_xact_assignment {
+    pub xtop: TransactionId,
+    pub nsubxacts: ::std::os::raw::c_int,
+    pub xsub: __IncompleteArrayField<TransactionId>,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct xl_xact_xinfo {
+    pub xinfo: uint32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct xl_xact_dbinfo {
+    pub dbId: Oid,
+    pub tsId: Oid,
+}
+impl Default for xl_xact_dbinfo {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default)]
+pub struct xl_xact_subxacts {
+    pub nsubxacts: ::std::os::raw::c_int,
+    pub subxacts: __IncompleteArrayField<TransactionId>,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct xl_xact_relfilenodes {
+    pub nrels: ::std::os::raw::c_int,
+    pub xnodes: __IncompleteArrayField<RelFileNode>,
+}
+impl Default for xl_xact_relfilenodes {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+pub struct xl_xact_invals {
+    pub nmsgs: ::std::os::raw::c_int,
+    pub msgs: __IncompleteArrayField<SharedInvalidationMessage>,
+}
+impl Default for xl_xact_invals {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct xl_xact_twophase {
+    pub xid: TransactionId,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct xl_xact_origin {
+    pub origin_lsn: XLogRecPtr,
+    pub origin_timestamp: TimestampTz,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct xl_xact_commit {
+    pub xact_time: TimestampTz,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct xl_xact_abort {
+    pub xact_time: TimestampTz,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct xl_xact_parsed_commit {
+    pub xact_time: TimestampTz,
+    pub xinfo: uint32,
+    pub dbId: Oid,
+    pub tsId: Oid,
+    pub nsubxacts: ::std::os::raw::c_int,
+    pub subxacts: *mut TransactionId,
+    pub nrels: ::std::os::raw::c_int,
+    pub xnodes: *mut RelFileNode,
+    pub nmsgs: ::std::os::raw::c_int,
+    pub msgs: *mut SharedInvalidationMessage,
+    pub twophase_xid: TransactionId,
+    pub twophase_gid: [::std::os::raw::c_char; 200usize],
+    pub nabortrels: ::std::os::raw::c_int,
+    pub abortnodes: *mut RelFileNode,
+    pub origin_lsn: XLogRecPtr,
+    pub origin_timestamp: TimestampTz,
+}
+impl Default for xl_xact_parsed_commit {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type xl_xact_parsed_prepare = xl_xact_parsed_commit;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct xl_xact_parsed_abort {
+    pub xact_time: TimestampTz,
+    pub xinfo: uint32,
+    pub dbId: Oid,
+    pub tsId: Oid,
+    pub nsubxacts: ::std::os::raw::c_int,
+    pub subxacts: *mut TransactionId,
+    pub nrels: ::std::os::raw::c_int,
+    pub xnodes: *mut RelFileNode,
+    pub twophase_xid: TransactionId,
+    pub twophase_gid: [::std::os::raw::c_char; 200usize],
+    pub origin_lsn: XLogRecPtr,
+    pub origin_timestamp: TimestampTz,
+}
+impl Default for xl_xact_parsed_abort {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn IsTransactionState() -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn IsAbortedTransactionBlockState() -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetTopTransactionId() -> TransactionId;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetTopTransactionIdIfAny() -> TransactionId;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetCurrentTransactionId() -> TransactionId;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetCurrentTransactionIdIfAny() -> TransactionId;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetStableLatestTransactionId() -> TransactionId;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetCurrentSubTransactionId() -> SubTransactionId;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn MarkCurrentTransactionIdLoggedIfAny();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SubTransactionIsActive(subxid: SubTransactionId) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetCurrentCommandId(used: bool) -> CommandId;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SetParallelStartTimestamps(xact_ts: TimestampTz, stmt_ts: TimestampTz);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetCurrentTransactionStartTimestamp() -> TimestampTz;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetCurrentStatementStartTimestamp() -> TimestampTz;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetCurrentTransactionStopTimestamp() -> TimestampTz;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SetCurrentStatementStartTimestamp();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetCurrentTransactionNestLevel() -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn TransactionIdIsCurrentTransactionId(xid: TransactionId) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn CommandCounterIncrement();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ForceSyncCommit();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn StartTransactionCommand();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn CommitTransactionCommand();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn AbortCurrentTransaction();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn BeginTransactionBlock();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn EndTransactionBlock() -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn PrepareTransactionBlock(gid: *const ::std::os::raw::c_char) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UserAbortTransactionBlock();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn BeginImplicitTransactionBlock();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn EndImplicitTransactionBlock();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ReleaseSavepoint(name: *const ::std::os::raw::c_char);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DefineSavepoint(name: *const ::std::os::raw::c_char);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RollbackToSavepoint(name: *const ::std::os::raw::c_char);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn BeginInternalSubTransaction(name: *const ::std::os::raw::c_char);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ReleaseCurrentSubTransaction();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RollbackAndReleaseCurrentSubTransaction();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn IsSubTransaction() -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn EstimateTransactionStateSpace() -> Size;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SerializeTransactionState(maxsize: Size, start_address: *mut ::std::os::raw::c_char);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn StartParallelWorkerTransaction(tstatespace: *mut ::std::os::raw::c_char);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn EndParallelWorkerTransaction();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn IsTransactionBlock() -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn IsTransactionOrTransactionBlock() -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn TransactionBlockStatusCode() -> ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn AbortOutOfAnyTransaction();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn PreventInTransactionBlock(isTopLevel: bool, stmtType: *const ::std::os::raw::c_char);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RequireTransactionBlock(isTopLevel: bool, stmtType: *const ::std::os::raw::c_char);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn WarnNoTransactionBlock(isTopLevel: bool, stmtType: *const ::std::os::raw::c_char);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn IsInTransactionBlock(isTopLevel: bool) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RegisterXactCallback(callback: XactCallback, arg: *mut ::std::os::raw::c_void);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnregisterXactCallback(callback: XactCallback, arg: *mut ::std::os::raw::c_void);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RegisterSubXactCallback(callback: SubXactCallback, arg: *mut ::std::os::raw::c_void);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnregisterSubXactCallback(callback: SubXactCallback, arg: *mut ::std::os::raw::c_void);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn xactGetCommittedChildren(ptr: *mut *mut TransactionId) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XactLogCommitRecord(
+        commit_time: TimestampTz,
+        nsubxacts: ::std::os::raw::c_int,
+        subxacts: *mut TransactionId,
+        nrels: ::std::os::raw::c_int,
+        rels: *mut RelFileNode,
+        nmsgs: ::std::os::raw::c_int,
+        msgs: *mut SharedInvalidationMessage,
+        relcacheInval: bool,
+        forceSync: bool,
+        xactflags: ::std::os::raw::c_int,
+        twophase_xid: TransactionId,
+        twophase_gid: *const ::std::os::raw::c_char,
+    ) -> XLogRecPtr;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XactLogAbortRecord(
+        abort_time: TimestampTz,
+        nsubxacts: ::std::os::raw::c_int,
+        subxacts: *mut TransactionId,
+        nrels: ::std::os::raw::c_int,
+        rels: *mut RelFileNode,
+        xactflags: ::std::os::raw::c_int,
+        twophase_xid: TransactionId,
+        twophase_gid: *const ::std::os::raw::c_char,
+    ) -> XLogRecPtr;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn xact_redo(record: *mut XLogReaderState);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn xact_desc(buf: StringInfo, record: *mut XLogReaderState);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn xact_identify(info: uint8) -> *const ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ParseCommitRecord(
+        info: uint8,
+        xlrec: *mut xl_xact_commit,
+        parsed: *mut xl_xact_parsed_commit,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ParseAbortRecord(
+        info: uint8,
+        xlrec: *mut xl_xact_abort,
+        parsed: *mut xl_xact_parsed_abort,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn EnterParallelMode();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ExitParallelMode();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn IsInParallelMode() -> bool;
+}
 pub const DependencyType_DEPENDENCY_NORMAL: DependencyType = 110;
 pub const DependencyType_DEPENDENCY_AUTO: DependencyType = 97;
 pub const DependencyType_DEPENDENCY_INTERNAL: DependencyType = 105;
@@ -30764,50 +31571,6 @@ impl Default for FormData_pg_authid {
     }
 }
 pub type Form_pg_authid = *mut FormData_pg_authid;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct FormData_pg_class {
-    pub relname: NameData,
-    pub relnamespace: Oid,
-    pub reltype: Oid,
-    pub reloftype: Oid,
-    pub relowner: Oid,
-    pub relam: Oid,
-    pub relfilenode: Oid,
-    pub reltablespace: Oid,
-    pub relpages: int32,
-    pub reltuples: float4,
-    pub relallvisible: int32,
-    pub reltoastrelid: Oid,
-    pub relhasindex: bool,
-    pub relisshared: bool,
-    pub relpersistence: ::std::os::raw::c_char,
-    pub relkind: ::std::os::raw::c_char,
-    pub relnatts: int16,
-    pub relchecks: int16,
-    pub relhasoids: bool,
-    pub relhasrules: bool,
-    pub relhastriggers: bool,
-    pub relhassubclass: bool,
-    pub relrowsecurity: bool,
-    pub relforcerowsecurity: bool,
-    pub relispopulated: bool,
-    pub relreplident: ::std::os::raw::c_char,
-    pub relispartition: bool,
-    pub relrewrite: Oid,
-    pub relfrozenxid: TransactionId,
-    pub relminmxid: TransactionId,
-}
-impl Default for FormData_pg_class {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type Form_pg_class = *mut FormData_pg_class;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct FormData_pg_database {
@@ -34907,7 +35670,7 @@ impl Default for pg_enc2name {
     }
 }
 extern "C" {
-    pub static mut pg_enc2name_tbl: [pg_enc2name; 0usize];
+    pub static pg_enc2name_tbl: [pg_enc2name; 0usize];
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -34925,7 +35688,7 @@ impl Default for pg_enc2gettext {
     }
 }
 extern "C" {
-    pub static mut pg_enc2gettext_tbl: [pg_enc2gettext; 0usize];
+    pub static pg_enc2gettext_tbl: [pg_enc2gettext; 0usize];
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -34977,7 +35740,7 @@ pub struct pg_wchar_tbl {
     pub maxmblen: ::std::os::raw::c_int,
 }
 extern "C" {
-    pub static mut pg_wchar_table: [pg_wchar_tbl; 0usize];
+    pub static pg_wchar_table: [pg_wchar_tbl; 0usize];
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -35391,7 +36154,7 @@ extern "C" {
         encoding: ::std::os::raw::c_int,
         mbstr: *const ::std::os::raw::c_char,
         len: ::std::os::raw::c_int,
-    );
+    ) -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -35400,7 +36163,7 @@ extern "C" {
         dest_encoding: ::std::os::raw::c_int,
         mbstr: *const ::std::os::raw::c_char,
         len: ::std::os::raw::c_int,
-    );
+    ) -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -39124,6 +39887,39 @@ extern "C" {
 extern "C" {
     pub fn get_parse_rowmark(qry: *mut Query, rtindex: Index) -> *mut RowMarkClause;
 }
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn scanstr(s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn downcase_truncate_identifier(
+        ident: *const ::std::os::raw::c_char,
+        len: ::std::os::raw::c_int,
+        warn: bool,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn downcase_identifier(
+        ident: *const ::std::os::raw::c_char,
+        len: ::std::os::raw::c_int,
+        warn: bool,
+        truncate: bool,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn truncate_identifier(
+        ident: *mut ::std::os::raw::c_char,
+        len: ::std::os::raw::c_int,
+        warn: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn scanner_isspace(ch: ::std::os::raw::c_char) -> bool;
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ExpandedRecordHeader {
@@ -40915,7 +41711,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn plpgsql_yyerror(message: *const ::std::os::raw::c_char);
+    pub fn plpgsql_yyerror(message: *const ::std::os::raw::c_char) -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -42467,7 +43263,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn proc_exit(code: ::std::os::raw::c_int);
+    pub fn proc_exit(code: ::std::os::raw::c_int) -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -42499,6 +43295,182 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn CreateSharedMemoryAndSemaphores(port: ::std::os::raw::c_int);
+}
+pub const XLTW_Oper_XLTW_None: XLTW_Oper = 0;
+pub const XLTW_Oper_XLTW_Update: XLTW_Oper = 1;
+pub const XLTW_Oper_XLTW_Delete: XLTW_Oper = 2;
+pub const XLTW_Oper_XLTW_Lock: XLTW_Oper = 3;
+pub const XLTW_Oper_XLTW_LockUpdated: XLTW_Oper = 4;
+pub const XLTW_Oper_XLTW_InsertIndex: XLTW_Oper = 5;
+pub const XLTW_Oper_XLTW_InsertIndexUnique: XLTW_Oper = 6;
+pub const XLTW_Oper_XLTW_FetchUpdated: XLTW_Oper = 7;
+pub const XLTW_Oper_XLTW_RecheckExclusionConstr: XLTW_Oper = 8;
+pub type XLTW_Oper = ::std::os::raw::c_uint;
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RelationInitLockInfo(relation: Relation);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockRelationOid(relid: Oid, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ConditionalLockRelationOid(relid: Oid, lockmode: LOCKMODE) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockRelationId(relid: *mut LockRelId, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockRelationOid(relid: Oid, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockRelation(relation: Relation, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ConditionalLockRelation(relation: Relation, lockmode: LOCKMODE) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockRelation(relation: Relation, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockHasWaitersRelation(relation: Relation, lockmode: LOCKMODE) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockRelationIdForSession(relid: *mut LockRelId, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockRelationIdForSession(relid: *mut LockRelId, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockRelationForExtension(relation: Relation, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockRelationForExtension(relation: Relation, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ConditionalLockRelationForExtension(relation: Relation, lockmode: LOCKMODE) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RelationExtensionLockWaiterCount(relation: Relation) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockDatabaseFrozenIds(lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockPage(relation: Relation, blkno: BlockNumber, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ConditionalLockPage(relation: Relation, blkno: BlockNumber, lockmode: LOCKMODE) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockPage(relation: Relation, blkno: BlockNumber, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockTuple(relation: Relation, tid: ItemPointer, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ConditionalLockTuple(relation: Relation, tid: ItemPointer, lockmode: LOCKMODE) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockTuple(relation: Relation, tid: ItemPointer, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XactLockTableInsert(xid: TransactionId);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XactLockTableDelete(xid: TransactionId);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XactLockTableWait(xid: TransactionId, rel: Relation, ctid: ItemPointer, oper: XLTW_Oper);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ConditionalXactLockTableWait(xid: TransactionId) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn WaitForLockers(heaplocktag: LOCKTAG, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn WaitForLockersMultiple(locktags: *mut List, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SpeculativeInsertionLockAcquire(xid: TransactionId) -> uint32;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SpeculativeInsertionLockRelease(xid: TransactionId);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SpeculativeInsertionWait(xid: TransactionId, token: uint32);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockDatabaseObject(classid: Oid, objid: Oid, objsubid: uint16, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockDatabaseObject(classid: Oid, objid: Oid, objsubid: uint16, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockSharedObject(classid: Oid, objid: Oid, objsubid: uint16, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockSharedObject(classid: Oid, objid: Oid, objsubid: uint16, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockSharedObjectForSession(
+        classid: Oid,
+        objid: Oid,
+        objsubid: uint16,
+        lockmode: LOCKMODE,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockSharedObjectForSession(
+        classid: Oid,
+        objid: Oid,
+        objsubid: uint16,
+        lockmode: LOCKMODE,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DescribeLockTag(buf: StringInfo, tag: *const LOCKTAG);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetLockNameFromTagType(locktag_type: uint16) -> *const ::std::os::raw::c_char;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -43610,7 +44582,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn quickdie(postgres_signal_arg: ::std::os::raw::c_int);
+    pub fn quickdie(postgres_signal_arg: ::std::os::raw::c_int) -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -43618,7 +44590,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn FloatExceptionHandler(postgres_signal_arg: ::std::os::raw::c_int);
+    pub fn FloatExceptionHandler(postgres_signal_arg: ::std::os::raw::c_int) -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -43648,7 +44620,7 @@ extern "C" {
         argv: *mut *mut ::std::os::raw::c_char,
         dbname: *const ::std::os::raw::c_char,
         username: *const ::std::os::raw::c_char,
-    );
+    ) -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -54679,10 +55651,6 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn pg_get_publication_tables(fcinfo: FunctionCallInfo) -> Datum;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
     pub fn pg_get_replica_identity_index(fcinfo: FunctionCallInfo) -> Datum;
 }
 #[pgrx_macros::pg_guard]
@@ -55422,6 +56390,177 @@ extern "C" {
         estimated_len: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_char;
 }
+pub const JsonTokenType_JSON_TOKEN_INVALID: JsonTokenType = 0;
+pub const JsonTokenType_JSON_TOKEN_STRING: JsonTokenType = 1;
+pub const JsonTokenType_JSON_TOKEN_NUMBER: JsonTokenType = 2;
+pub const JsonTokenType_JSON_TOKEN_OBJECT_START: JsonTokenType = 3;
+pub const JsonTokenType_JSON_TOKEN_OBJECT_END: JsonTokenType = 4;
+pub const JsonTokenType_JSON_TOKEN_ARRAY_START: JsonTokenType = 5;
+pub const JsonTokenType_JSON_TOKEN_ARRAY_END: JsonTokenType = 6;
+pub const JsonTokenType_JSON_TOKEN_COMMA: JsonTokenType = 7;
+pub const JsonTokenType_JSON_TOKEN_COLON: JsonTokenType = 8;
+pub const JsonTokenType_JSON_TOKEN_TRUE: JsonTokenType = 9;
+pub const JsonTokenType_JSON_TOKEN_FALSE: JsonTokenType = 10;
+pub const JsonTokenType_JSON_TOKEN_NULL: JsonTokenType = 11;
+pub const JsonTokenType_JSON_TOKEN_END: JsonTokenType = 12;
+pub type JsonTokenType = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct JsonLexContext {
+    pub input: *mut ::std::os::raw::c_char,
+    pub input_length: ::std::os::raw::c_int,
+    pub token_start: *mut ::std::os::raw::c_char,
+    pub token_terminator: *mut ::std::os::raw::c_char,
+    pub prev_token_terminator: *mut ::std::os::raw::c_char,
+    pub token_type: JsonTokenType,
+    pub lex_level: ::std::os::raw::c_int,
+    pub line_number: ::std::os::raw::c_int,
+    pub line_start: *mut ::std::os::raw::c_char,
+    pub strval: StringInfo,
+}
+impl Default for JsonLexContext {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type json_struct_action =
+    ::std::option::Option<unsafe extern "C" fn(state: *mut ::std::os::raw::c_void)>;
+pub type json_ofield_action = ::std::option::Option<
+    unsafe extern "C" fn(
+        state: *mut ::std::os::raw::c_void,
+        fname: *mut ::std::os::raw::c_char,
+        isnull: bool,
+    ),
+>;
+pub type json_aelem_action =
+    ::std::option::Option<unsafe extern "C" fn(state: *mut ::std::os::raw::c_void, isnull: bool)>;
+pub type json_scalar_action = ::std::option::Option<
+    unsafe extern "C" fn(
+        state: *mut ::std::os::raw::c_void,
+        token: *mut ::std::os::raw::c_char,
+        tokentype: JsonTokenType,
+    ),
+>;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct JsonSemAction {
+    pub semstate: *mut ::std::os::raw::c_void,
+    pub object_start: json_struct_action,
+    pub object_end: json_struct_action,
+    pub array_start: json_struct_action,
+    pub array_end: json_struct_action,
+    pub object_field_start: json_ofield_action,
+    pub object_field_end: json_ofield_action,
+    pub array_element_start: json_aelem_action,
+    pub array_element_end: json_aelem_action,
+    pub scalar: json_scalar_action,
+}
+impl Default for JsonSemAction {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn pg_parse_json(lex: *mut JsonLexContext, sem: *mut JsonSemAction);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn json_count_array_elements(lex: *mut JsonLexContext) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn makeJsonLexContext(json: *mut text, need_escapes: bool) -> *mut JsonLexContext;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn makeJsonLexContextCstringLen(
+        json: *mut ::std::os::raw::c_char,
+        len: ::std::os::raw::c_int,
+        need_escapes: bool,
+    ) -> *mut JsonLexContext;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn IsValidJsonNumber(
+        str_: *const ::std::os::raw::c_char,
+        len: ::std::os::raw::c_int,
+    ) -> bool;
+}
+pub const JsonToIndex_jtiKey: JsonToIndex = 1;
+pub const JsonToIndex_jtiString: JsonToIndex = 2;
+pub const JsonToIndex_jtiNumeric: JsonToIndex = 4;
+pub const JsonToIndex_jtiBool: JsonToIndex = 8;
+pub const JsonToIndex_jtiAll: JsonToIndex = 15;
+pub type JsonToIndex = ::std::os::raw::c_uint;
+pub type JsonIterateStringValuesAction = ::std::option::Option<
+    unsafe extern "C" fn(
+        state: *mut ::std::os::raw::c_void,
+        elem_value: *mut ::std::os::raw::c_char,
+        elem_len: ::std::os::raw::c_int,
+    ),
+>;
+pub type JsonTransformStringValuesAction = ::std::option::Option<
+    unsafe extern "C" fn(
+        state: *mut ::std::os::raw::c_void,
+        elem_value: *mut ::std::os::raw::c_char,
+        elem_len: ::std::os::raw::c_int,
+    ) -> *mut text,
+>;
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn parse_jsonb_index_flags(jb: *mut Jsonb) -> uint32;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn iterate_jsonb_values(
+        jb: *mut Jsonb,
+        flags: uint32,
+        state: *mut ::std::os::raw::c_void,
+        action: JsonIterateStringValuesAction,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn iterate_json_values(
+        json: *mut text,
+        flags: uint32,
+        action_state: *mut ::std::os::raw::c_void,
+        action: JsonIterateStringValuesAction,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn transform_jsonb_string_values(
+        jsonb: *mut Jsonb,
+        action_state: *mut ::std::os::raw::c_void,
+        transform_action: JsonTransformStringValuesAction,
+    ) -> *mut Jsonb;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn transform_json_string_values(
+        json: *mut text,
+        action_state: *mut ::std::os::raw::c_void,
+        transform_action: JsonTransformStringValuesAction,
+    ) -> *mut text;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn JsonEncodeDateTime(
+        buf: *mut ::std::os::raw::c_char,
+        value: Datum,
+        typid: Oid,
+    ) -> *mut ::std::os::raw::c_char;
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct OpBtreeInterpretation {
@@ -55925,592 +57064,6 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn get_index_isclustered(index_oid: Oid) -> bool;
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct FormData_pg_index {
-    pub indexrelid: Oid,
-    pub indrelid: Oid,
-    pub indnatts: int16,
-    pub indnkeyatts: int16,
-    pub indisunique: bool,
-    pub indisprimary: bool,
-    pub indisexclusion: bool,
-    pub indimmediate: bool,
-    pub indisclustered: bool,
-    pub indisvalid: bool,
-    pub indcheckxmin: bool,
-    pub indisready: bool,
-    pub indislive: bool,
-    pub indisreplident: bool,
-    pub indkey: int2vector,
-}
-impl Default for FormData_pg_index {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type Form_pg_index = *mut FormData_pg_index;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct FormData_pg_publication {
-    pub pubname: NameData,
-    pub pubowner: Oid,
-    pub puballtables: bool,
-    pub pubinsert: bool,
-    pub pubupdate: bool,
-    pub pubdelete: bool,
-    pub pubtruncate: bool,
-}
-impl Default for FormData_pg_publication {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type Form_pg_publication = *mut FormData_pg_publication;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct PublicationActions {
-    pub pubinsert: bool,
-    pub pubupdate: bool,
-    pub pubdelete: bool,
-    pub pubtruncate: bool,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct Publication {
-    pub oid: Oid,
-    pub name: *mut ::std::os::raw::c_char,
-    pub alltables: bool,
-    pub pubactions: PublicationActions,
-}
-impl Default for Publication {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetPublication(pubid: Oid) -> *mut Publication;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetPublicationByName(
-        pubname: *const ::std::os::raw::c_char,
-        missing_ok: bool,
-    ) -> *mut Publication;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetRelationPublications(relid: Oid) -> *mut List;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetPublicationRelations(pubid: Oid) -> *mut List;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetAllTablesPublications() -> *mut List;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetAllTablesPublicationRelations() -> *mut List;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn is_publishable_relation(rel: Relation) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn publication_add_relation(
-        pubid: Oid,
-        targetrel: Relation,
-        if_not_exists: bool,
-    ) -> ObjectAddress;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_publication_oid(pubname: *const ::std::os::raw::c_char, missing_ok: bool) -> Oid;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_publication_name(pubid: Oid) -> *mut ::std::os::raw::c_char;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct RewriteRule {
-    pub ruleId: Oid,
-    pub event: CmdType,
-    pub qual: *mut Node,
-    pub actions: *mut List,
-    pub enabled: ::std::os::raw::c_char,
-    pub isInstead: bool,
-}
-impl Default for RewriteRule {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct RuleLock {
-    pub numLocks: ::std::os::raw::c_int,
-    pub rules: *mut *mut RewriteRule,
-}
-impl Default for RuleLock {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct SMgrRelationData {
-    pub smgr_rnode: RelFileNodeBackend,
-    pub smgr_owner: *mut *mut SMgrRelationData,
-    pub smgr_targblock: BlockNumber,
-    pub smgr_fsm_nblocks: BlockNumber,
-    pub smgr_vm_nblocks: BlockNumber,
-    pub smgr_which: ::std::os::raw::c_int,
-    pub md_num_open_segs: [::std::os::raw::c_int; 4usize],
-    pub md_seg_fds: [*mut _MdfdVec; 4usize],
-    pub node: dlist_node,
-}
-impl Default for SMgrRelationData {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type SMgrRelation = *mut SMgrRelationData;
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrinit();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgropen(rnode: RelFileNode, backend: BackendId) -> SMgrRelation;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrexists(reln: SMgrRelation, forknum: ForkNumber) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrsetowner(owner: *mut SMgrRelation, reln: SMgrRelation);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrclearowner(owner: *mut SMgrRelation, reln: SMgrRelation);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrclose(reln: SMgrRelation);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrcloseall();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrclosenode(rnode: RelFileNodeBackend);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrcreate(reln: SMgrRelation, forknum: ForkNumber, isRedo: bool);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrdounlink(reln: SMgrRelation, isRedo: bool);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrdounlinkall(rels: *mut SMgrRelation, nrels: ::std::os::raw::c_int, isRedo: bool);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrdounlinkfork(reln: SMgrRelation, forknum: ForkNumber, isRedo: bool);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrextend(
-        reln: SMgrRelation,
-        forknum: ForkNumber,
-        blocknum: BlockNumber,
-        buffer: *mut ::std::os::raw::c_char,
-        skipFsync: bool,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrprefetch(reln: SMgrRelation, forknum: ForkNumber, blocknum: BlockNumber);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrread(
-        reln: SMgrRelation,
-        forknum: ForkNumber,
-        blocknum: BlockNumber,
-        buffer: *mut ::std::os::raw::c_char,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrwrite(
-        reln: SMgrRelation,
-        forknum: ForkNumber,
-        blocknum: BlockNumber,
-        buffer: *mut ::std::os::raw::c_char,
-        skipFsync: bool,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrwriteback(
-        reln: SMgrRelation,
-        forknum: ForkNumber,
-        blocknum: BlockNumber,
-        nblocks: BlockNumber,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrnblocks(reln: SMgrRelation, forknum: ForkNumber) -> BlockNumber;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrtruncate(reln: SMgrRelation, forknum: ForkNumber, nblocks: BlockNumber);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrimmedsync(reln: SMgrRelation, forknum: ForkNumber);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrpreckpt();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrsync();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrpostckpt();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn AtEOXact_SMgr();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn mdinit();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn mdclose(reln: SMgrRelation, forknum: ForkNumber);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn mdcreate(reln: SMgrRelation, forknum: ForkNumber, isRedo: bool);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn mdexists(reln: SMgrRelation, forknum: ForkNumber) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn mdunlink(rnode: RelFileNodeBackend, forknum: ForkNumber, isRedo: bool);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn mdextend(
-        reln: SMgrRelation,
-        forknum: ForkNumber,
-        blocknum: BlockNumber,
-        buffer: *mut ::std::os::raw::c_char,
-        skipFsync: bool,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn mdprefetch(reln: SMgrRelation, forknum: ForkNumber, blocknum: BlockNumber);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn mdread(
-        reln: SMgrRelation,
-        forknum: ForkNumber,
-        blocknum: BlockNumber,
-        buffer: *mut ::std::os::raw::c_char,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn mdwrite(
-        reln: SMgrRelation,
-        forknum: ForkNumber,
-        blocknum: BlockNumber,
-        buffer: *mut ::std::os::raw::c_char,
-        skipFsync: bool,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn mdwriteback(
-        reln: SMgrRelation,
-        forknum: ForkNumber,
-        blocknum: BlockNumber,
-        nblocks: BlockNumber,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn mdnblocks(reln: SMgrRelation, forknum: ForkNumber) -> BlockNumber;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn mdtruncate(reln: SMgrRelation, forknum: ForkNumber, nblocks: BlockNumber);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn mdimmedsync(reln: SMgrRelation, forknum: ForkNumber);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn mdpreckpt();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn mdsync();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn mdpostckpt();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn SetForwardFsyncRequests();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn RememberFsyncRequest(rnode: RelFileNode, forknum: ForkNumber, segno: BlockNumber);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn ForgetRelationFsyncRequests(rnode: RelFileNode, forknum: ForkNumber);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn ForgetDatabaseFsyncRequests(dbid: Oid);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn DropRelationFiles(
-        delrels: *mut RelFileNode,
-        ndelrels: ::std::os::raw::c_int,
-        isRedo: bool,
-    );
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct LockRelId {
-    pub relId: Oid,
-    pub dbId: Oid,
-}
-impl Default for LockRelId {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct LockInfoData {
-    pub lockRelId: LockRelId,
-}
-impl Default for LockInfoData {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type LockInfo = *mut LockInfoData;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct RelationData {
-    pub rd_node: RelFileNode,
-    pub rd_smgr: SMgrRelation,
-    pub rd_refcnt: ::std::os::raw::c_int,
-    pub rd_backend: BackendId,
-    pub rd_islocaltemp: bool,
-    pub rd_isnailed: bool,
-    pub rd_isvalid: bool,
-    pub rd_indexvalid: ::std::os::raw::c_char,
-    pub rd_statvalid: bool,
-    pub rd_createSubid: SubTransactionId,
-    pub rd_newRelfilenodeSubid: SubTransactionId,
-    pub rd_rel: Form_pg_class,
-    pub rd_att: TupleDesc,
-    pub rd_id: Oid,
-    pub rd_lockInfo: LockInfoData,
-    pub rd_rules: *mut RuleLock,
-    pub rd_rulescxt: MemoryContext,
-    pub trigdesc: *mut TriggerDesc,
-    pub rd_rsdesc: *mut RowSecurityDesc,
-    pub rd_fkeylist: *mut List,
-    pub rd_fkeyvalid: bool,
-    pub rd_partkeycxt: MemoryContext,
-    pub rd_partkey: *mut PartitionKeyData,
-    pub rd_pdcxt: MemoryContext,
-    pub rd_partdesc: *mut PartitionDescData,
-    pub rd_partcheck: *mut List,
-    pub rd_indexlist: *mut List,
-    pub rd_oidindex: Oid,
-    pub rd_pkindex: Oid,
-    pub rd_replidindex: Oid,
-    pub rd_statlist: *mut List,
-    pub rd_indexattr: *mut Bitmapset,
-    pub rd_projindexattr: *mut Bitmapset,
-    pub rd_keyattr: *mut Bitmapset,
-    pub rd_pkattr: *mut Bitmapset,
-    pub rd_idattr: *mut Bitmapset,
-    pub rd_projidx: *mut Bitmapset,
-    pub rd_pubactions: *mut PublicationActions,
-    pub rd_options: *mut bytea,
-    pub rd_index: Form_pg_index,
-    pub rd_indextuple: *mut HeapTupleData,
-    pub rd_amhandler: Oid,
-    pub rd_indexcxt: MemoryContext,
-    pub rd_amroutine: *mut IndexAmRoutine,
-    pub rd_opfamily: *mut Oid,
-    pub rd_opcintype: *mut Oid,
-    pub rd_support: *mut RegProcedure,
-    pub rd_supportinfo: *mut FmgrInfo,
-    pub rd_indoption: *mut int16,
-    pub rd_indexprs: *mut List,
-    pub rd_indpred: *mut List,
-    pub rd_exclops: *mut Oid,
-    pub rd_exclprocs: *mut Oid,
-    pub rd_exclstrats: *mut uint16,
-    pub rd_amcache: *mut ::std::os::raw::c_void,
-    pub rd_indcollation: *mut Oid,
-    pub rd_fdwroutine: *mut FdwRoutine,
-    pub rd_toastoid: Oid,
-    pub pgstat_info: *mut PgStat_TableStatus,
-    pub rd_partcheckvalid: bool,
-    pub rd_partcheckcxt: MemoryContext,
-}
-impl Default for RelationData {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct ForeignKeyCacheInfo {
-    pub type_: NodeTag,
-    pub conoid: Oid,
-    pub conrelid: Oid,
-    pub confrelid: Oid,
-    pub nkeys: ::std::os::raw::c_int,
-    pub conkey: [AttrNumber; 32usize],
-    pub confkey: [AttrNumber; 32usize],
-    pub conpfeqop: [Oid; 32usize],
-}
-impl Default for ForeignKeyCacheInfo {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct GenericIndexOpts {
-    pub vl_len_: int32,
-    pub recheck_on_update: bool,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct AutoVacOpts {
-    pub enabled: bool,
-    pub vacuum_threshold: ::std::os::raw::c_int,
-    pub analyze_threshold: ::std::os::raw::c_int,
-    pub vacuum_cost_delay: ::std::os::raw::c_int,
-    pub vacuum_cost_limit: ::std::os::raw::c_int,
-    pub freeze_min_age: ::std::os::raw::c_int,
-    pub freeze_max_age: ::std::os::raw::c_int,
-    pub freeze_table_age: ::std::os::raw::c_int,
-    pub multixact_freeze_min_age: ::std::os::raw::c_int,
-    pub multixact_freeze_max_age: ::std::os::raw::c_int,
-    pub multixact_freeze_table_age: ::std::os::raw::c_int,
-    pub log_min_duration: ::std::os::raw::c_int,
-    pub vacuum_scale_factor: float8,
-    pub analyze_scale_factor: float8,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct StdRdOptions {
-    pub vl_len_: int32,
-    pub fillfactor: ::std::os::raw::c_int,
-    pub vacuum_cleanup_index_scale_factor: float8,
-    pub toast_tuple_target: ::std::os::raw::c_int,
-    pub autovacuum: AutoVacOpts,
-    pub user_catalog_table: bool,
-    pub parallel_workers: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct ViewOptions {
-    pub vl_len_: int32,
-    pub security_barrier: bool,
-    pub check_option_offset: ::std::os::raw::c_int,
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn RelationIncrementReferenceCount(rel: Relation);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn RelationDecrementReferenceCount(rel: Relation);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn RelationGetRepsetList(rel: Relation) -> *mut List;
 }
 pub type SamplerRandomState = [::std::os::raw::c_ushort; 3usize];
 #[pgrx_macros::pg_guard]
@@ -57336,12 +57889,12 @@ pub struct ResourceOwnerData {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct SnapBuild {
+pub struct _MdfdVec {
     pub _address: u8,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct _MdfdVec {
+pub struct SnapBuild {
     pub _address: u8,
 }
 impl pg_sys::seal::Sealed for A_ArrayExpr {}

--- a/pgrx-pg-sys/src/pg12.rs
+++ b/pgrx-pg-sys/src/pg12.rs
@@ -2006,20 +2006,6 @@ pub const SK_SEARCHARRAY: u32 = 32;
 pub const SK_SEARCHNULL: u32 = 64;
 pub const SK_SEARCHNOTNULL: u32 = 128;
 pub const SK_ORDER_BY: u32 = 256;
-pub const GIN_COMPARE_PROC: u32 = 1;
-pub const GIN_EXTRACTVALUE_PROC: u32 = 2;
-pub const GIN_EXTRACTQUERY_PROC: u32 = 3;
-pub const GIN_CONSISTENT_PROC: u32 = 4;
-pub const GIN_COMPARE_PARTIAL_PROC: u32 = 5;
-pub const GIN_TRICONSISTENT_PROC: u32 = 6;
-pub const GINNProcs: u32 = 6;
-pub const GIN_SEARCH_MODE_DEFAULT: u32 = 0;
-pub const GIN_SEARCH_MODE_INCLUDE_EMPTY: u32 = 1;
-pub const GIN_SEARCH_MODE_ALL: u32 = 2;
-pub const GIN_SEARCH_MODE_EVERYTHING: u32 = 3;
-pub const GIN_FALSE: u32 = 0;
-pub const GIN_TRUE: u32 = 1;
-pub const GIN_MAYBE: u32 = 2;
 pub const XLR_NORMAL_MAX_BLOCK_ID: u32 = 4;
 pub const XLR_NORMAL_RDATAS: u32 = 20;
 pub const REGBUF_FORCE_IMAGE: u32 = 1;
@@ -2051,50 +2037,20 @@ pub const TABLESPACE_MAP: &[u8; 15usize] = b"tablespace_map\0";
 pub const TABLESPACE_MAP_OLD: &[u8; 19usize] = b"tablespace_map.old\0";
 pub const PROMOTE_SIGNAL_FILE: &[u8; 8usize] = b"promote\0";
 pub const FALLBACK_PROMOTE_SIGNAL_FILE: &[u8; 17usize] = b"fallback_promote\0";
-pub const GIST_CONSISTENT_PROC: u32 = 1;
-pub const GIST_UNION_PROC: u32 = 2;
-pub const GIST_COMPRESS_PROC: u32 = 3;
-pub const GIST_DECOMPRESS_PROC: u32 = 4;
-pub const GIST_PENALTY_PROC: u32 = 5;
-pub const GIST_PICKSPLIT_PROC: u32 = 6;
-pub const GIST_EQUAL_PROC: u32 = 7;
-pub const GIST_DISTANCE_PROC: u32 = 8;
-pub const GIST_FETCH_PROC: u32 = 9;
-pub const GISTNProcs: u32 = 9;
-pub const F_LEAF: u32 = 1;
-pub const F_DELETED: u32 = 2;
-pub const F_TUPLES_DELETED: u32 = 4;
-pub const F_FOLLOW_RIGHT: u32 = 8;
-pub const F_HAS_GARBAGE: u32 = 16;
-pub const GIST_PAGE_ID: u32 = 65409;
-pub const EOH_HEADER_MAGIC: i32 = -1;
-pub const EA_MAGIC: u32 = 689375833;
-pub const PG_AUTOCONF_FILENAME: &[u8; 21usize] = b"postgresql.auto.conf\0";
-pub const GUC_QUALIFIER_SEPARATOR: u8 = 46u8;
-pub const GUC_LIST_INPUT: u32 = 1;
-pub const GUC_LIST_QUOTE: u32 = 2;
-pub const GUC_NO_SHOW_ALL: u32 = 4;
-pub const GUC_NO_RESET_ALL: u32 = 8;
-pub const GUC_REPORT: u32 = 16;
-pub const GUC_NOT_IN_SAMPLE: u32 = 32;
-pub const GUC_DISALLOW_IN_FILE: u32 = 64;
-pub const GUC_CUSTOM_PLACEHOLDER: u32 = 128;
-pub const GUC_SUPERUSER_ONLY: u32 = 256;
-pub const GUC_IS_NAME: u32 = 512;
-pub const GUC_NOT_WHILE_SEC_REST: u32 = 1024;
-pub const GUC_DISALLOW_IN_AUTO_FILE: u32 = 2048;
-pub const GUC_UNIT_KB: u32 = 4096;
-pub const GUC_UNIT_BLOCKS: u32 = 8192;
-pub const GUC_UNIT_XBLOCKS: u32 = 12288;
-pub const GUC_UNIT_MB: u32 = 16384;
-pub const GUC_UNIT_BYTE: u32 = 32768;
-pub const GUC_UNIT_MEMORY: u32 = 61440;
-pub const GUC_UNIT_MS: u32 = 65536;
-pub const GUC_UNIT_S: u32 = 131072;
-pub const GUC_UNIT_MIN: u32 = 196608;
-pub const GUC_UNIT_TIME: u32 = 983040;
-pub const GUC_EXPLAIN: u32 = 1048576;
-pub const GUC_UNIT: u32 = 1044480;
+pub const XLOG_PAGE_MAGIC: u32 = 53505;
+pub const XLP_FIRST_IS_CONTRECORD: u32 = 1;
+pub const XLP_LONG_HEADER: u32 = 2;
+pub const XLP_BKP_REMOVABLE: u32 = 4;
+pub const XLP_FIRST_IS_OVERWRITE_CONTRECORD: u32 = 8;
+pub const XLP_ALL_FLAGS: u32 = 15;
+pub const WalSegMinSize: u32 = 1048576;
+pub const WalSegMaxSize: u32 = 1073741824;
+pub const DEFAULT_MIN_WAL_SEGS: u32 = 5;
+pub const DEFAULT_MAX_WAL_SEGS: u32 = 64;
+pub const XLOGDIR: &[u8; 7usize] = b"pg_wal\0";
+pub const XLOG_CONTROL_FILE: &[u8; 18usize] = b"global/pg_control\0";
+pub const MAXFNAMELEN: u32 = 64;
+pub const XLOG_FNAME_LEN: u32 = 24;
 pub const RelationRelationId: Oid = Oid(1259);
 pub const RelationRelation_Rowtype_Id: u32 = 83;
 pub const Anum_pg_class_oid: u32 = 1;
@@ -2182,6 +2138,8 @@ pub const Anum_pg_publication_pubupdate: u32 = 6;
 pub const Anum_pg_publication_pubdelete: u32 = 7;
 pub const Anum_pg_publication_pubtruncate: u32 = 8;
 pub const Natts_pg_publication: u32 = 8;
+pub const EOH_HEADER_MAGIC: i32 = -1;
+pub const EA_MAGIC: u32 = 689375833;
 pub const ACL_ID_PUBLIC: u32 = 0;
 pub const ACL_MODECHG_ADD: u32 = 1;
 pub const ACL_MODECHG_DEL: u32 = 2;
@@ -2213,6 +2171,64 @@ pub const ACL_ALL_RIGHTS_TABLESPACE: u32 = 512;
 pub const ACL_ALL_RIGHTS_TYPE: u32 = 256;
 pub const HEAP_MIN_FILLFACTOR: u32 = 10;
 pub const HEAP_DEFAULT_FILLFACTOR: u32 = 100;
+pub const MAX_GENERIC_XLOG_PAGES: u32 = 4;
+pub const GENERIC_XLOG_FULL_IMAGE: u32 = 1;
+pub const GIN_COMPARE_PROC: u32 = 1;
+pub const GIN_EXTRACTVALUE_PROC: u32 = 2;
+pub const GIN_EXTRACTQUERY_PROC: u32 = 3;
+pub const GIN_CONSISTENT_PROC: u32 = 4;
+pub const GIN_COMPARE_PARTIAL_PROC: u32 = 5;
+pub const GIN_TRICONSISTENT_PROC: u32 = 6;
+pub const GINNProcs: u32 = 6;
+pub const GIN_SEARCH_MODE_DEFAULT: u32 = 0;
+pub const GIN_SEARCH_MODE_INCLUDE_EMPTY: u32 = 1;
+pub const GIN_SEARCH_MODE_ALL: u32 = 2;
+pub const GIN_SEARCH_MODE_EVERYTHING: u32 = 3;
+pub const GIN_FALSE: u32 = 0;
+pub const GIN_TRUE: u32 = 1;
+pub const GIN_MAYBE: u32 = 2;
+pub const GIST_CONSISTENT_PROC: u32 = 1;
+pub const GIST_UNION_PROC: u32 = 2;
+pub const GIST_COMPRESS_PROC: u32 = 3;
+pub const GIST_DECOMPRESS_PROC: u32 = 4;
+pub const GIST_PENALTY_PROC: u32 = 5;
+pub const GIST_PICKSPLIT_PROC: u32 = 6;
+pub const GIST_EQUAL_PROC: u32 = 7;
+pub const GIST_DISTANCE_PROC: u32 = 8;
+pub const GIST_FETCH_PROC: u32 = 9;
+pub const GISTNProcs: u32 = 9;
+pub const F_LEAF: u32 = 1;
+pub const F_DELETED: u32 = 2;
+pub const F_TUPLES_DELETED: u32 = 4;
+pub const F_FOLLOW_RIGHT: u32 = 8;
+pub const F_HAS_GARBAGE: u32 = 16;
+pub const GIST_PAGE_ID: u32 = 65409;
+pub const PG_AUTOCONF_FILENAME: &[u8; 21usize] = b"postgresql.auto.conf\0";
+pub const GUC_QUALIFIER_SEPARATOR: u8 = 46u8;
+pub const GUC_LIST_INPUT: u32 = 1;
+pub const GUC_LIST_QUOTE: u32 = 2;
+pub const GUC_NO_SHOW_ALL: u32 = 4;
+pub const GUC_NO_RESET_ALL: u32 = 8;
+pub const GUC_REPORT: u32 = 16;
+pub const GUC_NOT_IN_SAMPLE: u32 = 32;
+pub const GUC_DISALLOW_IN_FILE: u32 = 64;
+pub const GUC_CUSTOM_PLACEHOLDER: u32 = 128;
+pub const GUC_SUPERUSER_ONLY: u32 = 256;
+pub const GUC_IS_NAME: u32 = 512;
+pub const GUC_NOT_WHILE_SEC_REST: u32 = 1024;
+pub const GUC_DISALLOW_IN_AUTO_FILE: u32 = 2048;
+pub const GUC_UNIT_KB: u32 = 4096;
+pub const GUC_UNIT_BLOCKS: u32 = 8192;
+pub const GUC_UNIT_XBLOCKS: u32 = 12288;
+pub const GUC_UNIT_MB: u32 = 16384;
+pub const GUC_UNIT_BYTE: u32 = 32768;
+pub const GUC_UNIT_MEMORY: u32 = 61440;
+pub const GUC_UNIT_MS: u32 = 65536;
+pub const GUC_UNIT_S: u32 = 131072;
+pub const GUC_UNIT_MIN: u32 = 196608;
+pub const GUC_UNIT_TIME: u32 = 983040;
+pub const GUC_EXPLAIN: u32 = 1048576;
+pub const GUC_UNIT: u32 = 1044480;
 pub const DEFAULT_TABLE_ACCESS_METHOD: &[u8; 5usize] = b"heap\0";
 pub const TABLE_INSERT_SKIP_WAL: u32 = 1;
 pub const TABLE_INSERT_SKIP_FSM: u32 = 2;
@@ -4125,7 +4141,7 @@ extern "C" {
         errorType: *const ::std::os::raw::c_char,
         fileName: *const ::std::os::raw::c_char,
         lineNumber: ::std::os::raw::c_int,
-    );
+    ) -> !;
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -6170,7 +6186,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn ReThrowError(edata: *mut ErrorData);
+    pub fn ReThrowError(edata: *mut ErrorData) -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -15547,11 +15563,7 @@ impl Default for Query {
         }
     }
 }
-#[doc = "\tSupporting data structures for Parse Trees"]
-#[doc = ""]
-#[doc = "\tMost of these node types appear in raw parsetrees output by the grammar,"]
-#[doc = "\tand get transformed to something else by the analyzer.  A few of them"]
-#[doc = "\tare used as-is in transformed querytrees."]
+#[doc = "\tSupporting data structures for Parse Trees\n\n\tMost of these node types appear in raw parsetrees output by the grammar,\n\tand get transformed to something else by the analyzer.  A few of them\n\tare used as-is in transformed querytrees."]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct TypeName {
@@ -16703,17 +16715,7 @@ pub const ObjectType_OBJECT_TSTEMPLATE: ObjectType = 46;
 pub const ObjectType_OBJECT_TYPE: ObjectType = 47;
 pub const ObjectType_OBJECT_USER_MAPPING: ObjectType = 48;
 pub const ObjectType_OBJECT_VIEW: ObjectType = 49;
-#[doc = "\t\tOther Statements (no optimizations required)"]
-#[doc = ""]
-#[doc = "\t\tThese are not touched by parser/analyze.c except to put them into"]
-#[doc = "\t\tthe utilityStmt field of a Query.  This is eventually passed to"]
-#[doc = "\t\tProcessUtility (by-passing rewriting and planning).  Some of the"]
-#[doc = "\t\tstatements do need attention from parse analysis, and this is"]
-#[doc = "\t\tdone by routines in parser/parse_utilcmd.c after ProcessUtility"]
-#[doc = "\t\treceives the command for execution."]
-#[doc = "\t\tDECLARE CURSOR, EXPLAIN, and CREATE TABLE AS are special cases:"]
-#[doc = "\t\tthey contain optimizable statements, which get processed normally"]
-#[doc = "\t\tby parser/analyze.c."]
+#[doc = "\t\tOther Statements (no optimizations required)\n\n\t\tThese are not touched by parser/analyze.c except to put them into\n\t\tthe utilityStmt field of a Query.  This is eventually passed to\n\t\tProcessUtility (by-passing rewriting and planning).  Some of the\n\t\tstatements do need attention from parse analysis, and this is\n\t\tdone by routines in parser/parse_utilcmd.c after ProcessUtility\n\t\treceives the command for execution.\n\t\tDECLARE CURSOR, EXPLAIN, and CREATE TABLE AS are special cases:\n\t\tthey contain optimizable statements, which get processed normally\n\t\tby parser/analyze.c."]
 pub type ObjectType = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -20887,56 +20889,7 @@ extern "C" {
     pub fn pg_tzenumerate_end(dir: *mut pg_tzenum);
 }
 extern "C" {
-    #[doc = "\t  System interrupt and critical section handling"]
-    #[doc = ""]
-    #[doc = " There are two types of interrupts that a running backend needs to accept"]
-    #[doc = " without messing up its state: QueryCancel (SIGINT) and ProcDie (SIGTERM)."]
-    #[doc = " In both cases, we need to be able to clean up the current transaction"]
-    #[doc = " gracefully, so we can't respond to the interrupt instantaneously ---"]
-    #[doc = " there's no guarantee that internal data structures would be self-consistent"]
-    #[doc = " if the code is interrupted at an arbitrary instant.  Instead, the signal"]
-    #[doc = " handlers set flags that are checked periodically during execution."]
-    #[doc = ""]
-    #[doc = " The CHECK_FOR_INTERRUPTS() macro is called at strategically located spots"]
-    #[doc = " where it is normally safe to accept a cancel or die interrupt.  In some"]
-    #[doc = " cases, we invoke CHECK_FOR_INTERRUPTS() inside low-level subroutines that"]
-    #[doc = " might sometimes be called in contexts that do *not* want to allow a cancel"]
-    #[doc = " or die interrupt.  The HOLD_INTERRUPTS() and RESUME_INTERRUPTS() macros"]
-    #[doc = " allow code to ensure that no cancel or die interrupt will be accepted,"]
-    #[doc = " even if CHECK_FOR_INTERRUPTS() gets called in a subroutine.  The interrupt"]
-    #[doc = " will be held off until CHECK_FOR_INTERRUPTS() is done outside any"]
-    #[doc = " HOLD_INTERRUPTS() ... RESUME_INTERRUPTS() section."]
-    #[doc = ""]
-    #[doc = " There is also a mechanism to prevent query cancel interrupts, while still"]
-    #[doc = " allowing die interrupts: HOLD_CANCEL_INTERRUPTS() and"]
-    #[doc = " RESUME_CANCEL_INTERRUPTS()."]
-    #[doc = ""]
-    #[doc = " Note that ProcessInterrupts() has also acquired a number of tasks that"]
-    #[doc = " do not necessarily cause a query-cancel-or-die response.  Hence, it's"]
-    #[doc = " possible that it will just clear InterruptPending and return."]
-    #[doc = ""]
-    #[doc = " INTERRUPTS_PENDING_CONDITION() can be checked to see whether an"]
-    #[doc = " interrupt needs to be serviced, without trying to do so immediately."]
-    #[doc = " Some callers are also interested in INTERRUPTS_CAN_BE_PROCESSED(),"]
-    #[doc = " which tells whether ProcessInterrupts is sure to clear the interrupt."]
-    #[doc = ""]
-    #[doc = " Special mechanisms are used to let an interrupt be accepted when we are"]
-    #[doc = " waiting for a lock or when we are waiting for command input (but, of"]
-    #[doc = " course, only if the interrupt holdoff counter is zero).  See the"]
-    #[doc = " related code for details."]
-    #[doc = ""]
-    #[doc = " A lost connection is handled similarly, although the loss of connection"]
-    #[doc = " does not raise a signal, but is detected when we fail to write to the"]
-    #[doc = " socket. If there was a signal for a broken connection, we could make use of"]
-    #[doc = " it by setting ClientConnectionLost in the signal handler."]
-    #[doc = ""]
-    #[doc = " A related, but conceptually distinct, mechanism is the \"critical section\""]
-    #[doc = " mechanism.  A critical section not only holds off cancel/die interrupts,"]
-    #[doc = " but causes any ereport(ERROR) or ereport(FATAL) to become ereport(PANIC)"]
-    #[doc = " --- that is, a system-wide reset is forced.  Needless to say, only really"]
-    #[doc = " *critical* code should be marked as a critical section!\tCurrently, this"]
-    #[doc = " mechanism is only used for XLOG-related code."]
-    #[doc = ""]
+    #[doc = "\t  System interrupt and critical section handling\n\n There are two types of interrupts that a running backend needs to accept\n without messing up its state: QueryCancel (SIGINT) and ProcDie (SIGTERM).\n In both cases, we need to be able to clean up the current transaction\n gracefully, so we can't respond to the interrupt instantaneously ---\n there's no guarantee that internal data structures would be self-consistent\n if the code is interrupted at an arbitrary instant.  Instead, the signal\n handlers set flags that are checked periodically during execution.\n\n The CHECK_FOR_INTERRUPTS() macro is called at strategically located spots\n where it is normally safe to accept a cancel or die interrupt.  In some\n cases, we invoke CHECK_FOR_INTERRUPTS() inside low-level subroutines that\n might sometimes be called in contexts that do *not* want to allow a cancel\n or die interrupt.  The HOLD_INTERRUPTS() and RESUME_INTERRUPTS() macros\n allow code to ensure that no cancel or die interrupt will be accepted,\n even if CHECK_FOR_INTERRUPTS() gets called in a subroutine.  The interrupt\n will be held off until CHECK_FOR_INTERRUPTS() is done outside any\n HOLD_INTERRUPTS() ... RESUME_INTERRUPTS() section.\n\n There is also a mechanism to prevent query cancel interrupts, while still\n allowing die interrupts: HOLD_CANCEL_INTERRUPTS() and\n RESUME_CANCEL_INTERRUPTS().\n\n Note that ProcessInterrupts() has also acquired a number of tasks that\n do not necessarily cause a query-cancel-or-die response.  Hence, it's\n possible that it will just clear InterruptPending and return.\n\n INTERRUPTS_PENDING_CONDITION() can be checked to see whether an\n interrupt needs to be serviced, without trying to do so immediately.\n Some callers are also interested in INTERRUPTS_CAN_BE_PROCESSED(),\n which tells whether ProcessInterrupts is sure to clear the interrupt.\n\n Special mechanisms are used to let an interrupt be accepted when we are\n waiting for a lock or when we are waiting for command input (but, of\n course, only if the interrupt holdoff counter is zero).  See the\n related code for details.\n\n A lost connection is handled similarly, although the loss of connection\n does not raise a signal, but is detected when we fail to write to the\n socket. If there was a signal for a broken connection, we could make use of\n it by setting ClientConnectionLost in the signal handler.\n\n A related, but conceptually distinct, mechanism is the \"critical section\"\n mechanism.  A critical section not only holds off cancel/die interrupts,\n but causes any ereport(ERROR) or ereport(FATAL) to become ereport(PANIC)\n --- that is, a system-wide reset is forced.  Needless to say, only really\n *critical* code should be marked as a critical section!\tCurrently, this\n mechanism is only used for XLOG-related code.\n"]
     pub static mut InterruptPending: sig_atomic_t;
 }
 extern "C" {
@@ -21259,8 +21212,7 @@ extern "C" {
 pub const ProcessingMode_BootstrapProcessing: ProcessingMode = 0;
 pub const ProcessingMode_InitProcessing: ProcessingMode = 1;
 pub const ProcessingMode_NormalProcessing: ProcessingMode = 2;
-#[doc = "\t  pmod.h --\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t *"]
-#[doc = "\t\t\tPOSTGRES processing mode definitions.                            *"]
+#[doc = "\t  pmod.h --\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t *\n\t\t\tPOSTGRES processing mode definitions.                            *"]
 pub type ProcessingMode = ::std::os::raw::c_uint;
 extern "C" {
     pub static mut Mode: ProcessingMode;
@@ -21280,8 +21232,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    #[doc = "\t  pinit.h --\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t *"]
-    #[doc = "\t\t\tPOSTGRES initialization and cleanup definitions.                 *"]
+    #[doc = "\t  pinit.h --\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t *\n\t\t\tPOSTGRES initialization and cleanup definitions.                 *"]
     pub fn pg_split_opts(
         argv: *mut *mut ::std::os::raw::c_char,
         argcp: *mut ::std::os::raw::c_int,
@@ -21502,7 +21453,7 @@ pub const ForkNumber_VISIBILITYMAP_FORKNUM: ForkNumber = 2;
 pub const ForkNumber_INIT_FORKNUM: ForkNumber = 3;
 pub type ForkNumber = ::std::os::raw::c_int;
 extern "C" {
-    pub static mut forkNames: [*const ::std::os::raw::c_char; 0usize];
+    pub static forkNames: [*const ::std::os::raw::c_char; 0usize];
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -22139,7 +22090,7 @@ extern "C" {
     pub static mut MainLWLockArray: *mut LWLockPadded;
 }
 extern "C" {
-    pub static mut MainLWLockNames: [*const ::std::os::raw::c_char; 0usize];
+    pub static MainLWLockNames: [*const ::std::os::raw::c_char; 0usize];
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -22478,7 +22429,7 @@ pub const LockTagType_LOCKTAG_ADVISORY: LockTagType = 9;
 pub const LockTagType_LOCKTAG_DATABASE_FROZEN_IDS: LockTagType = 10;
 pub type LockTagType = ::std::os::raw::c_uint;
 extern "C" {
-    pub static mut LockTagTypeNames: [*const ::std::os::raw::c_char; 0usize];
+    pub static LockTagTypeNames: [*const ::std::os::raw::c_char; 0usize];
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -22841,7 +22792,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn DeadLockReport();
+    pub fn DeadLockReport() -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -24863,31 +24814,6 @@ extern "C" {
 extern "C" {
     pub fn GetIndexAmRoutineByAmId(amoid: Oid, noerror: bool) -> *mut IndexAmRoutine;
 }
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct GinStatsData {
-    pub nPendingPages: BlockNumber,
-    pub nTotalPages: BlockNumber,
-    pub nEntryPages: BlockNumber,
-    pub nDataPages: BlockNumber,
-    pub nEntries: int64,
-    pub ginVersion: int32,
-}
-pub type GinTernaryValue = ::std::os::raw::c_char;
-extern "C" {
-    pub static mut GinFuzzySearchLimit: ::std::os::raw::c_int;
-}
-extern "C" {
-    pub static mut gin_pending_list_limit: ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn ginGetStats(index: Relation, stats: *mut GinStatsData);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn ginUpdateStats(index: Relation, stats: *const GinStatsData, is_build: bool);
-}
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn XLogBeginInsert();
@@ -25162,11 +25088,6 @@ pub struct CheckpointStatsData {
 extern "C" {
     pub static mut CheckpointStats: CheckpointStatsData;
 }
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct XLogRecData {
-    _unused: [u8; 0],
-}
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn XLogInsertRecord(
@@ -25440,48 +25361,44 @@ extern "C" {
 extern "C" {
     pub fn get_backup_status() -> SessionBackupState;
 }
-pub type GistNSN = XLogRecPtr;
-pub type PageGistNSN = PageXLogRecPtr;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct GISTPageOpaqueData {
-    pub nsn: PageGistNSN,
-    pub rightlink: BlockNumber,
-    pub flags: uint16,
-    pub gist_page_id: uint16,
+pub struct XLogPageHeaderData {
+    pub xlp_magic: uint16,
+    pub xlp_info: uint16,
+    pub xlp_tli: TimeLineID,
+    pub xlp_pageaddr: XLogRecPtr,
+    pub xlp_rem_len: uint32,
 }
-pub type GISTPageOpaque = *mut GISTPageOpaqueData;
+pub type XLogPageHeader = *mut XLogPageHeaderData;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct XLogLongPageHeaderData {
+    pub std: XLogPageHeaderData,
+    pub xlp_sysid: uint64,
+    pub xlp_seg_size: uint32,
+    pub xlp_xlog_blcksz: uint32,
+}
+pub type XLogLongPageHeader = *mut XLogLongPageHeaderData;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct xl_parameter_change {
+    pub MaxConnections: ::std::os::raw::c_int,
+    pub max_worker_processes: ::std::os::raw::c_int,
+    pub max_wal_senders: ::std::os::raw::c_int,
+    pub max_prepared_xacts: ::std::os::raw::c_int,
+    pub max_locks_per_xact: ::std::os::raw::c_int,
+    pub wal_level: ::std::os::raw::c_int,
+    pub wal_log_hints: bool,
+    pub track_commit_timestamp: bool,
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct GIST_SPLITVEC {
-    pub spl_left: *mut OffsetNumber,
-    pub spl_nleft: ::std::os::raw::c_int,
-    pub spl_ldatum: Datum,
-    pub spl_ldatum_exists: bool,
-    pub spl_right: *mut OffsetNumber,
-    pub spl_nright: ::std::os::raw::c_int,
-    pub spl_rdatum: Datum,
-    pub spl_rdatum_exists: bool,
+pub struct xl_restore_point {
+    pub rp_time: TimestampTz,
+    pub rp_name: [::std::os::raw::c_char; 64usize],
 }
-impl Default for GIST_SPLITVEC {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct GISTENTRY {
-    pub key: Datum,
-    pub rel: Relation,
-    pub page: Page,
-    pub offset: OffsetNumber,
-    pub leafkey: bool,
-}
-impl Default for GISTENTRY {
+impl Default for xl_restore_point {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -25492,16 +25409,203 @@ impl Default for GISTENTRY {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct GISTDeletedPageContents {
-    pub deleteXid: FullTransactionId,
+pub struct xl_overwrite_contrecord {
+    pub overwritten_lsn: XLogRecPtr,
+    pub overwrite_time: TimestampTz,
 }
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct xl_end_of_recovery {
+    pub end_time: TimestampTz,
+    pub ThisTimeLineID: TimeLineID,
+    pub PrevTimeLineID: TimeLineID,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct XLogRecData {
+    pub next: *mut XLogRecData,
+    pub data: *mut ::std::os::raw::c_char,
+    pub len: uint32,
+}
+impl Default for XLogRecData {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub const RecoveryTargetAction_RECOVERY_TARGET_ACTION_PAUSE: RecoveryTargetAction = 0;
+pub const RecoveryTargetAction_RECOVERY_TARGET_ACTION_PROMOTE: RecoveryTargetAction = 1;
+pub const RecoveryTargetAction_RECOVERY_TARGET_ACTION_SHUTDOWN: RecoveryTargetAction = 2;
+pub type RecoveryTargetAction = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct RmgrData {
+    pub rm_name: *const ::std::os::raw::c_char,
+    pub rm_redo: ::std::option::Option<unsafe extern "C" fn(record: *mut XLogReaderState)>,
+    pub rm_desc:
+        ::std::option::Option<unsafe extern "C" fn(buf: StringInfo, record: *mut XLogReaderState)>,
+    pub rm_identify:
+        ::std::option::Option<unsafe extern "C" fn(info: uint8) -> *const ::std::os::raw::c_char>,
+    pub rm_startup: ::std::option::Option<unsafe extern "C" fn()>,
+    pub rm_cleanup: ::std::option::Option<unsafe extern "C" fn()>,
+    pub rm_mask: ::std::option::Option<
+        unsafe extern "C" fn(pagedata: *mut ::std::os::raw::c_char, blkno: BlockNumber),
+    >,
+}
+impl Default for RmgrData {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+extern "C" {
+    pub static RmgrTable: [RmgrData; 0usize];
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetLastSegSwitchData(lastSwitchLSN: *mut XLogRecPtr) -> pg_time_t;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RequestXLogSwitch(mark_unimportant: bool) -> XLogRecPtr;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetOldestRestartPoint(oldrecptr: *mut XLogRecPtr, oldtli: *mut TimeLineID);
+}
+extern "C" {
+    pub static mut ArchiveRecoveryRequested: bool;
+}
+extern "C" {
+    pub static mut InArchiveRecovery: bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RestoreArchivedFile(
+        path: *mut ::std::os::raw::c_char,
+        xlogfname: *const ::std::os::raw::c_char,
+        recovername: *const ::std::os::raw::c_char,
+        expectedSize: off_t,
+        cleanupEnabled: bool,
+    ) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ExecuteRecoveryCommand(
+        command: *const ::std::os::raw::c_char,
+        commandName: *const ::std::os::raw::c_char,
+        failOnerror: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn KeepFileRestoredFromArchive(
+        path: *const ::std::os::raw::c_char,
+        xlogfname: *const ::std::os::raw::c_char,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XLogArchiveNotify(xlog: *const ::std::os::raw::c_char);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XLogArchiveNotifySeg(segno: XLogSegNo);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XLogArchiveForceDone(xlog: *const ::std::os::raw::c_char);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XLogArchiveCheckDone(xlog: *const ::std::os::raw::c_char) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XLogArchiveIsBusy(xlog: *const ::std::os::raw::c_char) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XLogArchiveIsReady(xlog: *const ::std::os::raw::c_char) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XLogArchiveIsReadyOrDone(xlog: *const ::std::os::raw::c_char) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XLogArchiveCleanup(xlog: *const ::std::os::raw::c_char);
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct FormData_pg_class {
+    pub oid: Oid,
+    pub relname: NameData,
+    pub relnamespace: Oid,
+    pub reltype: Oid,
+    pub reloftype: Oid,
+    pub relowner: Oid,
+    pub relam: Oid,
+    pub relfilenode: Oid,
+    pub reltablespace: Oid,
+    pub relpages: int32,
+    pub reltuples: float4,
+    pub relallvisible: int32,
+    pub reltoastrelid: Oid,
+    pub relhasindex: bool,
+    pub relisshared: bool,
+    pub relpersistence: ::std::os::raw::c_char,
+    pub relkind: ::std::os::raw::c_char,
+    pub relnatts: int16,
+    pub relchecks: int16,
+    pub relhasrules: bool,
+    pub relhastriggers: bool,
+    pub relhassubclass: bool,
+    pub relrowsecurity: bool,
+    pub relforcerowsecurity: bool,
+    pub relispopulated: bool,
+    pub relreplident: ::std::os::raw::c_char,
+    pub relispartition: bool,
+    pub relrewrite: Oid,
+    pub relfrozenxid: TransactionId,
+    pub relminmxid: TransactionId,
+}
+impl Default for FormData_pg_class {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type Form_pg_class = *mut FormData_pg_class;
 #[repr(C)]
 #[derive(Debug)]
-pub struct GistEntryVector {
-    pub n: int32,
-    pub vector: __IncompleteArrayField<GISTENTRY>,
+pub struct FormData_pg_index {
+    pub indexrelid: Oid,
+    pub indrelid: Oid,
+    pub indnatts: int16,
+    pub indnkeyatts: int16,
+    pub indisunique: bool,
+    pub indisprimary: bool,
+    pub indisexclusion: bool,
+    pub indimmediate: bool,
+    pub indisclustered: bool,
+    pub indisvalid: bool,
+    pub indcheckxmin: bool,
+    pub indisready: bool,
+    pub indislive: bool,
+    pub indisreplident: bool,
+    pub indkey: int2vector,
 }
-impl Default for GistEntryVector {
+impl Default for FormData_pg_index {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -25510,148 +25614,108 @@ impl Default for GistEntryVector {
         }
     }
 }
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn relation_open(relationId: Oid, lockmode: LOCKMODE) -> Relation;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn try_relation_open(relationId: Oid, lockmode: LOCKMODE) -> Relation;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn relation_openrv(relation: *const RangeVar, lockmode: LOCKMODE) -> Relation;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn relation_openrv_extended(
-        relation: *const RangeVar,
-        lockmode: LOCKMODE,
-        missing_ok: bool,
-    ) -> Relation;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn relation_close(relation: Relation, lockmode: LOCKMODE);
-}
+pub type Form_pg_index = *mut FormData_pg_index;
+pub const ParseExprKind_EXPR_KIND_NONE: ParseExprKind = 0;
+pub const ParseExprKind_EXPR_KIND_OTHER: ParseExprKind = 1;
+pub const ParseExprKind_EXPR_KIND_JOIN_ON: ParseExprKind = 2;
+pub const ParseExprKind_EXPR_KIND_JOIN_USING: ParseExprKind = 3;
+pub const ParseExprKind_EXPR_KIND_FROM_SUBSELECT: ParseExprKind = 4;
+pub const ParseExprKind_EXPR_KIND_FROM_FUNCTION: ParseExprKind = 5;
+pub const ParseExprKind_EXPR_KIND_WHERE: ParseExprKind = 6;
+pub const ParseExprKind_EXPR_KIND_HAVING: ParseExprKind = 7;
+pub const ParseExprKind_EXPR_KIND_FILTER: ParseExprKind = 8;
+pub const ParseExprKind_EXPR_KIND_WINDOW_PARTITION: ParseExprKind = 9;
+pub const ParseExprKind_EXPR_KIND_WINDOW_ORDER: ParseExprKind = 10;
+pub const ParseExprKind_EXPR_KIND_WINDOW_FRAME_RANGE: ParseExprKind = 11;
+pub const ParseExprKind_EXPR_KIND_WINDOW_FRAME_ROWS: ParseExprKind = 12;
+pub const ParseExprKind_EXPR_KIND_WINDOW_FRAME_GROUPS: ParseExprKind = 13;
+pub const ParseExprKind_EXPR_KIND_SELECT_TARGET: ParseExprKind = 14;
+pub const ParseExprKind_EXPR_KIND_INSERT_TARGET: ParseExprKind = 15;
+pub const ParseExprKind_EXPR_KIND_UPDATE_SOURCE: ParseExprKind = 16;
+pub const ParseExprKind_EXPR_KIND_UPDATE_TARGET: ParseExprKind = 17;
+pub const ParseExprKind_EXPR_KIND_GROUP_BY: ParseExprKind = 18;
+pub const ParseExprKind_EXPR_KIND_ORDER_BY: ParseExprKind = 19;
+pub const ParseExprKind_EXPR_KIND_DISTINCT_ON: ParseExprKind = 20;
+pub const ParseExprKind_EXPR_KIND_LIMIT: ParseExprKind = 21;
+pub const ParseExprKind_EXPR_KIND_OFFSET: ParseExprKind = 22;
+pub const ParseExprKind_EXPR_KIND_RETURNING: ParseExprKind = 23;
+pub const ParseExprKind_EXPR_KIND_VALUES: ParseExprKind = 24;
+pub const ParseExprKind_EXPR_KIND_VALUES_SINGLE: ParseExprKind = 25;
+pub const ParseExprKind_EXPR_KIND_CHECK_CONSTRAINT: ParseExprKind = 26;
+pub const ParseExprKind_EXPR_KIND_DOMAIN_CHECK: ParseExprKind = 27;
+pub const ParseExprKind_EXPR_KIND_COLUMN_DEFAULT: ParseExprKind = 28;
+pub const ParseExprKind_EXPR_KIND_FUNCTION_DEFAULT: ParseExprKind = 29;
+pub const ParseExprKind_EXPR_KIND_INDEX_EXPRESSION: ParseExprKind = 30;
+pub const ParseExprKind_EXPR_KIND_INDEX_PREDICATE: ParseExprKind = 31;
+pub const ParseExprKind_EXPR_KIND_ALTER_COL_TRANSFORM: ParseExprKind = 32;
+pub const ParseExprKind_EXPR_KIND_EXECUTE_PARAMETER: ParseExprKind = 33;
+pub const ParseExprKind_EXPR_KIND_TRIGGER_WHEN: ParseExprKind = 34;
+pub const ParseExprKind_EXPR_KIND_POLICY: ParseExprKind = 35;
+pub const ParseExprKind_EXPR_KIND_PARTITION_BOUND: ParseExprKind = 36;
+pub const ParseExprKind_EXPR_KIND_PARTITION_EXPRESSION: ParseExprKind = 37;
+pub const ParseExprKind_EXPR_KIND_CALL_ARGUMENT: ParseExprKind = 38;
+pub const ParseExprKind_EXPR_KIND_COPY_WHERE: ParseExprKind = 39;
+pub const ParseExprKind_EXPR_KIND_GENERATED_COLUMN: ParseExprKind = 40;
+pub type ParseExprKind = ::std::os::raw::c_uint;
+pub type PreParseColumnRefHook = ::std::option::Option<
+    unsafe extern "C" fn(pstate: *mut ParseState, cref: *mut ColumnRef) -> *mut Node,
+>;
+pub type PostParseColumnRefHook = ::std::option::Option<
+    unsafe extern "C" fn(
+        pstate: *mut ParseState,
+        cref: *mut ColumnRef,
+        var: *mut Node,
+    ) -> *mut Node,
+>;
+pub type ParseParamRefHook = ::std::option::Option<
+    unsafe extern "C" fn(pstate: *mut ParseState, pref: *mut ParamRef) -> *mut Node,
+>;
+pub type CoerceParamHook = ::std::option::Option<
+    unsafe extern "C" fn(
+        pstate: *mut ParseState,
+        param: *mut Param,
+        targetTypeId: Oid,
+        targetTypeMod: int32,
+        location: ::std::os::raw::c_int,
+    ) -> *mut Node,
+>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct TableScanDescData {
-    pub rs_rd: Relation,
-    pub rs_snapshot: *mut SnapshotData,
-    pub rs_nkeys: ::std::os::raw::c_int,
-    pub rs_key: *mut ScanKeyData,
-    pub rs_flags: uint32,
-    pub rs_parallel: *mut ParallelTableScanDescData,
+pub struct ParseState {
+    pub parentParseState: *mut ParseState,
+    pub p_sourcetext: *const ::std::os::raw::c_char,
+    pub p_rtable: *mut List,
+    pub p_joinexprs: *mut List,
+    pub p_joinlist: *mut List,
+    pub p_namespace: *mut List,
+    pub p_lateral_active: bool,
+    pub p_ctenamespace: *mut List,
+    pub p_future_ctes: *mut List,
+    pub p_parent_cte: *mut CommonTableExpr,
+    pub p_target_relation: Relation,
+    pub p_target_rangetblentry: *mut RangeTblEntry,
+    pub p_is_insert: bool,
+    pub p_windowdefs: *mut List,
+    pub p_expr_kind: ParseExprKind,
+    pub p_next_resno: ::std::os::raw::c_int,
+    pub p_multiassign_exprs: *mut List,
+    pub p_locking_clause: *mut List,
+    pub p_locked_from_parent: bool,
+    pub p_resolve_unknowns: bool,
+    pub p_queryEnv: *mut QueryEnvironment,
+    pub p_hasAggs: bool,
+    pub p_hasWindowFuncs: bool,
+    pub p_hasTargetSRFs: bool,
+    pub p_hasSubLinks: bool,
+    pub p_hasModifyingCTE: bool,
+    pub p_last_srf: *mut Node,
+    pub p_pre_columnref_hook: PreParseColumnRefHook,
+    pub p_post_columnref_hook: PostParseColumnRefHook,
+    pub p_paramref_hook: ParseParamRefHook,
+    pub p_coerce_param_hook: CoerceParamHook,
+    pub p_ref_hook_state: *mut ::std::os::raw::c_void,
 }
-impl Default for TableScanDescData {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type TableScanDesc = *mut TableScanDescData;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct ParallelTableScanDescData {
-    pub phs_relid: Oid,
-    pub phs_syncscan: bool,
-    pub phs_snapshot_any: bool,
-    pub phs_snapshot_off: Size,
-}
-impl Default for ParallelTableScanDescData {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type ParallelTableScanDesc = *mut ParallelTableScanDescData;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct ParallelBlockTableScanDescData {
-    pub base: ParallelTableScanDescData,
-    pub phs_nblocks: BlockNumber,
-    pub phs_mutex: slock_t,
-    pub phs_startblock: BlockNumber,
-    pub phs_nallocated: pg_atomic_uint64,
-}
-impl Default for ParallelBlockTableScanDescData {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type ParallelBlockTableScanDesc = *mut ParallelBlockTableScanDescData;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct IndexFetchTableData {
-    pub rel: Relation,
-}
-impl Default for IndexFetchTableData {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct IndexScanDescData {
-    pub heapRelation: Relation,
-    pub indexRelation: Relation,
-    pub xs_snapshot: *mut SnapshotData,
-    pub numberOfKeys: ::std::os::raw::c_int,
-    pub numberOfOrderBys: ::std::os::raw::c_int,
-    pub keyData: *mut ScanKeyData,
-    pub orderByData: *mut ScanKeyData,
-    pub xs_want_itup: bool,
-    pub xs_temp_snap: bool,
-    pub kill_prior_tuple: bool,
-    pub ignore_killed_tuples: bool,
-    pub xactStartedInRecovery: bool,
-    pub opaque: *mut ::std::os::raw::c_void,
-    pub xs_itup: IndexTuple,
-    pub xs_itupdesc: *mut TupleDescData,
-    pub xs_hitup: HeapTuple,
-    pub xs_hitupdesc: *mut TupleDescData,
-    pub xs_heaptid: ItemPointerData,
-    pub xs_heap_continue: bool,
-    pub xs_heapfetch: *mut IndexFetchTableData,
-    pub xs_recheck: bool,
-    pub xs_orderbyvals: *mut Datum,
-    pub xs_orderbynulls: *mut bool,
-    pub xs_recheckorderby: bool,
-    pub parallel_scan: *mut ParallelIndexScanDescData,
-}
-impl Default for IndexScanDescData {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct ParallelIndexScanDescData {
-    pub ps_relid: Oid,
-    pub ps_indexid: Oid,
-    pub ps_offset: Size,
-    pub ps_snapshot_data: __IncompleteArrayField<::std::os::raw::c_char>,
-}
-impl Default for ParallelIndexScanDescData {
+impl Default for ParseState {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -25662,15 +25726,30 @@ impl Default for ParallelIndexScanDescData {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct SysScanDescData {
-    pub heap_rel: Relation,
-    pub irel: Relation,
-    pub scan: *mut TableScanDescData,
-    pub iscan: *mut IndexScanDescData,
-    pub snapshot: *mut SnapshotData,
-    pub slot: *mut TupleTableSlot,
+pub struct ParseNamespaceItem {
+    pub p_rte: *mut RangeTblEntry,
+    pub p_rel_visible: bool,
+    pub p_cols_visible: bool,
+    pub p_lateral_only: bool,
+    pub p_lateral_ok: bool,
 }
-impl Default for SysScanDescData {
+impl Default for ParseNamespaceItem {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ParseCallbackState {
+    pub pstate: *mut ParseState,
+    pub location: ::std::os::raw::c_int,
+    pub errcallback: ErrorContextCallback,
+}
+impl Default for ParseCallbackState {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -25681,23 +25760,63 @@ impl Default for SysScanDescData {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn table_open(relationId: Oid, lockmode: LOCKMODE) -> Relation;
+    pub fn make_parsestate(parentParseState: *mut ParseState) -> *mut ParseState;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn table_openrv(relation: *const RangeVar, lockmode: LOCKMODE) -> Relation;
+    pub fn free_parsestate(pstate: *mut ParseState);
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn table_openrv_extended(
-        relation: *const RangeVar,
-        lockmode: LOCKMODE,
-        missing_ok: bool,
-    ) -> Relation;
+    pub fn parser_errposition(
+        pstate: *mut ParseState,
+        location: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn table_close(relation: Relation, lockmode: LOCKMODE);
+    pub fn setup_parser_errposition_callback(
+        pcbstate: *mut ParseCallbackState,
+        pstate: *mut ParseState,
+        location: ::std::os::raw::c_int,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn cancel_parser_errposition_callback(pcbstate: *mut ParseCallbackState);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn make_var(
+        pstate: *mut ParseState,
+        rte: *mut RangeTblEntry,
+        attrno: ::std::os::raw::c_int,
+        location: ::std::os::raw::c_int,
+    ) -> *mut Var;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn transformContainerType(containerType: *mut Oid, containerTypmod: *mut int32) -> Oid;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn transformContainerSubscripts(
+        pstate: *mut ParseState,
+        containerBase: *mut Node,
+        containerType: Oid,
+        elementType: Oid,
+        containerTypMod: int32,
+        indirection: *mut List,
+        assignFrom: *mut Node,
+    ) -> *mut SubscriptingRef;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn make_const(
+        pstate: *mut ParseState,
+        value: *mut Value,
+        location: ::std::os::raw::c_int,
+    ) -> *mut Const;
 }
 pub type EOM_get_flat_size_method =
     ::std::option::Option<unsafe extern "C" fn(eohptr: *mut ExpandedObjectHeader) -> Size>;
@@ -26311,867 +26430,6 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn deconstruct_expanded_array(eah: *mut ExpandedArrayHeader);
-}
-pub const GucContext_PGC_INTERNAL: GucContext = 0;
-pub const GucContext_PGC_POSTMASTER: GucContext = 1;
-pub const GucContext_PGC_SIGHUP: GucContext = 2;
-pub const GucContext_PGC_SU_BACKEND: GucContext = 3;
-pub const GucContext_PGC_BACKEND: GucContext = 4;
-pub const GucContext_PGC_SUSET: GucContext = 5;
-pub const GucContext_PGC_USERSET: GucContext = 6;
-pub type GucContext = ::std::os::raw::c_uint;
-pub const GucSource_PGC_S_DEFAULT: GucSource = 0;
-pub const GucSource_PGC_S_DYNAMIC_DEFAULT: GucSource = 1;
-pub const GucSource_PGC_S_ENV_VAR: GucSource = 2;
-pub const GucSource_PGC_S_FILE: GucSource = 3;
-pub const GucSource_PGC_S_ARGV: GucSource = 4;
-pub const GucSource_PGC_S_GLOBAL: GucSource = 5;
-pub const GucSource_PGC_S_DATABASE: GucSource = 6;
-pub const GucSource_PGC_S_USER: GucSource = 7;
-pub const GucSource_PGC_S_DATABASE_USER: GucSource = 8;
-pub const GucSource_PGC_S_CLIENT: GucSource = 9;
-pub const GucSource_PGC_S_OVERRIDE: GucSource = 10;
-pub const GucSource_PGC_S_INTERACTIVE: GucSource = 11;
-pub const GucSource_PGC_S_TEST: GucSource = 12;
-pub const GucSource_PGC_S_SESSION: GucSource = 13;
-pub type GucSource = ::std::os::raw::c_uint;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct ConfigVariable {
-    pub name: *mut ::std::os::raw::c_char,
-    pub value: *mut ::std::os::raw::c_char,
-    pub errmsg: *mut ::std::os::raw::c_char,
-    pub filename: *mut ::std::os::raw::c_char,
-    pub sourceline: ::std::os::raw::c_int,
-    pub ignore: bool,
-    pub applied: bool,
-    pub next: *mut ConfigVariable,
-}
-impl Default for ConfigVariable {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn ParseConfigFile(
-        config_file: *const ::std::os::raw::c_char,
-        strict: bool,
-        calling_file: *const ::std::os::raw::c_char,
-        calling_lineno: ::std::os::raw::c_int,
-        depth: ::std::os::raw::c_int,
-        elevel: ::std::os::raw::c_int,
-        head_p: *mut *mut ConfigVariable,
-        tail_p: *mut *mut ConfigVariable,
-    ) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn ParseConfigFp(
-        fp: *mut FILE,
-        config_file: *const ::std::os::raw::c_char,
-        depth: ::std::os::raw::c_int,
-        elevel: ::std::os::raw::c_int,
-        head_p: *mut *mut ConfigVariable,
-        tail_p: *mut *mut ConfigVariable,
-    ) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn ParseConfigDirectory(
-        includedir: *const ::std::os::raw::c_char,
-        calling_file: *const ::std::os::raw::c_char,
-        calling_lineno: ::std::os::raw::c_int,
-        depth: ::std::os::raw::c_int,
-        elevel: ::std::os::raw::c_int,
-        head_p: *mut *mut ConfigVariable,
-        tail_p: *mut *mut ConfigVariable,
-    ) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn FreeConfigVariables(list: *mut ConfigVariable);
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct config_enum_entry {
-    pub name: *const ::std::os::raw::c_char,
-    pub val: ::std::os::raw::c_int,
-    pub hidden: bool,
-}
-impl Default for config_enum_entry {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type GucBoolCheckHook = ::std::option::Option<
-    unsafe extern "C" fn(
-        newval: *mut bool,
-        extra: *mut *mut ::std::os::raw::c_void,
-        source: GucSource,
-    ) -> bool,
->;
-pub type GucIntCheckHook = ::std::option::Option<
-    unsafe extern "C" fn(
-        newval: *mut ::std::os::raw::c_int,
-        extra: *mut *mut ::std::os::raw::c_void,
-        source: GucSource,
-    ) -> bool,
->;
-pub type GucRealCheckHook = ::std::option::Option<
-    unsafe extern "C" fn(
-        newval: *mut f64,
-        extra: *mut *mut ::std::os::raw::c_void,
-        source: GucSource,
-    ) -> bool,
->;
-pub type GucStringCheckHook = ::std::option::Option<
-    unsafe extern "C" fn(
-        newval: *mut *mut ::std::os::raw::c_char,
-        extra: *mut *mut ::std::os::raw::c_void,
-        source: GucSource,
-    ) -> bool,
->;
-pub type GucEnumCheckHook = ::std::option::Option<
-    unsafe extern "C" fn(
-        newval: *mut ::std::os::raw::c_int,
-        extra: *mut *mut ::std::os::raw::c_void,
-        source: GucSource,
-    ) -> bool,
->;
-pub type GucBoolAssignHook =
-    ::std::option::Option<unsafe extern "C" fn(newval: bool, extra: *mut ::std::os::raw::c_void)>;
-pub type GucIntAssignHook = ::std::option::Option<
-    unsafe extern "C" fn(newval: ::std::os::raw::c_int, extra: *mut ::std::os::raw::c_void),
->;
-pub type GucRealAssignHook =
-    ::std::option::Option<unsafe extern "C" fn(newval: f64, extra: *mut ::std::os::raw::c_void)>;
-pub type GucStringAssignHook = ::std::option::Option<
-    unsafe extern "C" fn(newval: *const ::std::os::raw::c_char, extra: *mut ::std::os::raw::c_void),
->;
-pub type GucEnumAssignHook = ::std::option::Option<
-    unsafe extern "C" fn(newval: ::std::os::raw::c_int, extra: *mut ::std::os::raw::c_void),
->;
-pub type GucShowHook =
-    ::std::option::Option<unsafe extern "C" fn() -> *const ::std::os::raw::c_char>;
-pub const GucAction_GUC_ACTION_SET: GucAction = 0;
-pub const GucAction_GUC_ACTION_LOCAL: GucAction = 1;
-pub const GucAction_GUC_ACTION_SAVE: GucAction = 2;
-pub type GucAction = ::std::os::raw::c_uint;
-extern "C" {
-    pub static mut log_duration: bool;
-}
-extern "C" {
-    pub static mut Debug_print_plan: bool;
-}
-extern "C" {
-    pub static mut Debug_print_parse: bool;
-}
-extern "C" {
-    pub static mut Debug_print_rewritten: bool;
-}
-extern "C" {
-    pub static mut Debug_pretty_print: bool;
-}
-extern "C" {
-    pub static mut log_parser_stats: bool;
-}
-extern "C" {
-    pub static mut log_planner_stats: bool;
-}
-extern "C" {
-    pub static mut log_executor_stats: bool;
-}
-extern "C" {
-    pub static mut log_statement_stats: bool;
-}
-extern "C" {
-    pub static mut log_btree_build_stats: bool;
-}
-extern "C" {
-    pub static mut check_function_bodies: bool;
-}
-extern "C" {
-    pub static mut session_auth_is_superuser: bool;
-}
-extern "C" {
-    pub static mut log_min_error_statement: ::std::os::raw::c_int;
-}
-extern "C" {
-    pub static mut log_min_messages: ::std::os::raw::c_int;
-}
-extern "C" {
-    pub static mut client_min_messages: ::std::os::raw::c_int;
-}
-extern "C" {
-    pub static mut log_min_duration_statement: ::std::os::raw::c_int;
-}
-extern "C" {
-    pub static mut log_temp_files: ::std::os::raw::c_int;
-}
-extern "C" {
-    pub static mut log_xact_sample_rate: f64;
-}
-extern "C" {
-    pub static mut temp_file_limit: ::std::os::raw::c_int;
-}
-extern "C" {
-    pub static mut num_temp_buffers: ::std::os::raw::c_int;
-}
-extern "C" {
-    pub static mut cluster_name: *mut ::std::os::raw::c_char;
-}
-extern "C" {
-    pub static mut ConfigFileName: *mut ::std::os::raw::c_char;
-}
-extern "C" {
-    pub static mut HbaFileName: *mut ::std::os::raw::c_char;
-}
-extern "C" {
-    pub static mut IdentFileName: *mut ::std::os::raw::c_char;
-}
-extern "C" {
-    pub static mut external_pid_file: *mut ::std::os::raw::c_char;
-}
-extern "C" {
-    pub static mut application_name: *mut ::std::os::raw::c_char;
-}
-extern "C" {
-    pub static mut tcp_keepalives_idle: ::std::os::raw::c_int;
-}
-extern "C" {
-    pub static mut tcp_keepalives_interval: ::std::os::raw::c_int;
-}
-extern "C" {
-    pub static mut tcp_keepalives_count: ::std::os::raw::c_int;
-}
-extern "C" {
-    pub static mut tcp_user_timeout: ::std::os::raw::c_int;
-}
-extern "C" {
-    pub static mut trace_sort: bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn SetConfigOption(
-        name: *const ::std::os::raw::c_char,
-        value: *const ::std::os::raw::c_char,
-        context: GucContext,
-        source: GucSource,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn DefineCustomBoolVariable(
-        name: *const ::std::os::raw::c_char,
-        short_desc: *const ::std::os::raw::c_char,
-        long_desc: *const ::std::os::raw::c_char,
-        valueAddr: *mut bool,
-        bootValue: bool,
-        context: GucContext,
-        flags: ::std::os::raw::c_int,
-        check_hook: GucBoolCheckHook,
-        assign_hook: GucBoolAssignHook,
-        show_hook: GucShowHook,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn DefineCustomIntVariable(
-        name: *const ::std::os::raw::c_char,
-        short_desc: *const ::std::os::raw::c_char,
-        long_desc: *const ::std::os::raw::c_char,
-        valueAddr: *mut ::std::os::raw::c_int,
-        bootValue: ::std::os::raw::c_int,
-        minValue: ::std::os::raw::c_int,
-        maxValue: ::std::os::raw::c_int,
-        context: GucContext,
-        flags: ::std::os::raw::c_int,
-        check_hook: GucIntCheckHook,
-        assign_hook: GucIntAssignHook,
-        show_hook: GucShowHook,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn DefineCustomRealVariable(
-        name: *const ::std::os::raw::c_char,
-        short_desc: *const ::std::os::raw::c_char,
-        long_desc: *const ::std::os::raw::c_char,
-        valueAddr: *mut f64,
-        bootValue: f64,
-        minValue: f64,
-        maxValue: f64,
-        context: GucContext,
-        flags: ::std::os::raw::c_int,
-        check_hook: GucRealCheckHook,
-        assign_hook: GucRealAssignHook,
-        show_hook: GucShowHook,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn DefineCustomStringVariable(
-        name: *const ::std::os::raw::c_char,
-        short_desc: *const ::std::os::raw::c_char,
-        long_desc: *const ::std::os::raw::c_char,
-        valueAddr: *mut *mut ::std::os::raw::c_char,
-        bootValue: *const ::std::os::raw::c_char,
-        context: GucContext,
-        flags: ::std::os::raw::c_int,
-        check_hook: GucStringCheckHook,
-        assign_hook: GucStringAssignHook,
-        show_hook: GucShowHook,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn DefineCustomEnumVariable(
-        name: *const ::std::os::raw::c_char,
-        short_desc: *const ::std::os::raw::c_char,
-        long_desc: *const ::std::os::raw::c_char,
-        valueAddr: *mut ::std::os::raw::c_int,
-        bootValue: ::std::os::raw::c_int,
-        options: *const config_enum_entry,
-        context: GucContext,
-        flags: ::std::os::raw::c_int,
-        check_hook: GucEnumCheckHook,
-        assign_hook: GucEnumAssignHook,
-        show_hook: GucShowHook,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn EmitWarningsOnPlaceholders(className: *const ::std::os::raw::c_char);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetConfigOption(
-        name: *const ::std::os::raw::c_char,
-        missing_ok: bool,
-        restrict_privileged: bool,
-    ) -> *const ::std::os::raw::c_char;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetConfigOptionResetString(
-        name: *const ::std::os::raw::c_char,
-    ) -> *const ::std::os::raw::c_char;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetConfigOptionFlags(
-        name: *const ::std::os::raw::c_char,
-        missing_ok: bool,
-    ) -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn ProcessConfigFile(context: GucContext);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn InitializeGUCOptions();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn SelectConfigFiles(
-        userDoption: *const ::std::os::raw::c_char,
-        progname: *const ::std::os::raw::c_char,
-    ) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn ResetAllOptions();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn AtStart_GUC();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn NewGUCNestLevel() -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn AtEOXact_GUC(isCommit: bool, nestLevel: ::std::os::raw::c_int);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn BeginReportingGUCOptions();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn ParseLongOption(
-        string: *const ::std::os::raw::c_char,
-        name: *mut *mut ::std::os::raw::c_char,
-        value: *mut *mut ::std::os::raw::c_char,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn parse_int(
-        value: *const ::std::os::raw::c_char,
-        result: *mut ::std::os::raw::c_int,
-        flags: ::std::os::raw::c_int,
-        hintmsg: *mut *const ::std::os::raw::c_char,
-    ) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn parse_real(
-        value: *const ::std::os::raw::c_char,
-        result: *mut f64,
-        flags: ::std::os::raw::c_int,
-        hintmsg: *mut *const ::std::os::raw::c_char,
-    ) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn set_config_option(
-        name: *const ::std::os::raw::c_char,
-        value: *const ::std::os::raw::c_char,
-        context: GucContext,
-        source: GucSource,
-        action: GucAction,
-        changeVal: bool,
-        elevel: ::std::os::raw::c_int,
-        is_reload: bool,
-    ) -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn AlterSystemSetConfigFile(setstmt: *mut AlterSystemStmt);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetConfigOptionByName(
-        name: *const ::std::os::raw::c_char,
-        varname: *mut *const ::std::os::raw::c_char,
-        missing_ok: bool,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetConfigOptionByNum(
-        varnum: ::std::os::raw::c_int,
-        values: *mut *const ::std::os::raw::c_char,
-        noshow: *mut bool,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetNumConfigOptions() -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn SetPGVariable(name: *const ::std::os::raw::c_char, args: *mut List, is_local: bool);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetPGVariable(name: *const ::std::os::raw::c_char, dest: *mut DestReceiver);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetPGVariableResultDesc(name: *const ::std::os::raw::c_char) -> TupleDesc;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn ExecSetVariableStmt(stmt: *mut VariableSetStmt, isTopLevel: bool);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn ExtractSetVariableArgs(stmt: *mut VariableSetStmt) -> *mut ::std::os::raw::c_char;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn ProcessGUCArray(
-        array: *mut ArrayType,
-        context: GucContext,
-        source: GucSource,
-        action: GucAction,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GUCArrayAdd(
-        array: *mut ArrayType,
-        name: *const ::std::os::raw::c_char,
-        value: *const ::std::os::raw::c_char,
-    ) -> *mut ArrayType;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GUCArrayDelete(
-        array: *mut ArrayType,
-        name: *const ::std::os::raw::c_char,
-    ) -> *mut ArrayType;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GUCArrayReset(array: *mut ArrayType) -> *mut ArrayType;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn EstimateGUCStateSpace() -> Size;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn SerializeGUCState(maxsize: Size, start_address: *mut ::std::os::raw::c_char);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn RestoreGUCState(gucstate: *mut ::std::os::raw::c_void);
-}
-extern "C" {
-    pub static mut GUC_check_errmsg_string: *mut ::std::os::raw::c_char;
-}
-extern "C" {
-    pub static mut GUC_check_errdetail_string: *mut ::std::os::raw::c_char;
-}
-extern "C" {
-    pub static mut GUC_check_errhint_string: *mut ::std::os::raw::c_char;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GUC_check_errcode(sqlerrcode: ::std::os::raw::c_int);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn check_default_tablespace(
-        newval: *mut *mut ::std::os::raw::c_char,
-        extra: *mut *mut ::std::os::raw::c_void,
-        source: GucSource,
-    ) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn check_temp_tablespaces(
-        newval: *mut *mut ::std::os::raw::c_char,
-        extra: *mut *mut ::std::os::raw::c_void,
-        source: GucSource,
-    ) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn assign_temp_tablespaces(
-        newval: *const ::std::os::raw::c_char,
-        extra: *mut ::std::os::raw::c_void,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn check_search_path(
-        newval: *mut *mut ::std::os::raw::c_char,
-        extra: *mut *mut ::std::os::raw::c_void,
-        source: GucSource,
-    ) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn assign_search_path(
-        newval: *const ::std::os::raw::c_char,
-        extra: *mut ::std::os::raw::c_void,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn check_wal_buffers(
-        newval: *mut ::std::os::raw::c_int,
-        extra: *mut *mut ::std::os::raw::c_void,
-        source: GucSource,
-    ) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn assign_xlog_sync_method(
-        new_sync_method: ::std::os::raw::c_int,
-        extra: *mut ::std::os::raw::c_void,
-    );
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct FormData_pg_class {
-    pub oid: Oid,
-    pub relname: NameData,
-    pub relnamespace: Oid,
-    pub reltype: Oid,
-    pub reloftype: Oid,
-    pub relowner: Oid,
-    pub relam: Oid,
-    pub relfilenode: Oid,
-    pub reltablespace: Oid,
-    pub relpages: int32,
-    pub reltuples: float4,
-    pub relallvisible: int32,
-    pub reltoastrelid: Oid,
-    pub relhasindex: bool,
-    pub relisshared: bool,
-    pub relpersistence: ::std::os::raw::c_char,
-    pub relkind: ::std::os::raw::c_char,
-    pub relnatts: int16,
-    pub relchecks: int16,
-    pub relhasrules: bool,
-    pub relhastriggers: bool,
-    pub relhassubclass: bool,
-    pub relrowsecurity: bool,
-    pub relforcerowsecurity: bool,
-    pub relispopulated: bool,
-    pub relreplident: ::std::os::raw::c_char,
-    pub relispartition: bool,
-    pub relrewrite: Oid,
-    pub relfrozenxid: TransactionId,
-    pub relminmxid: TransactionId,
-}
-impl Default for FormData_pg_class {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type Form_pg_class = *mut FormData_pg_class;
-#[repr(C)]
-#[derive(Debug)]
-pub struct FormData_pg_index {
-    pub indexrelid: Oid,
-    pub indrelid: Oid,
-    pub indnatts: int16,
-    pub indnkeyatts: int16,
-    pub indisunique: bool,
-    pub indisprimary: bool,
-    pub indisexclusion: bool,
-    pub indimmediate: bool,
-    pub indisclustered: bool,
-    pub indisvalid: bool,
-    pub indcheckxmin: bool,
-    pub indisready: bool,
-    pub indislive: bool,
-    pub indisreplident: bool,
-    pub indkey: int2vector,
-}
-impl Default for FormData_pg_index {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type Form_pg_index = *mut FormData_pg_index;
-pub const ParseExprKind_EXPR_KIND_NONE: ParseExprKind = 0;
-pub const ParseExprKind_EXPR_KIND_OTHER: ParseExprKind = 1;
-pub const ParseExprKind_EXPR_KIND_JOIN_ON: ParseExprKind = 2;
-pub const ParseExprKind_EXPR_KIND_JOIN_USING: ParseExprKind = 3;
-pub const ParseExprKind_EXPR_KIND_FROM_SUBSELECT: ParseExprKind = 4;
-pub const ParseExprKind_EXPR_KIND_FROM_FUNCTION: ParseExprKind = 5;
-pub const ParseExprKind_EXPR_KIND_WHERE: ParseExprKind = 6;
-pub const ParseExprKind_EXPR_KIND_HAVING: ParseExprKind = 7;
-pub const ParseExprKind_EXPR_KIND_FILTER: ParseExprKind = 8;
-pub const ParseExprKind_EXPR_KIND_WINDOW_PARTITION: ParseExprKind = 9;
-pub const ParseExprKind_EXPR_KIND_WINDOW_ORDER: ParseExprKind = 10;
-pub const ParseExprKind_EXPR_KIND_WINDOW_FRAME_RANGE: ParseExprKind = 11;
-pub const ParseExprKind_EXPR_KIND_WINDOW_FRAME_ROWS: ParseExprKind = 12;
-pub const ParseExprKind_EXPR_KIND_WINDOW_FRAME_GROUPS: ParseExprKind = 13;
-pub const ParseExprKind_EXPR_KIND_SELECT_TARGET: ParseExprKind = 14;
-pub const ParseExprKind_EXPR_KIND_INSERT_TARGET: ParseExprKind = 15;
-pub const ParseExprKind_EXPR_KIND_UPDATE_SOURCE: ParseExprKind = 16;
-pub const ParseExprKind_EXPR_KIND_UPDATE_TARGET: ParseExprKind = 17;
-pub const ParseExprKind_EXPR_KIND_GROUP_BY: ParseExprKind = 18;
-pub const ParseExprKind_EXPR_KIND_ORDER_BY: ParseExprKind = 19;
-pub const ParseExprKind_EXPR_KIND_DISTINCT_ON: ParseExprKind = 20;
-pub const ParseExprKind_EXPR_KIND_LIMIT: ParseExprKind = 21;
-pub const ParseExprKind_EXPR_KIND_OFFSET: ParseExprKind = 22;
-pub const ParseExprKind_EXPR_KIND_RETURNING: ParseExprKind = 23;
-pub const ParseExprKind_EXPR_KIND_VALUES: ParseExprKind = 24;
-pub const ParseExprKind_EXPR_KIND_VALUES_SINGLE: ParseExprKind = 25;
-pub const ParseExprKind_EXPR_KIND_CHECK_CONSTRAINT: ParseExprKind = 26;
-pub const ParseExprKind_EXPR_KIND_DOMAIN_CHECK: ParseExprKind = 27;
-pub const ParseExprKind_EXPR_KIND_COLUMN_DEFAULT: ParseExprKind = 28;
-pub const ParseExprKind_EXPR_KIND_FUNCTION_DEFAULT: ParseExprKind = 29;
-pub const ParseExprKind_EXPR_KIND_INDEX_EXPRESSION: ParseExprKind = 30;
-pub const ParseExprKind_EXPR_KIND_INDEX_PREDICATE: ParseExprKind = 31;
-pub const ParseExprKind_EXPR_KIND_ALTER_COL_TRANSFORM: ParseExprKind = 32;
-pub const ParseExprKind_EXPR_KIND_EXECUTE_PARAMETER: ParseExprKind = 33;
-pub const ParseExprKind_EXPR_KIND_TRIGGER_WHEN: ParseExprKind = 34;
-pub const ParseExprKind_EXPR_KIND_POLICY: ParseExprKind = 35;
-pub const ParseExprKind_EXPR_KIND_PARTITION_BOUND: ParseExprKind = 36;
-pub const ParseExprKind_EXPR_KIND_PARTITION_EXPRESSION: ParseExprKind = 37;
-pub const ParseExprKind_EXPR_KIND_CALL_ARGUMENT: ParseExprKind = 38;
-pub const ParseExprKind_EXPR_KIND_COPY_WHERE: ParseExprKind = 39;
-pub const ParseExprKind_EXPR_KIND_GENERATED_COLUMN: ParseExprKind = 40;
-pub type ParseExprKind = ::std::os::raw::c_uint;
-pub type PreParseColumnRefHook = ::std::option::Option<
-    unsafe extern "C" fn(pstate: *mut ParseState, cref: *mut ColumnRef) -> *mut Node,
->;
-pub type PostParseColumnRefHook = ::std::option::Option<
-    unsafe extern "C" fn(
-        pstate: *mut ParseState,
-        cref: *mut ColumnRef,
-        var: *mut Node,
-    ) -> *mut Node,
->;
-pub type ParseParamRefHook = ::std::option::Option<
-    unsafe extern "C" fn(pstate: *mut ParseState, pref: *mut ParamRef) -> *mut Node,
->;
-pub type CoerceParamHook = ::std::option::Option<
-    unsafe extern "C" fn(
-        pstate: *mut ParseState,
-        param: *mut Param,
-        targetTypeId: Oid,
-        targetTypeMod: int32,
-        location: ::std::os::raw::c_int,
-    ) -> *mut Node,
->;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct ParseState {
-    pub parentParseState: *mut ParseState,
-    pub p_sourcetext: *const ::std::os::raw::c_char,
-    pub p_rtable: *mut List,
-    pub p_joinexprs: *mut List,
-    pub p_joinlist: *mut List,
-    pub p_namespace: *mut List,
-    pub p_lateral_active: bool,
-    pub p_ctenamespace: *mut List,
-    pub p_future_ctes: *mut List,
-    pub p_parent_cte: *mut CommonTableExpr,
-    pub p_target_relation: Relation,
-    pub p_target_rangetblentry: *mut RangeTblEntry,
-    pub p_is_insert: bool,
-    pub p_windowdefs: *mut List,
-    pub p_expr_kind: ParseExprKind,
-    pub p_next_resno: ::std::os::raw::c_int,
-    pub p_multiassign_exprs: *mut List,
-    pub p_locking_clause: *mut List,
-    pub p_locked_from_parent: bool,
-    pub p_resolve_unknowns: bool,
-    pub p_queryEnv: *mut QueryEnvironment,
-    pub p_hasAggs: bool,
-    pub p_hasWindowFuncs: bool,
-    pub p_hasTargetSRFs: bool,
-    pub p_hasSubLinks: bool,
-    pub p_hasModifyingCTE: bool,
-    pub p_last_srf: *mut Node,
-    pub p_pre_columnref_hook: PreParseColumnRefHook,
-    pub p_post_columnref_hook: PostParseColumnRefHook,
-    pub p_paramref_hook: ParseParamRefHook,
-    pub p_coerce_param_hook: CoerceParamHook,
-    pub p_ref_hook_state: *mut ::std::os::raw::c_void,
-}
-impl Default for ParseState {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct ParseNamespaceItem {
-    pub p_rte: *mut RangeTblEntry,
-    pub p_rel_visible: bool,
-    pub p_cols_visible: bool,
-    pub p_lateral_only: bool,
-    pub p_lateral_ok: bool,
-}
-impl Default for ParseNamespaceItem {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct ParseCallbackState {
-    pub pstate: *mut ParseState,
-    pub location: ::std::os::raw::c_int,
-    pub errcallback: ErrorContextCallback,
-}
-impl Default for ParseCallbackState {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn make_parsestate(parentParseState: *mut ParseState) -> *mut ParseState;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn free_parsestate(pstate: *mut ParseState);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn parser_errposition(
-        pstate: *mut ParseState,
-        location: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn setup_parser_errposition_callback(
-        pcbstate: *mut ParseCallbackState,
-        pstate: *mut ParseState,
-        location: ::std::os::raw::c_int,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn cancel_parser_errposition_callback(pcbstate: *mut ParseCallbackState);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn make_var(
-        pstate: *mut ParseState,
-        rte: *mut RangeTblEntry,
-        attrno: ::std::os::raw::c_int,
-        location: ::std::os::raw::c_int,
-    ) -> *mut Var;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn transformContainerType(containerType: *mut Oid, containerTypmod: *mut int32) -> Oid;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn transformContainerSubscripts(
-        pstate: *mut ParseState,
-        containerBase: *mut Node,
-        containerType: Oid,
-        elementType: Oid,
-        containerTypMod: int32,
-        indirection: *mut List,
-        assignFrom: *mut Node,
-    ) -> *mut SubscriptingRef;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn make_const(
-        pstate: *mut ParseState,
-        value: *mut Value,
-        location: ::std::os::raw::c_int,
-    ) -> *mut Const;
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -28193,6 +27451,916 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn RelationGetRepsetList(rel: Relation) -> *mut List;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct GenericXLogState {
+    _unused: [u8; 0],
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GenericXLogStart(relation: Relation) -> *mut GenericXLogState;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GenericXLogRegisterBuffer(
+        state: *mut GenericXLogState,
+        buffer: Buffer,
+        flags: ::std::os::raw::c_int,
+    ) -> Page;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GenericXLogFinish(state: *mut GenericXLogState) -> XLogRecPtr;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GenericXLogAbort(state: *mut GenericXLogState);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn generic_redo(record: *mut XLogReaderState);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn generic_identify(info: uint8) -> *const ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn generic_desc(buf: StringInfo, record: *mut XLogReaderState);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn generic_mask(pagedata: *mut ::std::os::raw::c_char, blkno: BlockNumber);
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct GinStatsData {
+    pub nPendingPages: BlockNumber,
+    pub nTotalPages: BlockNumber,
+    pub nEntryPages: BlockNumber,
+    pub nDataPages: BlockNumber,
+    pub nEntries: int64,
+    pub ginVersion: int32,
+}
+pub type GinTernaryValue = ::std::os::raw::c_char;
+extern "C" {
+    pub static mut GinFuzzySearchLimit: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut gin_pending_list_limit: ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ginGetStats(index: Relation, stats: *mut GinStatsData);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ginUpdateStats(index: Relation, stats: *const GinStatsData, is_build: bool);
+}
+pub type GistNSN = XLogRecPtr;
+pub type PageGistNSN = PageXLogRecPtr;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct GISTPageOpaqueData {
+    pub nsn: PageGistNSN,
+    pub rightlink: BlockNumber,
+    pub flags: uint16,
+    pub gist_page_id: uint16,
+}
+pub type GISTPageOpaque = *mut GISTPageOpaqueData;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct GIST_SPLITVEC {
+    pub spl_left: *mut OffsetNumber,
+    pub spl_nleft: ::std::os::raw::c_int,
+    pub spl_ldatum: Datum,
+    pub spl_ldatum_exists: bool,
+    pub spl_right: *mut OffsetNumber,
+    pub spl_nright: ::std::os::raw::c_int,
+    pub spl_rdatum: Datum,
+    pub spl_rdatum_exists: bool,
+}
+impl Default for GIST_SPLITVEC {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct GISTENTRY {
+    pub key: Datum,
+    pub rel: Relation,
+    pub page: Page,
+    pub offset: OffsetNumber,
+    pub leafkey: bool,
+}
+impl Default for GISTENTRY {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct GISTDeletedPageContents {
+    pub deleteXid: FullTransactionId,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct GistEntryVector {
+    pub n: int32,
+    pub vector: __IncompleteArrayField<GISTENTRY>,
+}
+impl Default for GistEntryVector {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn relation_open(relationId: Oid, lockmode: LOCKMODE) -> Relation;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn try_relation_open(relationId: Oid, lockmode: LOCKMODE) -> Relation;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn relation_openrv(relation: *const RangeVar, lockmode: LOCKMODE) -> Relation;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn relation_openrv_extended(
+        relation: *const RangeVar,
+        lockmode: LOCKMODE,
+        missing_ok: bool,
+    ) -> Relation;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn relation_close(relation: Relation, lockmode: LOCKMODE);
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct TableScanDescData {
+    pub rs_rd: Relation,
+    pub rs_snapshot: *mut SnapshotData,
+    pub rs_nkeys: ::std::os::raw::c_int,
+    pub rs_key: *mut ScanKeyData,
+    pub rs_flags: uint32,
+    pub rs_parallel: *mut ParallelTableScanDescData,
+}
+impl Default for TableScanDescData {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type TableScanDesc = *mut TableScanDescData;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ParallelTableScanDescData {
+    pub phs_relid: Oid,
+    pub phs_syncscan: bool,
+    pub phs_snapshot_any: bool,
+    pub phs_snapshot_off: Size,
+}
+impl Default for ParallelTableScanDescData {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type ParallelTableScanDesc = *mut ParallelTableScanDescData;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ParallelBlockTableScanDescData {
+    pub base: ParallelTableScanDescData,
+    pub phs_nblocks: BlockNumber,
+    pub phs_mutex: slock_t,
+    pub phs_startblock: BlockNumber,
+    pub phs_nallocated: pg_atomic_uint64,
+}
+impl Default for ParallelBlockTableScanDescData {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type ParallelBlockTableScanDesc = *mut ParallelBlockTableScanDescData;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct IndexFetchTableData {
+    pub rel: Relation,
+}
+impl Default for IndexFetchTableData {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct IndexScanDescData {
+    pub heapRelation: Relation,
+    pub indexRelation: Relation,
+    pub xs_snapshot: *mut SnapshotData,
+    pub numberOfKeys: ::std::os::raw::c_int,
+    pub numberOfOrderBys: ::std::os::raw::c_int,
+    pub keyData: *mut ScanKeyData,
+    pub orderByData: *mut ScanKeyData,
+    pub xs_want_itup: bool,
+    pub xs_temp_snap: bool,
+    pub kill_prior_tuple: bool,
+    pub ignore_killed_tuples: bool,
+    pub xactStartedInRecovery: bool,
+    pub opaque: *mut ::std::os::raw::c_void,
+    pub xs_itup: IndexTuple,
+    pub xs_itupdesc: *mut TupleDescData,
+    pub xs_hitup: HeapTuple,
+    pub xs_hitupdesc: *mut TupleDescData,
+    pub xs_heaptid: ItemPointerData,
+    pub xs_heap_continue: bool,
+    pub xs_heapfetch: *mut IndexFetchTableData,
+    pub xs_recheck: bool,
+    pub xs_orderbyvals: *mut Datum,
+    pub xs_orderbynulls: *mut bool,
+    pub xs_recheckorderby: bool,
+    pub parallel_scan: *mut ParallelIndexScanDescData,
+}
+impl Default for IndexScanDescData {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct ParallelIndexScanDescData {
+    pub ps_relid: Oid,
+    pub ps_indexid: Oid,
+    pub ps_offset: Size,
+    pub ps_snapshot_data: __IncompleteArrayField<::std::os::raw::c_char>,
+}
+impl Default for ParallelIndexScanDescData {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct SysScanDescData {
+    pub heap_rel: Relation,
+    pub irel: Relation,
+    pub scan: *mut TableScanDescData,
+    pub iscan: *mut IndexScanDescData,
+    pub snapshot: *mut SnapshotData,
+    pub slot: *mut TupleTableSlot,
+}
+impl Default for SysScanDescData {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn table_open(relationId: Oid, lockmode: LOCKMODE) -> Relation;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn table_openrv(relation: *const RangeVar, lockmode: LOCKMODE) -> Relation;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn table_openrv_extended(
+        relation: *const RangeVar,
+        lockmode: LOCKMODE,
+        missing_ok: bool,
+    ) -> Relation;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn table_close(relation: Relation, lockmode: LOCKMODE);
+}
+pub const GucContext_PGC_INTERNAL: GucContext = 0;
+pub const GucContext_PGC_POSTMASTER: GucContext = 1;
+pub const GucContext_PGC_SIGHUP: GucContext = 2;
+pub const GucContext_PGC_SU_BACKEND: GucContext = 3;
+pub const GucContext_PGC_BACKEND: GucContext = 4;
+pub const GucContext_PGC_SUSET: GucContext = 5;
+pub const GucContext_PGC_USERSET: GucContext = 6;
+pub type GucContext = ::std::os::raw::c_uint;
+pub const GucSource_PGC_S_DEFAULT: GucSource = 0;
+pub const GucSource_PGC_S_DYNAMIC_DEFAULT: GucSource = 1;
+pub const GucSource_PGC_S_ENV_VAR: GucSource = 2;
+pub const GucSource_PGC_S_FILE: GucSource = 3;
+pub const GucSource_PGC_S_ARGV: GucSource = 4;
+pub const GucSource_PGC_S_GLOBAL: GucSource = 5;
+pub const GucSource_PGC_S_DATABASE: GucSource = 6;
+pub const GucSource_PGC_S_USER: GucSource = 7;
+pub const GucSource_PGC_S_DATABASE_USER: GucSource = 8;
+pub const GucSource_PGC_S_CLIENT: GucSource = 9;
+pub const GucSource_PGC_S_OVERRIDE: GucSource = 10;
+pub const GucSource_PGC_S_INTERACTIVE: GucSource = 11;
+pub const GucSource_PGC_S_TEST: GucSource = 12;
+pub const GucSource_PGC_S_SESSION: GucSource = 13;
+pub type GucSource = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ConfigVariable {
+    pub name: *mut ::std::os::raw::c_char,
+    pub value: *mut ::std::os::raw::c_char,
+    pub errmsg: *mut ::std::os::raw::c_char,
+    pub filename: *mut ::std::os::raw::c_char,
+    pub sourceline: ::std::os::raw::c_int,
+    pub ignore: bool,
+    pub applied: bool,
+    pub next: *mut ConfigVariable,
+}
+impl Default for ConfigVariable {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ParseConfigFile(
+        config_file: *const ::std::os::raw::c_char,
+        strict: bool,
+        calling_file: *const ::std::os::raw::c_char,
+        calling_lineno: ::std::os::raw::c_int,
+        depth: ::std::os::raw::c_int,
+        elevel: ::std::os::raw::c_int,
+        head_p: *mut *mut ConfigVariable,
+        tail_p: *mut *mut ConfigVariable,
+    ) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ParseConfigFp(
+        fp: *mut FILE,
+        config_file: *const ::std::os::raw::c_char,
+        depth: ::std::os::raw::c_int,
+        elevel: ::std::os::raw::c_int,
+        head_p: *mut *mut ConfigVariable,
+        tail_p: *mut *mut ConfigVariable,
+    ) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ParseConfigDirectory(
+        includedir: *const ::std::os::raw::c_char,
+        calling_file: *const ::std::os::raw::c_char,
+        calling_lineno: ::std::os::raw::c_int,
+        depth: ::std::os::raw::c_int,
+        elevel: ::std::os::raw::c_int,
+        head_p: *mut *mut ConfigVariable,
+        tail_p: *mut *mut ConfigVariable,
+    ) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn FreeConfigVariables(list: *mut ConfigVariable);
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct config_enum_entry {
+    pub name: *const ::std::os::raw::c_char,
+    pub val: ::std::os::raw::c_int,
+    pub hidden: bool,
+}
+impl Default for config_enum_entry {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type GucBoolCheckHook = ::std::option::Option<
+    unsafe extern "C" fn(
+        newval: *mut bool,
+        extra: *mut *mut ::std::os::raw::c_void,
+        source: GucSource,
+    ) -> bool,
+>;
+pub type GucIntCheckHook = ::std::option::Option<
+    unsafe extern "C" fn(
+        newval: *mut ::std::os::raw::c_int,
+        extra: *mut *mut ::std::os::raw::c_void,
+        source: GucSource,
+    ) -> bool,
+>;
+pub type GucRealCheckHook = ::std::option::Option<
+    unsafe extern "C" fn(
+        newval: *mut f64,
+        extra: *mut *mut ::std::os::raw::c_void,
+        source: GucSource,
+    ) -> bool,
+>;
+pub type GucStringCheckHook = ::std::option::Option<
+    unsafe extern "C" fn(
+        newval: *mut *mut ::std::os::raw::c_char,
+        extra: *mut *mut ::std::os::raw::c_void,
+        source: GucSource,
+    ) -> bool,
+>;
+pub type GucEnumCheckHook = ::std::option::Option<
+    unsafe extern "C" fn(
+        newval: *mut ::std::os::raw::c_int,
+        extra: *mut *mut ::std::os::raw::c_void,
+        source: GucSource,
+    ) -> bool,
+>;
+pub type GucBoolAssignHook =
+    ::std::option::Option<unsafe extern "C" fn(newval: bool, extra: *mut ::std::os::raw::c_void)>;
+pub type GucIntAssignHook = ::std::option::Option<
+    unsafe extern "C" fn(newval: ::std::os::raw::c_int, extra: *mut ::std::os::raw::c_void),
+>;
+pub type GucRealAssignHook =
+    ::std::option::Option<unsafe extern "C" fn(newval: f64, extra: *mut ::std::os::raw::c_void)>;
+pub type GucStringAssignHook = ::std::option::Option<
+    unsafe extern "C" fn(newval: *const ::std::os::raw::c_char, extra: *mut ::std::os::raw::c_void),
+>;
+pub type GucEnumAssignHook = ::std::option::Option<
+    unsafe extern "C" fn(newval: ::std::os::raw::c_int, extra: *mut ::std::os::raw::c_void),
+>;
+pub type GucShowHook =
+    ::std::option::Option<unsafe extern "C" fn() -> *const ::std::os::raw::c_char>;
+pub const GucAction_GUC_ACTION_SET: GucAction = 0;
+pub const GucAction_GUC_ACTION_LOCAL: GucAction = 1;
+pub const GucAction_GUC_ACTION_SAVE: GucAction = 2;
+pub type GucAction = ::std::os::raw::c_uint;
+extern "C" {
+    pub static mut log_duration: bool;
+}
+extern "C" {
+    pub static mut Debug_print_plan: bool;
+}
+extern "C" {
+    pub static mut Debug_print_parse: bool;
+}
+extern "C" {
+    pub static mut Debug_print_rewritten: bool;
+}
+extern "C" {
+    pub static mut Debug_pretty_print: bool;
+}
+extern "C" {
+    pub static mut log_parser_stats: bool;
+}
+extern "C" {
+    pub static mut log_planner_stats: bool;
+}
+extern "C" {
+    pub static mut log_executor_stats: bool;
+}
+extern "C" {
+    pub static mut log_statement_stats: bool;
+}
+extern "C" {
+    pub static mut log_btree_build_stats: bool;
+}
+extern "C" {
+    pub static mut check_function_bodies: bool;
+}
+extern "C" {
+    pub static mut session_auth_is_superuser: bool;
+}
+extern "C" {
+    pub static mut log_min_error_statement: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut log_min_messages: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut client_min_messages: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut log_min_duration_statement: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut log_temp_files: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut log_xact_sample_rate: f64;
+}
+extern "C" {
+    pub static mut temp_file_limit: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut num_temp_buffers: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut cluster_name: *mut ::std::os::raw::c_char;
+}
+extern "C" {
+    pub static mut ConfigFileName: *mut ::std::os::raw::c_char;
+}
+extern "C" {
+    pub static mut HbaFileName: *mut ::std::os::raw::c_char;
+}
+extern "C" {
+    pub static mut IdentFileName: *mut ::std::os::raw::c_char;
+}
+extern "C" {
+    pub static mut external_pid_file: *mut ::std::os::raw::c_char;
+}
+extern "C" {
+    pub static mut application_name: *mut ::std::os::raw::c_char;
+}
+extern "C" {
+    pub static mut tcp_keepalives_idle: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut tcp_keepalives_interval: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut tcp_keepalives_count: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut tcp_user_timeout: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut trace_sort: bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SetConfigOption(
+        name: *const ::std::os::raw::c_char,
+        value: *const ::std::os::raw::c_char,
+        context: GucContext,
+        source: GucSource,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DefineCustomBoolVariable(
+        name: *const ::std::os::raw::c_char,
+        short_desc: *const ::std::os::raw::c_char,
+        long_desc: *const ::std::os::raw::c_char,
+        valueAddr: *mut bool,
+        bootValue: bool,
+        context: GucContext,
+        flags: ::std::os::raw::c_int,
+        check_hook: GucBoolCheckHook,
+        assign_hook: GucBoolAssignHook,
+        show_hook: GucShowHook,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DefineCustomIntVariable(
+        name: *const ::std::os::raw::c_char,
+        short_desc: *const ::std::os::raw::c_char,
+        long_desc: *const ::std::os::raw::c_char,
+        valueAddr: *mut ::std::os::raw::c_int,
+        bootValue: ::std::os::raw::c_int,
+        minValue: ::std::os::raw::c_int,
+        maxValue: ::std::os::raw::c_int,
+        context: GucContext,
+        flags: ::std::os::raw::c_int,
+        check_hook: GucIntCheckHook,
+        assign_hook: GucIntAssignHook,
+        show_hook: GucShowHook,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DefineCustomRealVariable(
+        name: *const ::std::os::raw::c_char,
+        short_desc: *const ::std::os::raw::c_char,
+        long_desc: *const ::std::os::raw::c_char,
+        valueAddr: *mut f64,
+        bootValue: f64,
+        minValue: f64,
+        maxValue: f64,
+        context: GucContext,
+        flags: ::std::os::raw::c_int,
+        check_hook: GucRealCheckHook,
+        assign_hook: GucRealAssignHook,
+        show_hook: GucShowHook,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DefineCustomStringVariable(
+        name: *const ::std::os::raw::c_char,
+        short_desc: *const ::std::os::raw::c_char,
+        long_desc: *const ::std::os::raw::c_char,
+        valueAddr: *mut *mut ::std::os::raw::c_char,
+        bootValue: *const ::std::os::raw::c_char,
+        context: GucContext,
+        flags: ::std::os::raw::c_int,
+        check_hook: GucStringCheckHook,
+        assign_hook: GucStringAssignHook,
+        show_hook: GucShowHook,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DefineCustomEnumVariable(
+        name: *const ::std::os::raw::c_char,
+        short_desc: *const ::std::os::raw::c_char,
+        long_desc: *const ::std::os::raw::c_char,
+        valueAddr: *mut ::std::os::raw::c_int,
+        bootValue: ::std::os::raw::c_int,
+        options: *const config_enum_entry,
+        context: GucContext,
+        flags: ::std::os::raw::c_int,
+        check_hook: GucEnumCheckHook,
+        assign_hook: GucEnumAssignHook,
+        show_hook: GucShowHook,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn EmitWarningsOnPlaceholders(className: *const ::std::os::raw::c_char);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetConfigOption(
+        name: *const ::std::os::raw::c_char,
+        missing_ok: bool,
+        restrict_privileged: bool,
+    ) -> *const ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetConfigOptionResetString(
+        name: *const ::std::os::raw::c_char,
+    ) -> *const ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetConfigOptionFlags(
+        name: *const ::std::os::raw::c_char,
+        missing_ok: bool,
+    ) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ProcessConfigFile(context: GucContext);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn InitializeGUCOptions();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SelectConfigFiles(
+        userDoption: *const ::std::os::raw::c_char,
+        progname: *const ::std::os::raw::c_char,
+    ) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ResetAllOptions();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn AtStart_GUC();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn NewGUCNestLevel() -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn AtEOXact_GUC(isCommit: bool, nestLevel: ::std::os::raw::c_int);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn BeginReportingGUCOptions();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ParseLongOption(
+        string: *const ::std::os::raw::c_char,
+        name: *mut *mut ::std::os::raw::c_char,
+        value: *mut *mut ::std::os::raw::c_char,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn parse_int(
+        value: *const ::std::os::raw::c_char,
+        result: *mut ::std::os::raw::c_int,
+        flags: ::std::os::raw::c_int,
+        hintmsg: *mut *const ::std::os::raw::c_char,
+    ) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn parse_real(
+        value: *const ::std::os::raw::c_char,
+        result: *mut f64,
+        flags: ::std::os::raw::c_int,
+        hintmsg: *mut *const ::std::os::raw::c_char,
+    ) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn set_config_option(
+        name: *const ::std::os::raw::c_char,
+        value: *const ::std::os::raw::c_char,
+        context: GucContext,
+        source: GucSource,
+        action: GucAction,
+        changeVal: bool,
+        elevel: ::std::os::raw::c_int,
+        is_reload: bool,
+    ) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn AlterSystemSetConfigFile(setstmt: *mut AlterSystemStmt);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetConfigOptionByName(
+        name: *const ::std::os::raw::c_char,
+        varname: *mut *const ::std::os::raw::c_char,
+        missing_ok: bool,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetConfigOptionByNum(
+        varnum: ::std::os::raw::c_int,
+        values: *mut *const ::std::os::raw::c_char,
+        noshow: *mut bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetNumConfigOptions() -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SetPGVariable(name: *const ::std::os::raw::c_char, args: *mut List, is_local: bool);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetPGVariable(name: *const ::std::os::raw::c_char, dest: *mut DestReceiver);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetPGVariableResultDesc(name: *const ::std::os::raw::c_char) -> TupleDesc;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ExecSetVariableStmt(stmt: *mut VariableSetStmt, isTopLevel: bool);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ExtractSetVariableArgs(stmt: *mut VariableSetStmt) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ProcessGUCArray(
+        array: *mut ArrayType,
+        context: GucContext,
+        source: GucSource,
+        action: GucAction,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GUCArrayAdd(
+        array: *mut ArrayType,
+        name: *const ::std::os::raw::c_char,
+        value: *const ::std::os::raw::c_char,
+    ) -> *mut ArrayType;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GUCArrayDelete(
+        array: *mut ArrayType,
+        name: *const ::std::os::raw::c_char,
+    ) -> *mut ArrayType;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GUCArrayReset(array: *mut ArrayType) -> *mut ArrayType;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn EstimateGUCStateSpace() -> Size;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SerializeGUCState(maxsize: Size, start_address: *mut ::std::os::raw::c_char);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RestoreGUCState(gucstate: *mut ::std::os::raw::c_void);
+}
+extern "C" {
+    pub static mut GUC_check_errmsg_string: *mut ::std::os::raw::c_char;
+}
+extern "C" {
+    pub static mut GUC_check_errdetail_string: *mut ::std::os::raw::c_char;
+}
+extern "C" {
+    pub static mut GUC_check_errhint_string: *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GUC_check_errcode(sqlerrcode: ::std::os::raw::c_int);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn check_default_tablespace(
+        newval: *mut *mut ::std::os::raw::c_char,
+        extra: *mut *mut ::std::os::raw::c_void,
+        source: GucSource,
+    ) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn check_temp_tablespaces(
+        newval: *mut *mut ::std::os::raw::c_char,
+        extra: *mut *mut ::std::os::raw::c_void,
+        source: GucSource,
+    ) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn assign_temp_tablespaces(
+        newval: *const ::std::os::raw::c_char,
+        extra: *mut ::std::os::raw::c_void,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn check_search_path(
+        newval: *mut *mut ::std::os::raw::c_char,
+        extra: *mut *mut ::std::os::raw::c_void,
+        source: GucSource,
+    ) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn assign_search_path(
+        newval: *const ::std::os::raw::c_char,
+        extra: *mut ::std::os::raw::c_void,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn check_wal_buffers(
+        newval: *mut ::std::os::raw::c_int,
+        extra: *mut *mut ::std::os::raw::c_void,
+        source: GucSource,
+    ) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn assign_xlog_sync_method(
+        new_sync_method: ::std::os::raw::c_int,
+        extra: *mut ::std::os::raw::c_void,
+    );
 }
 extern "C" {
     pub static mut default_table_access_method: *mut ::std::os::raw::c_char;
@@ -29652,10 +29820,10 @@ impl Default for DynamicZoneAbbrev {
     }
 }
 extern "C" {
-    pub static mut months: [*const ::std::os::raw::c_char; 0usize];
+    pub static months: [*const ::std::os::raw::c_char; 0usize];
 }
 extern "C" {
-    pub static mut days: [*const ::std::os::raw::c_char; 0usize];
+    pub static days: [*const ::std::os::raw::c_char; 0usize];
 }
 extern "C" {
     pub static mut day_tab: [[::std::os::raw::c_int; 13usize]; 2usize];
@@ -29755,7 +29923,7 @@ extern "C" {
         dterr: ::std::os::raw::c_int,
         str_: *const ::std::os::raw::c_char,
         datatype: *const ::std::os::raw::c_char,
-    );
+    ) -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -36970,7 +37138,7 @@ impl Default for pg_enc2name {
     }
 }
 extern "C" {
-    pub static mut pg_enc2name_tbl: [pg_enc2name; 0usize];
+    pub static pg_enc2name_tbl: [pg_enc2name; 0usize];
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -36988,7 +37156,7 @@ impl Default for pg_enc2gettext {
     }
 }
 extern "C" {
-    pub static mut pg_enc2gettext_tbl: [pg_enc2gettext; 0usize];
+    pub static pg_enc2gettext_tbl: [pg_enc2gettext; 0usize];
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -37040,7 +37208,7 @@ pub struct pg_wchar_tbl {
     pub maxmblen: ::std::os::raw::c_int,
 }
 extern "C" {
-    pub static mut pg_wchar_table: [pg_wchar_tbl; 0usize];
+    pub static pg_wchar_table: [pg_wchar_tbl; 0usize];
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -37454,7 +37622,7 @@ extern "C" {
         encoding: ::std::os::raw::c_int,
         mbstr: *const ::std::os::raw::c_char,
         len: ::std::os::raw::c_int,
-    );
+    ) -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -37463,7 +37631,7 @@ extern "C" {
         dest_encoding: ::std::os::raw::c_int,
         mbstr: *const ::std::os::raw::c_char,
         len: ::std::os::raw::c_int,
-    );
+    ) -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -41577,6 +41745,39 @@ extern "C" {
 extern "C" {
     pub fn get_parse_rowmark(qry: *mut Query, rtindex: Index) -> *mut RowMarkClause;
 }
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn scanstr(s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn downcase_truncate_identifier(
+        ident: *const ::std::os::raw::c_char,
+        len: ::std::os::raw::c_int,
+        warn: bool,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn downcase_identifier(
+        ident: *const ::std::os::raw::c_char,
+        len: ::std::os::raw::c_int,
+        warn: bool,
+        truncate: bool,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn truncate_identifier(
+        ident: *mut ::std::os::raw::c_char,
+        len: ::std::os::raw::c_int,
+        warn: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn scanner_isspace(ch: ::std::os::raw::c_char) -> bool;
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ExpandedRecordHeader {
@@ -43401,7 +43602,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn plpgsql_yyerror(message: *const ::std::os::raw::c_char);
+    pub fn plpgsql_yyerror(message: *const ::std::os::raw::c_char) -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -44872,7 +45073,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn proc_exit(code: ::std::os::raw::c_int);
+    pub fn proc_exit(code: ::std::os::raw::c_int) -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -44904,6 +45105,190 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn CreateSharedMemoryAndSemaphores(port: ::std::os::raw::c_int);
+}
+pub const XLTW_Oper_XLTW_None: XLTW_Oper = 0;
+pub const XLTW_Oper_XLTW_Update: XLTW_Oper = 1;
+pub const XLTW_Oper_XLTW_Delete: XLTW_Oper = 2;
+pub const XLTW_Oper_XLTW_Lock: XLTW_Oper = 3;
+pub const XLTW_Oper_XLTW_LockUpdated: XLTW_Oper = 4;
+pub const XLTW_Oper_XLTW_InsertIndex: XLTW_Oper = 5;
+pub const XLTW_Oper_XLTW_InsertIndexUnique: XLTW_Oper = 6;
+pub const XLTW_Oper_XLTW_FetchUpdated: XLTW_Oper = 7;
+pub const XLTW_Oper_XLTW_RecheckExclusionConstr: XLTW_Oper = 8;
+pub type XLTW_Oper = ::std::os::raw::c_uint;
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RelationInitLockInfo(relation: Relation);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockRelationOid(relid: Oid, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ConditionalLockRelationOid(relid: Oid, lockmode: LOCKMODE) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockRelationId(relid: *mut LockRelId, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockRelationOid(relid: Oid, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockRelation(relation: Relation, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ConditionalLockRelation(relation: Relation, lockmode: LOCKMODE) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockRelation(relation: Relation, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn CheckRelationLockedByMe(
+        relation: Relation,
+        lockmode: LOCKMODE,
+        orstronger: bool,
+    ) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockHasWaitersRelation(relation: Relation, lockmode: LOCKMODE) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockRelationIdForSession(relid: *mut LockRelId, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockRelationIdForSession(relid: *mut LockRelId, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockRelationForExtension(relation: Relation, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockRelationForExtension(relation: Relation, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ConditionalLockRelationForExtension(relation: Relation, lockmode: LOCKMODE) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RelationExtensionLockWaiterCount(relation: Relation) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockDatabaseFrozenIds(lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockPage(relation: Relation, blkno: BlockNumber, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ConditionalLockPage(relation: Relation, blkno: BlockNumber, lockmode: LOCKMODE) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockPage(relation: Relation, blkno: BlockNumber, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockTuple(relation: Relation, tid: ItemPointer, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ConditionalLockTuple(relation: Relation, tid: ItemPointer, lockmode: LOCKMODE) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockTuple(relation: Relation, tid: ItemPointer, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XactLockTableInsert(xid: TransactionId);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XactLockTableDelete(xid: TransactionId);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XactLockTableWait(xid: TransactionId, rel: Relation, ctid: ItemPointer, oper: XLTW_Oper);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ConditionalXactLockTableWait(xid: TransactionId) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn WaitForLockers(heaplocktag: LOCKTAG, lockmode: LOCKMODE, progress: bool);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn WaitForLockersMultiple(locktags: *mut List, lockmode: LOCKMODE, progress: bool);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SpeculativeInsertionLockAcquire(xid: TransactionId) -> uint32;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SpeculativeInsertionLockRelease(xid: TransactionId);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SpeculativeInsertionWait(xid: TransactionId, token: uint32);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockDatabaseObject(classid: Oid, objid: Oid, objsubid: uint16, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockDatabaseObject(classid: Oid, objid: Oid, objsubid: uint16, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockSharedObject(classid: Oid, objid: Oid, objsubid: uint16, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockSharedObject(classid: Oid, objid: Oid, objsubid: uint16, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockSharedObjectForSession(
+        classid: Oid,
+        objid: Oid,
+        objsubid: uint16,
+        lockmode: LOCKMODE,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockSharedObjectForSession(
+        classid: Oid,
+        objid: Oid,
+        objsubid: uint16,
+        lockmode: LOCKMODE,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DescribeLockTag(buf: StringInfo, tag: *const LOCKTAG);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetLockNameFromTagType(locktag_type: uint16) -> *const ::std::os::raw::c_char;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -45438,7 +45823,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn quickdie(postgres_signal_arg: ::std::os::raw::c_int);
+    pub fn quickdie(postgres_signal_arg: ::std::os::raw::c_int) -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -45446,7 +45831,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn FloatExceptionHandler(postgres_signal_arg: ::std::os::raw::c_int);
+    pub fn FloatExceptionHandler(postgres_signal_arg: ::std::os::raw::c_int) -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -45476,7 +45861,7 @@ extern "C" {
         argv: *mut *mut ::std::os::raw::c_char,
         dbname: *const ::std::os::raw::c_char,
         username: *const ::std::os::raw::c_char,
-    );
+    ) -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -56860,15 +57245,15 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn float_overflow_error();
+    pub fn float_overflow_error() -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn float_underflow_error();
+    pub fn float_underflow_error() -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn float_zero_divide_error();
+    pub fn float_zero_divide_error() -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -57291,6 +57676,177 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn JsonbTypeName(jb: *mut JsonbValue) -> *const ::std::os::raw::c_char;
+}
+pub const JsonTokenType_JSON_TOKEN_INVALID: JsonTokenType = 0;
+pub const JsonTokenType_JSON_TOKEN_STRING: JsonTokenType = 1;
+pub const JsonTokenType_JSON_TOKEN_NUMBER: JsonTokenType = 2;
+pub const JsonTokenType_JSON_TOKEN_OBJECT_START: JsonTokenType = 3;
+pub const JsonTokenType_JSON_TOKEN_OBJECT_END: JsonTokenType = 4;
+pub const JsonTokenType_JSON_TOKEN_ARRAY_START: JsonTokenType = 5;
+pub const JsonTokenType_JSON_TOKEN_ARRAY_END: JsonTokenType = 6;
+pub const JsonTokenType_JSON_TOKEN_COMMA: JsonTokenType = 7;
+pub const JsonTokenType_JSON_TOKEN_COLON: JsonTokenType = 8;
+pub const JsonTokenType_JSON_TOKEN_TRUE: JsonTokenType = 9;
+pub const JsonTokenType_JSON_TOKEN_FALSE: JsonTokenType = 10;
+pub const JsonTokenType_JSON_TOKEN_NULL: JsonTokenType = 11;
+pub const JsonTokenType_JSON_TOKEN_END: JsonTokenType = 12;
+pub type JsonTokenType = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct JsonLexContext {
+    pub input: *mut ::std::os::raw::c_char,
+    pub input_length: ::std::os::raw::c_int,
+    pub token_start: *mut ::std::os::raw::c_char,
+    pub token_terminator: *mut ::std::os::raw::c_char,
+    pub prev_token_terminator: *mut ::std::os::raw::c_char,
+    pub token_type: JsonTokenType,
+    pub lex_level: ::std::os::raw::c_int,
+    pub line_number: ::std::os::raw::c_int,
+    pub line_start: *mut ::std::os::raw::c_char,
+    pub strval: StringInfo,
+}
+impl Default for JsonLexContext {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type json_struct_action =
+    ::std::option::Option<unsafe extern "C" fn(state: *mut ::std::os::raw::c_void)>;
+pub type json_ofield_action = ::std::option::Option<
+    unsafe extern "C" fn(
+        state: *mut ::std::os::raw::c_void,
+        fname: *mut ::std::os::raw::c_char,
+        isnull: bool,
+    ),
+>;
+pub type json_aelem_action =
+    ::std::option::Option<unsafe extern "C" fn(state: *mut ::std::os::raw::c_void, isnull: bool)>;
+pub type json_scalar_action = ::std::option::Option<
+    unsafe extern "C" fn(
+        state: *mut ::std::os::raw::c_void,
+        token: *mut ::std::os::raw::c_char,
+        tokentype: JsonTokenType,
+    ),
+>;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct JsonSemAction {
+    pub semstate: *mut ::std::os::raw::c_void,
+    pub object_start: json_struct_action,
+    pub object_end: json_struct_action,
+    pub array_start: json_struct_action,
+    pub array_end: json_struct_action,
+    pub object_field_start: json_ofield_action,
+    pub object_field_end: json_ofield_action,
+    pub array_element_start: json_aelem_action,
+    pub array_element_end: json_aelem_action,
+    pub scalar: json_scalar_action,
+}
+impl Default for JsonSemAction {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn pg_parse_json(lex: *mut JsonLexContext, sem: *mut JsonSemAction);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn json_count_array_elements(lex: *mut JsonLexContext) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn makeJsonLexContext(json: *mut text, need_escapes: bool) -> *mut JsonLexContext;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn makeJsonLexContextCstringLen(
+        json: *mut ::std::os::raw::c_char,
+        len: ::std::os::raw::c_int,
+        need_escapes: bool,
+    ) -> *mut JsonLexContext;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn IsValidJsonNumber(
+        str_: *const ::std::os::raw::c_char,
+        len: ::std::os::raw::c_int,
+    ) -> bool;
+}
+pub const JsonToIndex_jtiKey: JsonToIndex = 1;
+pub const JsonToIndex_jtiString: JsonToIndex = 2;
+pub const JsonToIndex_jtiNumeric: JsonToIndex = 4;
+pub const JsonToIndex_jtiBool: JsonToIndex = 8;
+pub const JsonToIndex_jtiAll: JsonToIndex = 15;
+pub type JsonToIndex = ::std::os::raw::c_uint;
+pub type JsonIterateStringValuesAction = ::std::option::Option<
+    unsafe extern "C" fn(
+        state: *mut ::std::os::raw::c_void,
+        elem_value: *mut ::std::os::raw::c_char,
+        elem_len: ::std::os::raw::c_int,
+    ),
+>;
+pub type JsonTransformStringValuesAction = ::std::option::Option<
+    unsafe extern "C" fn(
+        state: *mut ::std::os::raw::c_void,
+        elem_value: *mut ::std::os::raw::c_char,
+        elem_len: ::std::os::raw::c_int,
+    ) -> *mut text,
+>;
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn parse_jsonb_index_flags(jb: *mut Jsonb) -> uint32;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn iterate_jsonb_values(
+        jb: *mut Jsonb,
+        flags: uint32,
+        state: *mut ::std::os::raw::c_void,
+        action: JsonIterateStringValuesAction,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn iterate_json_values(
+        json: *mut text,
+        flags: uint32,
+        action_state: *mut ::std::os::raw::c_void,
+        action: JsonIterateStringValuesAction,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn transform_jsonb_string_values(
+        jsonb: *mut Jsonb,
+        action_state: *mut ::std::os::raw::c_void,
+        transform_action: JsonTransformStringValuesAction,
+    ) -> *mut Jsonb;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn transform_json_string_values(
+        json: *mut text,
+        action_state: *mut ::std::os::raw::c_void,
+        transform_action: JsonTransformStringValuesAction,
+    ) -> *mut text;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn JsonEncodeDateTime(
+        buf: *mut ::std::os::raw::c_char,
+        value: Datum,
+        typid: Oid,
+    ) -> *mut ::std::os::raw::c_char;
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/pgrx-pg-sys/src/pg13.rs
+++ b/pgrx-pg-sys/src/pg13.rs
@@ -2233,21 +2233,6 @@ pub const SK_SEARCHARRAY: u32 = 32;
 pub const SK_SEARCHNULL: u32 = 64;
 pub const SK_SEARCHNOTNULL: u32 = 128;
 pub const SK_ORDER_BY: u32 = 256;
-pub const GIN_COMPARE_PROC: u32 = 1;
-pub const GIN_EXTRACTVALUE_PROC: u32 = 2;
-pub const GIN_EXTRACTQUERY_PROC: u32 = 3;
-pub const GIN_CONSISTENT_PROC: u32 = 4;
-pub const GIN_COMPARE_PARTIAL_PROC: u32 = 5;
-pub const GIN_TRICONSISTENT_PROC: u32 = 6;
-pub const GIN_OPTIONS_PROC: u32 = 7;
-pub const GINNProcs: u32 = 7;
-pub const GIN_SEARCH_MODE_DEFAULT: u32 = 0;
-pub const GIN_SEARCH_MODE_INCLUDE_EMPTY: u32 = 1;
-pub const GIN_SEARCH_MODE_ALL: u32 = 2;
-pub const GIN_SEARCH_MODE_EVERYTHING: u32 = 3;
-pub const GIN_FALSE: u32 = 0;
-pub const GIN_TRUE: u32 = 1;
-pub const GIN_MAYBE: u32 = 2;
 pub const XLR_NORMAL_MAX_BLOCK_ID: u32 = 4;
 pub const XLR_NORMAL_RDATAS: u32 = 20;
 pub const REGBUF_FORCE_IMAGE: u32 = 1;
@@ -2279,51 +2264,20 @@ pub const TABLESPACE_MAP: &[u8; 15usize] = b"tablespace_map\0";
 pub const TABLESPACE_MAP_OLD: &[u8; 19usize] = b"tablespace_map.old\0";
 pub const PROMOTE_SIGNAL_FILE: &[u8; 8usize] = b"promote\0";
 pub const FALLBACK_PROMOTE_SIGNAL_FILE: &[u8; 17usize] = b"fallback_promote\0";
-pub const GIST_CONSISTENT_PROC: u32 = 1;
-pub const GIST_UNION_PROC: u32 = 2;
-pub const GIST_COMPRESS_PROC: u32 = 3;
-pub const GIST_DECOMPRESS_PROC: u32 = 4;
-pub const GIST_PENALTY_PROC: u32 = 5;
-pub const GIST_PICKSPLIT_PROC: u32 = 6;
-pub const GIST_EQUAL_PROC: u32 = 7;
-pub const GIST_DISTANCE_PROC: u32 = 8;
-pub const GIST_FETCH_PROC: u32 = 9;
-pub const GIST_OPTIONS_PROC: u32 = 10;
-pub const GISTNProcs: u32 = 10;
-pub const F_LEAF: u32 = 1;
-pub const F_DELETED: u32 = 2;
-pub const F_TUPLES_DELETED: u32 = 4;
-pub const F_FOLLOW_RIGHT: u32 = 8;
-pub const F_HAS_GARBAGE: u32 = 16;
-pub const GIST_PAGE_ID: u32 = 65409;
-pub const EOH_HEADER_MAGIC: i32 = -1;
-pub const EA_MAGIC: u32 = 689375833;
-pub const PG_AUTOCONF_FILENAME: &[u8; 21usize] = b"postgresql.auto.conf\0";
-pub const GUC_QUALIFIER_SEPARATOR: u8 = 46u8;
-pub const GUC_LIST_INPUT: u32 = 1;
-pub const GUC_LIST_QUOTE: u32 = 2;
-pub const GUC_NO_SHOW_ALL: u32 = 4;
-pub const GUC_NO_RESET_ALL: u32 = 8;
-pub const GUC_REPORT: u32 = 16;
-pub const GUC_NOT_IN_SAMPLE: u32 = 32;
-pub const GUC_DISALLOW_IN_FILE: u32 = 64;
-pub const GUC_CUSTOM_PLACEHOLDER: u32 = 128;
-pub const GUC_SUPERUSER_ONLY: u32 = 256;
-pub const GUC_IS_NAME: u32 = 512;
-pub const GUC_NOT_WHILE_SEC_REST: u32 = 1024;
-pub const GUC_DISALLOW_IN_AUTO_FILE: u32 = 2048;
-pub const GUC_UNIT_KB: u32 = 4096;
-pub const GUC_UNIT_BLOCKS: u32 = 8192;
-pub const GUC_UNIT_XBLOCKS: u32 = 12288;
-pub const GUC_UNIT_MB: u32 = 16384;
-pub const GUC_UNIT_BYTE: u32 = 32768;
-pub const GUC_UNIT_MEMORY: u32 = 61440;
-pub const GUC_UNIT_MS: u32 = 65536;
-pub const GUC_UNIT_S: u32 = 131072;
-pub const GUC_UNIT_MIN: u32 = 196608;
-pub const GUC_UNIT_TIME: u32 = 983040;
-pub const GUC_EXPLAIN: u32 = 1048576;
-pub const GUC_UNIT: u32 = 1044480;
+pub const XLOG_PAGE_MAGIC: u32 = 53510;
+pub const XLP_FIRST_IS_CONTRECORD: u32 = 1;
+pub const XLP_LONG_HEADER: u32 = 2;
+pub const XLP_BKP_REMOVABLE: u32 = 4;
+pub const XLP_FIRST_IS_OVERWRITE_CONTRECORD: u32 = 8;
+pub const XLP_ALL_FLAGS: u32 = 15;
+pub const WalSegMinSize: u32 = 1048576;
+pub const WalSegMaxSize: u32 = 1073741824;
+pub const DEFAULT_MIN_WAL_SEGS: u32 = 5;
+pub const DEFAULT_MAX_WAL_SEGS: u32 = 64;
+pub const XLOGDIR: &[u8; 7usize] = b"pg_wal\0";
+pub const XLOG_CONTROL_FILE: &[u8; 18usize] = b"global/pg_control\0";
+pub const MAXFNAMELEN: u32 = 64;
+pub const XLOG_FNAME_LEN: u32 = 24;
 pub const RelationRelationId: Oid = Oid(1259);
 pub const RelationRelation_Rowtype_Id: u32 = 83;
 pub const Anum_pg_class_oid: u32 = 1;
@@ -2414,6 +2368,68 @@ pub const Anum_pg_publication_pubviaroot: u32 = 9;
 pub const Natts_pg_publication: u32 = 9;
 pub const HEAP_MIN_FILLFACTOR: u32 = 10;
 pub const HEAP_DEFAULT_FILLFACTOR: u32 = 100;
+pub const MAX_GENERIC_XLOG_PAGES: u32 = 4;
+pub const GENERIC_XLOG_FULL_IMAGE: u32 = 1;
+pub const GIN_COMPARE_PROC: u32 = 1;
+pub const GIN_EXTRACTVALUE_PROC: u32 = 2;
+pub const GIN_EXTRACTQUERY_PROC: u32 = 3;
+pub const GIN_CONSISTENT_PROC: u32 = 4;
+pub const GIN_COMPARE_PARTIAL_PROC: u32 = 5;
+pub const GIN_TRICONSISTENT_PROC: u32 = 6;
+pub const GIN_OPTIONS_PROC: u32 = 7;
+pub const GINNProcs: u32 = 7;
+pub const GIN_SEARCH_MODE_DEFAULT: u32 = 0;
+pub const GIN_SEARCH_MODE_INCLUDE_EMPTY: u32 = 1;
+pub const GIN_SEARCH_MODE_ALL: u32 = 2;
+pub const GIN_SEARCH_MODE_EVERYTHING: u32 = 3;
+pub const GIN_FALSE: u32 = 0;
+pub const GIN_TRUE: u32 = 1;
+pub const GIN_MAYBE: u32 = 2;
+pub const GIST_CONSISTENT_PROC: u32 = 1;
+pub const GIST_UNION_PROC: u32 = 2;
+pub const GIST_COMPRESS_PROC: u32 = 3;
+pub const GIST_DECOMPRESS_PROC: u32 = 4;
+pub const GIST_PENALTY_PROC: u32 = 5;
+pub const GIST_PICKSPLIT_PROC: u32 = 6;
+pub const GIST_EQUAL_PROC: u32 = 7;
+pub const GIST_DISTANCE_PROC: u32 = 8;
+pub const GIST_FETCH_PROC: u32 = 9;
+pub const GIST_OPTIONS_PROC: u32 = 10;
+pub const GISTNProcs: u32 = 10;
+pub const F_LEAF: u32 = 1;
+pub const F_DELETED: u32 = 2;
+pub const F_TUPLES_DELETED: u32 = 4;
+pub const F_FOLLOW_RIGHT: u32 = 8;
+pub const F_HAS_GARBAGE: u32 = 16;
+pub const GIST_PAGE_ID: u32 = 65409;
+pub const EOH_HEADER_MAGIC: i32 = -1;
+pub const EA_MAGIC: u32 = 689375833;
+pub const PG_AUTOCONF_FILENAME: &[u8; 21usize] = b"postgresql.auto.conf\0";
+pub const GUC_QUALIFIER_SEPARATOR: u8 = 46u8;
+pub const GUC_LIST_INPUT: u32 = 1;
+pub const GUC_LIST_QUOTE: u32 = 2;
+pub const GUC_NO_SHOW_ALL: u32 = 4;
+pub const GUC_NO_RESET_ALL: u32 = 8;
+pub const GUC_REPORT: u32 = 16;
+pub const GUC_NOT_IN_SAMPLE: u32 = 32;
+pub const GUC_DISALLOW_IN_FILE: u32 = 64;
+pub const GUC_CUSTOM_PLACEHOLDER: u32 = 128;
+pub const GUC_SUPERUSER_ONLY: u32 = 256;
+pub const GUC_IS_NAME: u32 = 512;
+pub const GUC_NOT_WHILE_SEC_REST: u32 = 1024;
+pub const GUC_DISALLOW_IN_AUTO_FILE: u32 = 2048;
+pub const GUC_UNIT_KB: u32 = 4096;
+pub const GUC_UNIT_BLOCKS: u32 = 8192;
+pub const GUC_UNIT_XBLOCKS: u32 = 12288;
+pub const GUC_UNIT_MB: u32 = 16384;
+pub const GUC_UNIT_BYTE: u32 = 32768;
+pub const GUC_UNIT_MEMORY: u32 = 61440;
+pub const GUC_UNIT_MS: u32 = 65536;
+pub const GUC_UNIT_S: u32 = 131072;
+pub const GUC_UNIT_MIN: u32 = 196608;
+pub const GUC_UNIT_TIME: u32 = 983040;
+pub const GUC_EXPLAIN: u32 = 1048576;
+pub const GUC_UNIT: u32 = 1044480;
 pub const DEFAULT_TABLE_ACCESS_METHOD: &[u8; 5usize] = b"heap\0";
 pub const TABLE_INSERT_SKIP_FSM: u32 = 2;
 pub const TABLE_INSERT_FROZEN: u32 = 4;
@@ -4168,7 +4184,7 @@ extern "C" {
         errorType: *const ::std::os::raw::c_char,
         fileName: *const ::std::os::raw::c_char,
         lineNumber: ::std::os::raw::c_int,
-    );
+    ) -> !;
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -6224,7 +6240,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn ReThrowError(edata: *mut ErrorData);
+    pub fn ReThrowError(edata: *mut ErrorData) -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -16287,11 +16303,7 @@ impl Default for Query {
         }
     }
 }
-#[doc = "\tSupporting data structures for Parse Trees"]
-#[doc = ""]
-#[doc = "\tMost of these node types appear in raw parsetrees output by the grammar,"]
-#[doc = "\tand get transformed to something else by the analyzer.  A few of them"]
-#[doc = "\tare used as-is in transformed querytrees."]
+#[doc = "\tSupporting data structures for Parse Trees\n\n\tMost of these node types appear in raw parsetrees output by the grammar,\n\tand get transformed to something else by the analyzer.  A few of them\n\tare used as-is in transformed querytrees."]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct TypeName {
@@ -17448,17 +17460,7 @@ pub const ObjectType_OBJECT_TSTEMPLATE: ObjectType = 46;
 pub const ObjectType_OBJECT_TYPE: ObjectType = 47;
 pub const ObjectType_OBJECT_USER_MAPPING: ObjectType = 48;
 pub const ObjectType_OBJECT_VIEW: ObjectType = 49;
-#[doc = "\t\tOther Statements (no optimizations required)"]
-#[doc = ""]
-#[doc = "\t\tThese are not touched by parser/analyze.c except to put them into"]
-#[doc = "\t\tthe utilityStmt field of a Query.  This is eventually passed to"]
-#[doc = "\t\tProcessUtility (by-passing rewriting and planning).  Some of the"]
-#[doc = "\t\tstatements do need attention from parse analysis, and this is"]
-#[doc = "\t\tdone by routines in parser/parse_utilcmd.c after ProcessUtility"]
-#[doc = "\t\treceives the command for execution."]
-#[doc = "\t\tDECLARE CURSOR, EXPLAIN, and CREATE TABLE AS are special cases:"]
-#[doc = "\t\tthey contain optimizable statements, which get processed normally"]
-#[doc = "\t\tby parser/analyze.c."]
+#[doc = "\t\tOther Statements (no optimizations required)\n\n\t\tThese are not touched by parser/analyze.c except to put them into\n\t\tthe utilityStmt field of a Query.  This is eventually passed to\n\t\tProcessUtility (by-passing rewriting and planning).  Some of the\n\t\tstatements do need attention from parse analysis, and this is\n\t\tdone by routines in parser/parse_utilcmd.c after ProcessUtility\n\t\treceives the command for execution.\n\t\tDECLARE CURSOR, EXPLAIN, and CREATE TABLE AS are special cases:\n\t\tthey contain optimizable statements, which get processed normally\n\t\tby parser/analyze.c."]
 pub type ObjectType = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -21693,56 +21695,7 @@ extern "C" {
     pub fn pg_tzenumerate_end(dir: *mut pg_tzenum);
 }
 extern "C" {
-    #[doc = "\t  System interrupt and critical section handling"]
-    #[doc = ""]
-    #[doc = " There are two types of interrupts that a running backend needs to accept"]
-    #[doc = " without messing up its state: QueryCancel (SIGINT) and ProcDie (SIGTERM)."]
-    #[doc = " In both cases, we need to be able to clean up the current transaction"]
-    #[doc = " gracefully, so we can't respond to the interrupt instantaneously ---"]
-    #[doc = " there's no guarantee that internal data structures would be self-consistent"]
-    #[doc = " if the code is interrupted at an arbitrary instant.  Instead, the signal"]
-    #[doc = " handlers set flags that are checked periodically during execution."]
-    #[doc = ""]
-    #[doc = " The CHECK_FOR_INTERRUPTS() macro is called at strategically located spots"]
-    #[doc = " where it is normally safe to accept a cancel or die interrupt.  In some"]
-    #[doc = " cases, we invoke CHECK_FOR_INTERRUPTS() inside low-level subroutines that"]
-    #[doc = " might sometimes be called in contexts that do *not* want to allow a cancel"]
-    #[doc = " or die interrupt.  The HOLD_INTERRUPTS() and RESUME_INTERRUPTS() macros"]
-    #[doc = " allow code to ensure that no cancel or die interrupt will be accepted,"]
-    #[doc = " even if CHECK_FOR_INTERRUPTS() gets called in a subroutine.  The interrupt"]
-    #[doc = " will be held off until CHECK_FOR_INTERRUPTS() is done outside any"]
-    #[doc = " HOLD_INTERRUPTS() ... RESUME_INTERRUPTS() section."]
-    #[doc = ""]
-    #[doc = " There is also a mechanism to prevent query cancel interrupts, while still"]
-    #[doc = " allowing die interrupts: HOLD_CANCEL_INTERRUPTS() and"]
-    #[doc = " RESUME_CANCEL_INTERRUPTS()."]
-    #[doc = ""]
-    #[doc = " Note that ProcessInterrupts() has also acquired a number of tasks that"]
-    #[doc = " do not necessarily cause a query-cancel-or-die response.  Hence, it's"]
-    #[doc = " possible that it will just clear InterruptPending and return."]
-    #[doc = ""]
-    #[doc = " INTERRUPTS_PENDING_CONDITION() can be checked to see whether an"]
-    #[doc = " interrupt needs to be serviced, without trying to do so immediately."]
-    #[doc = " Some callers are also interested in INTERRUPTS_CAN_BE_PROCESSED(),"]
-    #[doc = " which tells whether ProcessInterrupts is sure to clear the interrupt."]
-    #[doc = ""]
-    #[doc = " Special mechanisms are used to let an interrupt be accepted when we are"]
-    #[doc = " waiting for a lock or when we are waiting for command input (but, of"]
-    #[doc = " course, only if the interrupt holdoff counter is zero).  See the"]
-    #[doc = " related code for details."]
-    #[doc = ""]
-    #[doc = " A lost connection is handled similarly, although the loss of connection"]
-    #[doc = " does not raise a signal, but is detected when we fail to write to the"]
-    #[doc = " socket. If there was a signal for a broken connection, we could make use of"]
-    #[doc = " it by setting ClientConnectionLost in the signal handler."]
-    #[doc = ""]
-    #[doc = " A related, but conceptually distinct, mechanism is the \"critical section\""]
-    #[doc = " mechanism.  A critical section not only holds off cancel/die interrupts,"]
-    #[doc = " but causes any ereport(ERROR) or ereport(FATAL) to become ereport(PANIC)"]
-    #[doc = " --- that is, a system-wide reset is forced.  Needless to say, only really"]
-    #[doc = " *critical* code should be marked as a critical section!\tCurrently, this"]
-    #[doc = " mechanism is only used for XLOG-related code."]
-    #[doc = ""]
+    #[doc = "\t  System interrupt and critical section handling\n\n There are two types of interrupts that a running backend needs to accept\n without messing up its state: QueryCancel (SIGINT) and ProcDie (SIGTERM).\n In both cases, we need to be able to clean up the current transaction\n gracefully, so we can't respond to the interrupt instantaneously ---\n there's no guarantee that internal data structures would be self-consistent\n if the code is interrupted at an arbitrary instant.  Instead, the signal\n handlers set flags that are checked periodically during execution.\n\n The CHECK_FOR_INTERRUPTS() macro is called at strategically located spots\n where it is normally safe to accept a cancel or die interrupt.  In some\n cases, we invoke CHECK_FOR_INTERRUPTS() inside low-level subroutines that\n might sometimes be called in contexts that do *not* want to allow a cancel\n or die interrupt.  The HOLD_INTERRUPTS() and RESUME_INTERRUPTS() macros\n allow code to ensure that no cancel or die interrupt will be accepted,\n even if CHECK_FOR_INTERRUPTS() gets called in a subroutine.  The interrupt\n will be held off until CHECK_FOR_INTERRUPTS() is done outside any\n HOLD_INTERRUPTS() ... RESUME_INTERRUPTS() section.\n\n There is also a mechanism to prevent query cancel interrupts, while still\n allowing die interrupts: HOLD_CANCEL_INTERRUPTS() and\n RESUME_CANCEL_INTERRUPTS().\n\n Note that ProcessInterrupts() has also acquired a number of tasks that\n do not necessarily cause a query-cancel-or-die response.  Hence, it's\n possible that it will just clear InterruptPending and return.\n\n INTERRUPTS_PENDING_CONDITION() can be checked to see whether an\n interrupt needs to be serviced, without trying to do so immediately.\n Some callers are also interested in INTERRUPTS_CAN_BE_PROCESSED(),\n which tells whether ProcessInterrupts is sure to clear the interrupt.\n\n Special mechanisms are used to let an interrupt be accepted when we are\n waiting for a lock or when we are waiting for command input (but, of\n course, only if the interrupt holdoff counter is zero).  See the\n related code for details.\n\n A lost connection is handled similarly, although the loss of connection\n does not raise a signal, but is detected when we fail to write to the\n socket. If there was a signal for a broken connection, we could make use of\n it by setting ClientConnectionLost in the signal handler.\n\n A related, but conceptually distinct, mechanism is the \"critical section\"\n mechanism.  A critical section not only holds off cancel/die interrupts,\n but causes any ereport(ERROR) or ereport(FATAL) to become ereport(PANIC)\n --- that is, a system-wide reset is forced.  Needless to say, only really\n *critical* code should be marked as a critical section!\tCurrently, this\n mechanism is only used for XLOG-related code.\n"]
     pub static mut InterruptPending: sig_atomic_t;
 }
 extern "C" {
@@ -22086,8 +22039,7 @@ extern "C" {
 pub const ProcessingMode_BootstrapProcessing: ProcessingMode = 0;
 pub const ProcessingMode_InitProcessing: ProcessingMode = 1;
 pub const ProcessingMode_NormalProcessing: ProcessingMode = 2;
-#[doc = "\t  pmod.h --\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t *"]
-#[doc = "\t\t\tPOSTGRES processing mode definitions.                            *"]
+#[doc = "\t  pmod.h --\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t *\n\t\t\tPOSTGRES processing mode definitions.                            *"]
 pub type ProcessingMode = ::std::os::raw::c_uint;
 extern "C" {
     pub static mut Mode: ProcessingMode;
@@ -22107,8 +22059,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    #[doc = "\t  pinit.h --\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t *"]
-    #[doc = "\t\t\tPOSTGRES initialization and cleanup definitions.                 *"]
+    #[doc = "\t  pinit.h --\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t *\n\t\t\tPOSTGRES initialization and cleanup definitions.                 *"]
     pub fn pg_split_opts(
         argv: *mut *mut ::std::os::raw::c_char,
         argcp: *mut ::std::os::raw::c_int,
@@ -22337,7 +22288,7 @@ pub const ForkNumber_VISIBILITYMAP_FORKNUM: ForkNumber = 2;
 pub const ForkNumber_INIT_FORKNUM: ForkNumber = 3;
 pub type ForkNumber = ::std::os::raw::c_int;
 extern "C" {
-    pub static mut forkNames: [*const ::std::os::raw::c_char; 0usize];
+    pub static forkNames: [*const ::std::os::raw::c_char; 0usize];
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -23375,7 +23326,7 @@ pub const LockTagType_LOCKTAG_USERLOCK: LockTagType = 9;
 pub const LockTagType_LOCKTAG_ADVISORY: LockTagType = 10;
 pub type LockTagType = ::std::os::raw::c_uint;
 extern "C" {
-    pub static mut LockTagTypeNames: [*const ::std::os::raw::c_char; 0usize];
+    pub static LockTagTypeNames: [*const ::std::os::raw::c_char; 0usize];
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -23742,7 +23693,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn DeadLockReport();
+    pub fn DeadLockReport() -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -25871,31 +25822,6 @@ extern "C" {
 extern "C" {
     pub fn GetIndexAmRoutineByAmId(amoid: Oid, noerror: bool) -> *mut IndexAmRoutine;
 }
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct GinStatsData {
-    pub nPendingPages: BlockNumber,
-    pub nTotalPages: BlockNumber,
-    pub nEntryPages: BlockNumber,
-    pub nDataPages: BlockNumber,
-    pub nEntries: int64,
-    pub ginVersion: int32,
-}
-pub type GinTernaryValue = ::std::os::raw::c_char;
-extern "C" {
-    pub static mut GinFuzzySearchLimit: ::std::os::raw::c_int;
-}
-extern "C" {
-    pub static mut gin_pending_list_limit: ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn ginGetStats(index: Relation, stats: *mut GinStatsData);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn ginUpdateStats(index: Relation, stats: *const GinStatsData, is_build: bool);
-}
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn XLogBeginInsert();
@@ -26185,11 +26111,6 @@ pub const WALAvailability_WALAVAIL_EXTENDED: WALAvailability = 2;
 pub const WALAvailability_WALAVAIL_UNRESERVED: WALAvailability = 3;
 pub const WALAvailability_WALAVAIL_REMOVED: WALAvailability = 4;
 pub type WALAvailability = ::std::os::raw::c_uint;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct XLogRecData {
-    _unused: [u8; 0],
-}
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn XLogInsertRecord(
@@ -26475,6 +26396,871 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn get_backup_status() -> SessionBackupState;
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct XLogPageHeaderData {
+    pub xlp_magic: uint16,
+    pub xlp_info: uint16,
+    pub xlp_tli: TimeLineID,
+    pub xlp_pageaddr: XLogRecPtr,
+    pub xlp_rem_len: uint32,
+}
+pub type XLogPageHeader = *mut XLogPageHeaderData;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct XLogLongPageHeaderData {
+    pub std: XLogPageHeaderData,
+    pub xlp_sysid: uint64,
+    pub xlp_seg_size: uint32,
+    pub xlp_xlog_blcksz: uint32,
+}
+pub type XLogLongPageHeader = *mut XLogLongPageHeaderData;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct xl_parameter_change {
+    pub MaxConnections: ::std::os::raw::c_int,
+    pub max_worker_processes: ::std::os::raw::c_int,
+    pub max_wal_senders: ::std::os::raw::c_int,
+    pub max_prepared_xacts: ::std::os::raw::c_int,
+    pub max_locks_per_xact: ::std::os::raw::c_int,
+    pub wal_level: ::std::os::raw::c_int,
+    pub wal_log_hints: bool,
+    pub track_commit_timestamp: bool,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct xl_restore_point {
+    pub rp_time: TimestampTz,
+    pub rp_name: [::std::os::raw::c_char; 64usize],
+}
+impl Default for xl_restore_point {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct xl_overwrite_contrecord {
+    pub overwritten_lsn: XLogRecPtr,
+    pub overwrite_time: TimestampTz,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct xl_end_of_recovery {
+    pub end_time: TimestampTz,
+    pub ThisTimeLineID: TimeLineID,
+    pub PrevTimeLineID: TimeLineID,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct XLogRecData {
+    pub next: *mut XLogRecData,
+    pub data: *mut ::std::os::raw::c_char,
+    pub len: uint32,
+}
+impl Default for XLogRecData {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub const RecoveryTargetAction_RECOVERY_TARGET_ACTION_PAUSE: RecoveryTargetAction = 0;
+pub const RecoveryTargetAction_RECOVERY_TARGET_ACTION_PROMOTE: RecoveryTargetAction = 1;
+pub const RecoveryTargetAction_RECOVERY_TARGET_ACTION_SHUTDOWN: RecoveryTargetAction = 2;
+pub type RecoveryTargetAction = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct RmgrData {
+    pub rm_name: *const ::std::os::raw::c_char,
+    pub rm_redo: ::std::option::Option<unsafe extern "C" fn(record: *mut XLogReaderState)>,
+    pub rm_desc:
+        ::std::option::Option<unsafe extern "C" fn(buf: StringInfo, record: *mut XLogReaderState)>,
+    pub rm_identify:
+        ::std::option::Option<unsafe extern "C" fn(info: uint8) -> *const ::std::os::raw::c_char>,
+    pub rm_startup: ::std::option::Option<unsafe extern "C" fn()>,
+    pub rm_cleanup: ::std::option::Option<unsafe extern "C" fn()>,
+    pub rm_mask: ::std::option::Option<
+        unsafe extern "C" fn(pagedata: *mut ::std::os::raw::c_char, blkno: BlockNumber),
+    >,
+}
+impl Default for RmgrData {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+extern "C" {
+    pub static RmgrTable: [RmgrData; 0usize];
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetLastSegSwitchData(lastSwitchLSN: *mut XLogRecPtr) -> pg_time_t;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RequestXLogSwitch(mark_unimportant: bool) -> XLogRecPtr;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetOldestRestartPoint(oldrecptr: *mut XLogRecPtr, oldtli: *mut TimeLineID);
+}
+extern "C" {
+    pub static mut ArchiveRecoveryRequested: bool;
+}
+extern "C" {
+    pub static mut InArchiveRecovery: bool;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct FormData_pg_class {
+    pub oid: Oid,
+    pub relname: NameData,
+    pub relnamespace: Oid,
+    pub reltype: Oid,
+    pub reloftype: Oid,
+    pub relowner: Oid,
+    pub relam: Oid,
+    pub relfilenode: Oid,
+    pub reltablespace: Oid,
+    pub relpages: int32,
+    pub reltuples: float4,
+    pub relallvisible: int32,
+    pub reltoastrelid: Oid,
+    pub relhasindex: bool,
+    pub relisshared: bool,
+    pub relpersistence: ::std::os::raw::c_char,
+    pub relkind: ::std::os::raw::c_char,
+    pub relnatts: int16,
+    pub relchecks: int16,
+    pub relhasrules: bool,
+    pub relhastriggers: bool,
+    pub relhassubclass: bool,
+    pub relrowsecurity: bool,
+    pub relforcerowsecurity: bool,
+    pub relispopulated: bool,
+    pub relreplident: ::std::os::raw::c_char,
+    pub relispartition: bool,
+    pub relrewrite: Oid,
+    pub relfrozenxid: TransactionId,
+    pub relminmxid: TransactionId,
+}
+impl Default for FormData_pg_class {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type Form_pg_class = *mut FormData_pg_class;
+#[repr(C)]
+#[derive(Debug)]
+pub struct FormData_pg_index {
+    pub indexrelid: Oid,
+    pub indrelid: Oid,
+    pub indnatts: int16,
+    pub indnkeyatts: int16,
+    pub indisunique: bool,
+    pub indisprimary: bool,
+    pub indisexclusion: bool,
+    pub indimmediate: bool,
+    pub indisclustered: bool,
+    pub indisvalid: bool,
+    pub indcheckxmin: bool,
+    pub indisready: bool,
+    pub indislive: bool,
+    pub indisreplident: bool,
+    pub indkey: int2vector,
+}
+impl Default for FormData_pg_index {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type Form_pg_index = *mut FormData_pg_index;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ObjectAddress {
+    pub classId: Oid,
+    pub objectId: Oid,
+    pub objectSubId: int32,
+}
+impl Default for ObjectAddress {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+extern "C" {
+    pub static InvalidObjectAddress: ObjectAddress;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_object_address(
+        objtype: ObjectType,
+        object: *mut Node,
+        relp: *mut Relation,
+        lockmode: LOCKMODE,
+        missing_ok: bool,
+    ) -> ObjectAddress;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_object_address_rv(
+        objtype: ObjectType,
+        rel: *mut RangeVar,
+        object: *mut List,
+        relp: *mut Relation,
+        lockmode: LOCKMODE,
+        missing_ok: bool,
+    ) -> ObjectAddress;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn check_object_ownership(
+        roleid: Oid,
+        objtype: ObjectType,
+        address: ObjectAddress,
+        object: *mut Node,
+        relation: Relation,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_object_namespace(address: *const ObjectAddress) -> Oid;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn is_objectclass_supported(class_id: Oid) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_object_oid_index(class_id: Oid) -> Oid;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_object_catcache_oid(class_id: Oid) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_object_catcache_name(class_id: Oid) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_object_attnum_oid(class_id: Oid) -> AttrNumber;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_object_attnum_name(class_id: Oid) -> AttrNumber;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_object_attnum_namespace(class_id: Oid) -> AttrNumber;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_object_attnum_owner(class_id: Oid) -> AttrNumber;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_object_attnum_acl(class_id: Oid) -> AttrNumber;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_object_type(class_id: Oid, object_id: Oid) -> ObjectType;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_object_namensp_unique(class_id: Oid) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_catalog_object_by_oid(
+        catalog: Relation,
+        oidcol: AttrNumber,
+        objectId: Oid,
+    ) -> HeapTuple;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn getObjectDescription(object: *const ObjectAddress) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn getObjectDescriptionOids(classid: Oid, objid: Oid) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn read_objtype_from_string(
+        objtype: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn getObjectTypeDescription(object: *const ObjectAddress) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn getObjectIdentity(address: *const ObjectAddress) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn getObjectIdentityParts(
+        address: *const ObjectAddress,
+        objname: *mut *mut List,
+        objargs: *mut *mut List,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn strlist_to_textarray(list: *mut List) -> *mut ArrayType;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_relkind_objtype(relkind: ::std::os::raw::c_char) -> ObjectType;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct FormData_pg_publication {
+    pub oid: Oid,
+    pub pubname: NameData,
+    pub pubowner: Oid,
+    pub puballtables: bool,
+    pub pubinsert: bool,
+    pub pubupdate: bool,
+    pub pubdelete: bool,
+    pub pubtruncate: bool,
+    pub pubviaroot: bool,
+}
+impl Default for FormData_pg_publication {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type Form_pg_publication = *mut FormData_pg_publication;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct PublicationActions {
+    pub pubinsert: bool,
+    pub pubupdate: bool,
+    pub pubdelete: bool,
+    pub pubtruncate: bool,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct Publication {
+    pub oid: Oid,
+    pub name: *mut ::std::os::raw::c_char,
+    pub alltables: bool,
+    pub pubviaroot: bool,
+    pub pubactions: PublicationActions,
+}
+impl Default for Publication {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetPublication(pubid: Oid) -> *mut Publication;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetPublicationByName(
+        pubname: *const ::std::os::raw::c_char,
+        missing_ok: bool,
+    ) -> *mut Publication;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetRelationPublications(relid: Oid) -> *mut List;
+}
+pub const PublicationPartOpt_PUBLICATION_PART_ROOT: PublicationPartOpt = 0;
+pub const PublicationPartOpt_PUBLICATION_PART_LEAF: PublicationPartOpt = 1;
+pub const PublicationPartOpt_PUBLICATION_PART_ALL: PublicationPartOpt = 2;
+pub type PublicationPartOpt = ::std::os::raw::c_uint;
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetPublicationRelations(pubid: Oid, pub_partopt: PublicationPartOpt) -> *mut List;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetAllTablesPublications() -> *mut List;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetAllTablesPublicationRelations(pubviaroot: bool) -> *mut List;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn is_publishable_relation(rel: Relation) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn publication_add_relation(
+        pubid: Oid,
+        targetrel: Relation,
+        if_not_exists: bool,
+    ) -> ObjectAddress;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetPubPartitionOptionRelations(
+        result: *mut List,
+        pub_partopt: PublicationPartOpt,
+        relid: Oid,
+    ) -> *mut List;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_publication_oid(pubname: *const ::std::os::raw::c_char, missing_ok: bool) -> Oid;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_publication_name(pubid: Oid, missing_ok: bool) -> *mut ::std::os::raw::c_char;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct RewriteRule {
+    pub ruleId: Oid,
+    pub event: CmdType,
+    pub qual: *mut Node,
+    pub actions: *mut List,
+    pub enabled: ::std::os::raw::c_char,
+    pub isInstead: bool,
+}
+impl Default for RewriteRule {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct RuleLock {
+    pub numLocks: ::std::os::raw::c_int,
+    pub rules: *mut *mut RewriteRule,
+}
+impl Default for RuleLock {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct SMgrRelationData {
+    pub smgr_rnode: RelFileNodeBackend,
+    pub smgr_owner: *mut *mut SMgrRelationData,
+    pub smgr_targblock: BlockNumber,
+    pub smgr_fsm_nblocks: BlockNumber,
+    pub smgr_vm_nblocks: BlockNumber,
+    pub smgr_which: ::std::os::raw::c_int,
+    pub md_num_open_segs: [::std::os::raw::c_int; 4usize],
+    pub md_seg_fds: [*mut _MdfdVec; 4usize],
+    pub node: dlist_node,
+}
+impl Default for SMgrRelationData {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type SMgrRelation = *mut SMgrRelationData;
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrinit();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgropen(rnode: RelFileNode, backend: BackendId) -> SMgrRelation;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrexists(reln: SMgrRelation, forknum: ForkNumber) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrsetowner(owner: *mut SMgrRelation, reln: SMgrRelation);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrclearowner(owner: *mut SMgrRelation, reln: SMgrRelation);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrclose(reln: SMgrRelation);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrcloseall();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrclosenode(rnode: RelFileNodeBackend);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrcreate(reln: SMgrRelation, forknum: ForkNumber, isRedo: bool);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrdosyncall(rels: *mut SMgrRelation, nrels: ::std::os::raw::c_int);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrdounlinkall(rels: *mut SMgrRelation, nrels: ::std::os::raw::c_int, isRedo: bool);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrextend(
+        reln: SMgrRelation,
+        forknum: ForkNumber,
+        blocknum: BlockNumber,
+        buffer: *mut ::std::os::raw::c_char,
+        skipFsync: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrprefetch(reln: SMgrRelation, forknum: ForkNumber, blocknum: BlockNumber) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrread(
+        reln: SMgrRelation,
+        forknum: ForkNumber,
+        blocknum: BlockNumber,
+        buffer: *mut ::std::os::raw::c_char,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrwrite(
+        reln: SMgrRelation,
+        forknum: ForkNumber,
+        blocknum: BlockNumber,
+        buffer: *mut ::std::os::raw::c_char,
+        skipFsync: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrwriteback(
+        reln: SMgrRelation,
+        forknum: ForkNumber,
+        blocknum: BlockNumber,
+        nblocks: BlockNumber,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrnblocks(reln: SMgrRelation, forknum: ForkNumber) -> BlockNumber;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrtruncate(
+        reln: SMgrRelation,
+        forknum: *mut ForkNumber,
+        nforks: ::std::os::raw::c_int,
+        nblocks: *mut BlockNumber,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrimmedsync(reln: SMgrRelation, forknum: ForkNumber);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn AtEOXact_SMgr();
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct LockRelId {
+    pub relId: Oid,
+    pub dbId: Oid,
+}
+impl Default for LockRelId {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct LockInfoData {
+    pub lockRelId: LockRelId,
+}
+impl Default for LockInfoData {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type LockInfo = *mut LockInfoData;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct RelationData {
+    pub rd_node: RelFileNode,
+    pub rd_smgr: SMgrRelation,
+    pub rd_refcnt: ::std::os::raw::c_int,
+    pub rd_backend: BackendId,
+    pub rd_islocaltemp: bool,
+    pub rd_isnailed: bool,
+    pub rd_isvalid: bool,
+    pub rd_indexvalid: bool,
+    pub rd_statvalid: bool,
+    pub rd_createSubid: SubTransactionId,
+    pub rd_newRelfilenodeSubid: SubTransactionId,
+    pub rd_firstRelfilenodeSubid: SubTransactionId,
+    pub rd_droppedSubid: SubTransactionId,
+    pub rd_rel: Form_pg_class,
+    pub rd_att: TupleDesc,
+    pub rd_id: Oid,
+    pub rd_lockInfo: LockInfoData,
+    pub rd_rules: *mut RuleLock,
+    pub rd_rulescxt: MemoryContext,
+    pub trigdesc: *mut TriggerDesc,
+    pub rd_rsdesc: *mut RowSecurityDesc,
+    pub rd_fkeylist: *mut List,
+    pub rd_fkeyvalid: bool,
+    pub rd_partkey: PartitionKey,
+    pub rd_partkeycxt: MemoryContext,
+    pub rd_partdesc: PartitionDesc,
+    pub rd_pdcxt: MemoryContext,
+    pub rd_partcheck: *mut List,
+    pub rd_partcheckvalid: bool,
+    pub rd_partcheckcxt: MemoryContext,
+    pub rd_indexlist: *mut List,
+    pub rd_pkindex: Oid,
+    pub rd_replidindex: Oid,
+    pub rd_statlist: *mut List,
+    pub rd_indexattr: *mut Bitmapset,
+    pub rd_keyattr: *mut Bitmapset,
+    pub rd_pkattr: *mut Bitmapset,
+    pub rd_idattr: *mut Bitmapset,
+    pub rd_pubactions: *mut PublicationActions,
+    pub rd_options: *mut bytea,
+    pub rd_amhandler: Oid,
+    pub rd_tableam: *const TableAmRoutine,
+    pub rd_index: Form_pg_index,
+    pub rd_indextuple: *mut HeapTupleData,
+    pub rd_indexcxt: MemoryContext,
+    pub rd_indam: *mut IndexAmRoutine,
+    pub rd_opfamily: *mut Oid,
+    pub rd_opcintype: *mut Oid,
+    pub rd_support: *mut RegProcedure,
+    pub rd_supportinfo: *mut FmgrInfo,
+    pub rd_indoption: *mut int16,
+    pub rd_indexprs: *mut List,
+    pub rd_indpred: *mut List,
+    pub rd_exclops: *mut Oid,
+    pub rd_exclprocs: *mut Oid,
+    pub rd_exclstrats: *mut uint16,
+    pub rd_indcollation: *mut Oid,
+    pub rd_opcoptions: *mut *mut bytea,
+    pub rd_amcache: *mut ::std::os::raw::c_void,
+    pub rd_fdwroutine: *mut FdwRoutine,
+    pub rd_toastoid: Oid,
+    pub pgstat_info: *mut PgStat_TableStatus,
+}
+impl Default for RelationData {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ForeignKeyCacheInfo {
+    pub type_: NodeTag,
+    pub conoid: Oid,
+    pub conrelid: Oid,
+    pub confrelid: Oid,
+    pub nkeys: ::std::os::raw::c_int,
+    pub conkey: [AttrNumber; 32usize],
+    pub confkey: [AttrNumber; 32usize],
+    pub conpfeqop: [Oid; 32usize],
+}
+impl Default for ForeignKeyCacheInfo {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct AutoVacOpts {
+    pub enabled: bool,
+    pub vacuum_threshold: ::std::os::raw::c_int,
+    pub vacuum_ins_threshold: ::std::os::raw::c_int,
+    pub analyze_threshold: ::std::os::raw::c_int,
+    pub vacuum_cost_limit: ::std::os::raw::c_int,
+    pub freeze_min_age: ::std::os::raw::c_int,
+    pub freeze_max_age: ::std::os::raw::c_int,
+    pub freeze_table_age: ::std::os::raw::c_int,
+    pub multixact_freeze_min_age: ::std::os::raw::c_int,
+    pub multixact_freeze_max_age: ::std::os::raw::c_int,
+    pub multixact_freeze_table_age: ::std::os::raw::c_int,
+    pub log_min_duration: ::std::os::raw::c_int,
+    pub vacuum_cost_delay: float8,
+    pub vacuum_scale_factor: float8,
+    pub vacuum_ins_scale_factor: float8,
+    pub analyze_scale_factor: float8,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct StdRdOptions {
+    pub vl_len_: int32,
+    pub fillfactor: ::std::os::raw::c_int,
+    pub toast_tuple_target: ::std::os::raw::c_int,
+    pub autovacuum: AutoVacOpts,
+    pub user_catalog_table: bool,
+    pub parallel_workers: ::std::os::raw::c_int,
+    pub vacuum_index_cleanup: bool,
+    pub vacuum_truncate: bool,
+}
+pub const ViewOptCheckOption_VIEW_OPTION_CHECK_OPTION_NOT_SET: ViewOptCheckOption = 0;
+pub const ViewOptCheckOption_VIEW_OPTION_CHECK_OPTION_LOCAL: ViewOptCheckOption = 1;
+pub const ViewOptCheckOption_VIEW_OPTION_CHECK_OPTION_CASCADED: ViewOptCheckOption = 2;
+pub type ViewOptCheckOption = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ViewOptions {
+    pub vl_len_: int32,
+    pub security_barrier: bool,
+    pub check_option: ViewOptCheckOption,
+}
+impl Default for ViewOptions {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RelationIncrementReferenceCount(rel: Relation);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RelationDecrementReferenceCount(rel: Relation);
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct GenericXLogState {
+    _unused: [u8; 0],
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GenericXLogStart(relation: Relation) -> *mut GenericXLogState;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GenericXLogRegisterBuffer(
+        state: *mut GenericXLogState,
+        buffer: Buffer,
+        flags: ::std::os::raw::c_int,
+    ) -> Page;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GenericXLogFinish(state: *mut GenericXLogState) -> XLogRecPtr;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GenericXLogAbort(state: *mut GenericXLogState);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn generic_redo(record: *mut XLogReaderState);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn generic_identify(info: uint8) -> *const ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn generic_desc(buf: StringInfo, record: *mut XLogReaderState);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn generic_mask(pagedata: *mut ::std::os::raw::c_char, blkno: BlockNumber);
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct GinStatsData {
+    pub nPendingPages: BlockNumber,
+    pub nTotalPages: BlockNumber,
+    pub nEntryPages: BlockNumber,
+    pub nDataPages: BlockNumber,
+    pub nEntries: int64,
+    pub ginVersion: int32,
+}
+pub type GinTernaryValue = ::std::os::raw::c_char;
+extern "C" {
+    pub static mut GinFuzzySearchLimit: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut gin_pending_list_limit: ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ginGetStats(index: Relation, stats: *mut GinStatsData);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ginUpdateStats(index: Relation, stats: *const GinStatsData, is_build: bool);
 }
 pub type GistNSN = XLogRecPtr;
 pub type PageGistNSN = PageXLogRecPtr;
@@ -27950,681 +28736,6 @@ extern "C" {
         new_sync_method: ::std::os::raw::c_int,
         extra: *mut ::std::os::raw::c_void,
     );
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct FormData_pg_class {
-    pub oid: Oid,
-    pub relname: NameData,
-    pub relnamespace: Oid,
-    pub reltype: Oid,
-    pub reloftype: Oid,
-    pub relowner: Oid,
-    pub relam: Oid,
-    pub relfilenode: Oid,
-    pub reltablespace: Oid,
-    pub relpages: int32,
-    pub reltuples: float4,
-    pub relallvisible: int32,
-    pub reltoastrelid: Oid,
-    pub relhasindex: bool,
-    pub relisshared: bool,
-    pub relpersistence: ::std::os::raw::c_char,
-    pub relkind: ::std::os::raw::c_char,
-    pub relnatts: int16,
-    pub relchecks: int16,
-    pub relhasrules: bool,
-    pub relhastriggers: bool,
-    pub relhassubclass: bool,
-    pub relrowsecurity: bool,
-    pub relforcerowsecurity: bool,
-    pub relispopulated: bool,
-    pub relreplident: ::std::os::raw::c_char,
-    pub relispartition: bool,
-    pub relrewrite: Oid,
-    pub relfrozenxid: TransactionId,
-    pub relminmxid: TransactionId,
-}
-impl Default for FormData_pg_class {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type Form_pg_class = *mut FormData_pg_class;
-#[repr(C)]
-#[derive(Debug)]
-pub struct FormData_pg_index {
-    pub indexrelid: Oid,
-    pub indrelid: Oid,
-    pub indnatts: int16,
-    pub indnkeyatts: int16,
-    pub indisunique: bool,
-    pub indisprimary: bool,
-    pub indisexclusion: bool,
-    pub indimmediate: bool,
-    pub indisclustered: bool,
-    pub indisvalid: bool,
-    pub indcheckxmin: bool,
-    pub indisready: bool,
-    pub indislive: bool,
-    pub indisreplident: bool,
-    pub indkey: int2vector,
-}
-impl Default for FormData_pg_index {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type Form_pg_index = *mut FormData_pg_index;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct ObjectAddress {
-    pub classId: Oid,
-    pub objectId: Oid,
-    pub objectSubId: int32,
-}
-impl Default for ObjectAddress {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-extern "C" {
-    pub static InvalidObjectAddress: ObjectAddress;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_object_address(
-        objtype: ObjectType,
-        object: *mut Node,
-        relp: *mut Relation,
-        lockmode: LOCKMODE,
-        missing_ok: bool,
-    ) -> ObjectAddress;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_object_address_rv(
-        objtype: ObjectType,
-        rel: *mut RangeVar,
-        object: *mut List,
-        relp: *mut Relation,
-        lockmode: LOCKMODE,
-        missing_ok: bool,
-    ) -> ObjectAddress;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn check_object_ownership(
-        roleid: Oid,
-        objtype: ObjectType,
-        address: ObjectAddress,
-        object: *mut Node,
-        relation: Relation,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_object_namespace(address: *const ObjectAddress) -> Oid;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn is_objectclass_supported(class_id: Oid) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_object_oid_index(class_id: Oid) -> Oid;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_object_catcache_oid(class_id: Oid) -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_object_catcache_name(class_id: Oid) -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_object_attnum_oid(class_id: Oid) -> AttrNumber;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_object_attnum_name(class_id: Oid) -> AttrNumber;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_object_attnum_namespace(class_id: Oid) -> AttrNumber;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_object_attnum_owner(class_id: Oid) -> AttrNumber;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_object_attnum_acl(class_id: Oid) -> AttrNumber;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_object_type(class_id: Oid, object_id: Oid) -> ObjectType;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_object_namensp_unique(class_id: Oid) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_catalog_object_by_oid(
-        catalog: Relation,
-        oidcol: AttrNumber,
-        objectId: Oid,
-    ) -> HeapTuple;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn getObjectDescription(object: *const ObjectAddress) -> *mut ::std::os::raw::c_char;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn getObjectDescriptionOids(classid: Oid, objid: Oid) -> *mut ::std::os::raw::c_char;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn read_objtype_from_string(
-        objtype: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn getObjectTypeDescription(object: *const ObjectAddress) -> *mut ::std::os::raw::c_char;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn getObjectIdentity(address: *const ObjectAddress) -> *mut ::std::os::raw::c_char;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn getObjectIdentityParts(
-        address: *const ObjectAddress,
-        objname: *mut *mut List,
-        objargs: *mut *mut List,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn strlist_to_textarray(list: *mut List) -> *mut ArrayType;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_relkind_objtype(relkind: ::std::os::raw::c_char) -> ObjectType;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct FormData_pg_publication {
-    pub oid: Oid,
-    pub pubname: NameData,
-    pub pubowner: Oid,
-    pub puballtables: bool,
-    pub pubinsert: bool,
-    pub pubupdate: bool,
-    pub pubdelete: bool,
-    pub pubtruncate: bool,
-    pub pubviaroot: bool,
-}
-impl Default for FormData_pg_publication {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type Form_pg_publication = *mut FormData_pg_publication;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct PublicationActions {
-    pub pubinsert: bool,
-    pub pubupdate: bool,
-    pub pubdelete: bool,
-    pub pubtruncate: bool,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct Publication {
-    pub oid: Oid,
-    pub name: *mut ::std::os::raw::c_char,
-    pub alltables: bool,
-    pub pubviaroot: bool,
-    pub pubactions: PublicationActions,
-}
-impl Default for Publication {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetPublication(pubid: Oid) -> *mut Publication;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetPublicationByName(
-        pubname: *const ::std::os::raw::c_char,
-        missing_ok: bool,
-    ) -> *mut Publication;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetRelationPublications(relid: Oid) -> *mut List;
-}
-pub const PublicationPartOpt_PUBLICATION_PART_ROOT: PublicationPartOpt = 0;
-pub const PublicationPartOpt_PUBLICATION_PART_LEAF: PublicationPartOpt = 1;
-pub const PublicationPartOpt_PUBLICATION_PART_ALL: PublicationPartOpt = 2;
-pub type PublicationPartOpt = ::std::os::raw::c_uint;
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetPublicationRelations(pubid: Oid, pub_partopt: PublicationPartOpt) -> *mut List;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetAllTablesPublications() -> *mut List;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetAllTablesPublicationRelations(pubviaroot: bool) -> *mut List;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn is_publishable_relation(rel: Relation) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn publication_add_relation(
-        pubid: Oid,
-        targetrel: Relation,
-        if_not_exists: bool,
-    ) -> ObjectAddress;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetPubPartitionOptionRelations(
-        result: *mut List,
-        pub_partopt: PublicationPartOpt,
-        relid: Oid,
-    ) -> *mut List;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_publication_oid(pubname: *const ::std::os::raw::c_char, missing_ok: bool) -> Oid;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_publication_name(pubid: Oid, missing_ok: bool) -> *mut ::std::os::raw::c_char;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct RewriteRule {
-    pub ruleId: Oid,
-    pub event: CmdType,
-    pub qual: *mut Node,
-    pub actions: *mut List,
-    pub enabled: ::std::os::raw::c_char,
-    pub isInstead: bool,
-}
-impl Default for RewriteRule {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct RuleLock {
-    pub numLocks: ::std::os::raw::c_int,
-    pub rules: *mut *mut RewriteRule,
-}
-impl Default for RuleLock {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct SMgrRelationData {
-    pub smgr_rnode: RelFileNodeBackend,
-    pub smgr_owner: *mut *mut SMgrRelationData,
-    pub smgr_targblock: BlockNumber,
-    pub smgr_fsm_nblocks: BlockNumber,
-    pub smgr_vm_nblocks: BlockNumber,
-    pub smgr_which: ::std::os::raw::c_int,
-    pub md_num_open_segs: [::std::os::raw::c_int; 4usize],
-    pub md_seg_fds: [*mut _MdfdVec; 4usize],
-    pub node: dlist_node,
-}
-impl Default for SMgrRelationData {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type SMgrRelation = *mut SMgrRelationData;
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrinit();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgropen(rnode: RelFileNode, backend: BackendId) -> SMgrRelation;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrexists(reln: SMgrRelation, forknum: ForkNumber) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrsetowner(owner: *mut SMgrRelation, reln: SMgrRelation);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrclearowner(owner: *mut SMgrRelation, reln: SMgrRelation);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrclose(reln: SMgrRelation);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrcloseall();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrclosenode(rnode: RelFileNodeBackend);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrcreate(reln: SMgrRelation, forknum: ForkNumber, isRedo: bool);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrdosyncall(rels: *mut SMgrRelation, nrels: ::std::os::raw::c_int);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrdounlinkall(rels: *mut SMgrRelation, nrels: ::std::os::raw::c_int, isRedo: bool);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrextend(
-        reln: SMgrRelation,
-        forknum: ForkNumber,
-        blocknum: BlockNumber,
-        buffer: *mut ::std::os::raw::c_char,
-        skipFsync: bool,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrprefetch(reln: SMgrRelation, forknum: ForkNumber, blocknum: BlockNumber) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrread(
-        reln: SMgrRelation,
-        forknum: ForkNumber,
-        blocknum: BlockNumber,
-        buffer: *mut ::std::os::raw::c_char,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrwrite(
-        reln: SMgrRelation,
-        forknum: ForkNumber,
-        blocknum: BlockNumber,
-        buffer: *mut ::std::os::raw::c_char,
-        skipFsync: bool,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrwriteback(
-        reln: SMgrRelation,
-        forknum: ForkNumber,
-        blocknum: BlockNumber,
-        nblocks: BlockNumber,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrnblocks(reln: SMgrRelation, forknum: ForkNumber) -> BlockNumber;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrtruncate(
-        reln: SMgrRelation,
-        forknum: *mut ForkNumber,
-        nforks: ::std::os::raw::c_int,
-        nblocks: *mut BlockNumber,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrimmedsync(reln: SMgrRelation, forknum: ForkNumber);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn AtEOXact_SMgr();
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct LockRelId {
-    pub relId: Oid,
-    pub dbId: Oid,
-}
-impl Default for LockRelId {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct LockInfoData {
-    pub lockRelId: LockRelId,
-}
-impl Default for LockInfoData {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type LockInfo = *mut LockInfoData;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct RelationData {
-    pub rd_node: RelFileNode,
-    pub rd_smgr: SMgrRelation,
-    pub rd_refcnt: ::std::os::raw::c_int,
-    pub rd_backend: BackendId,
-    pub rd_islocaltemp: bool,
-    pub rd_isnailed: bool,
-    pub rd_isvalid: bool,
-    pub rd_indexvalid: bool,
-    pub rd_statvalid: bool,
-    pub rd_createSubid: SubTransactionId,
-    pub rd_newRelfilenodeSubid: SubTransactionId,
-    pub rd_firstRelfilenodeSubid: SubTransactionId,
-    pub rd_droppedSubid: SubTransactionId,
-    pub rd_rel: Form_pg_class,
-    pub rd_att: TupleDesc,
-    pub rd_id: Oid,
-    pub rd_lockInfo: LockInfoData,
-    pub rd_rules: *mut RuleLock,
-    pub rd_rulescxt: MemoryContext,
-    pub trigdesc: *mut TriggerDesc,
-    pub rd_rsdesc: *mut RowSecurityDesc,
-    pub rd_fkeylist: *mut List,
-    pub rd_fkeyvalid: bool,
-    pub rd_partkey: PartitionKey,
-    pub rd_partkeycxt: MemoryContext,
-    pub rd_partdesc: PartitionDesc,
-    pub rd_pdcxt: MemoryContext,
-    pub rd_partcheck: *mut List,
-    pub rd_partcheckvalid: bool,
-    pub rd_partcheckcxt: MemoryContext,
-    pub rd_indexlist: *mut List,
-    pub rd_pkindex: Oid,
-    pub rd_replidindex: Oid,
-    pub rd_statlist: *mut List,
-    pub rd_indexattr: *mut Bitmapset,
-    pub rd_keyattr: *mut Bitmapset,
-    pub rd_pkattr: *mut Bitmapset,
-    pub rd_idattr: *mut Bitmapset,
-    pub rd_pubactions: *mut PublicationActions,
-    pub rd_options: *mut bytea,
-    pub rd_amhandler: Oid,
-    pub rd_tableam: *const TableAmRoutine,
-    pub rd_index: Form_pg_index,
-    pub rd_indextuple: *mut HeapTupleData,
-    pub rd_indexcxt: MemoryContext,
-    pub rd_indam: *mut IndexAmRoutine,
-    pub rd_opfamily: *mut Oid,
-    pub rd_opcintype: *mut Oid,
-    pub rd_support: *mut RegProcedure,
-    pub rd_supportinfo: *mut FmgrInfo,
-    pub rd_indoption: *mut int16,
-    pub rd_indexprs: *mut List,
-    pub rd_indpred: *mut List,
-    pub rd_exclops: *mut Oid,
-    pub rd_exclprocs: *mut Oid,
-    pub rd_exclstrats: *mut uint16,
-    pub rd_indcollation: *mut Oid,
-    pub rd_opcoptions: *mut *mut bytea,
-    pub rd_amcache: *mut ::std::os::raw::c_void,
-    pub rd_fdwroutine: *mut FdwRoutine,
-    pub rd_toastoid: Oid,
-    pub pgstat_info: *mut PgStat_TableStatus,
-}
-impl Default for RelationData {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct ForeignKeyCacheInfo {
-    pub type_: NodeTag,
-    pub conoid: Oid,
-    pub conrelid: Oid,
-    pub confrelid: Oid,
-    pub nkeys: ::std::os::raw::c_int,
-    pub conkey: [AttrNumber; 32usize],
-    pub confkey: [AttrNumber; 32usize],
-    pub conpfeqop: [Oid; 32usize],
-}
-impl Default for ForeignKeyCacheInfo {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct AutoVacOpts {
-    pub enabled: bool,
-    pub vacuum_threshold: ::std::os::raw::c_int,
-    pub vacuum_ins_threshold: ::std::os::raw::c_int,
-    pub analyze_threshold: ::std::os::raw::c_int,
-    pub vacuum_cost_limit: ::std::os::raw::c_int,
-    pub freeze_min_age: ::std::os::raw::c_int,
-    pub freeze_max_age: ::std::os::raw::c_int,
-    pub freeze_table_age: ::std::os::raw::c_int,
-    pub multixact_freeze_min_age: ::std::os::raw::c_int,
-    pub multixact_freeze_max_age: ::std::os::raw::c_int,
-    pub multixact_freeze_table_age: ::std::os::raw::c_int,
-    pub log_min_duration: ::std::os::raw::c_int,
-    pub vacuum_cost_delay: float8,
-    pub vacuum_scale_factor: float8,
-    pub vacuum_ins_scale_factor: float8,
-    pub analyze_scale_factor: float8,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct StdRdOptions {
-    pub vl_len_: int32,
-    pub fillfactor: ::std::os::raw::c_int,
-    pub toast_tuple_target: ::std::os::raw::c_int,
-    pub autovacuum: AutoVacOpts,
-    pub user_catalog_table: bool,
-    pub parallel_workers: ::std::os::raw::c_int,
-    pub vacuum_index_cleanup: bool,
-    pub vacuum_truncate: bool,
-}
-pub const ViewOptCheckOption_VIEW_OPTION_CHECK_OPTION_NOT_SET: ViewOptCheckOption = 0;
-pub const ViewOptCheckOption_VIEW_OPTION_CHECK_OPTION_LOCAL: ViewOptCheckOption = 1;
-pub const ViewOptCheckOption_VIEW_OPTION_CHECK_OPTION_CASCADED: ViewOptCheckOption = 2;
-pub type ViewOptCheckOption = ::std::os::raw::c_uint;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct ViewOptions {
-    pub vl_len_: int32,
-    pub security_barrier: bool,
-    pub check_option: ViewOptCheckOption,
-}
-impl Default for ViewOptions {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn RelationIncrementReferenceCount(rel: Relation);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn RelationDecrementReferenceCount(rel: Relation);
 }
 extern "C" {
     pub static mut default_table_access_method: *mut ::std::os::raw::c_char;
@@ -30335,10 +30446,10 @@ impl Default for DynamicZoneAbbrev {
     }
 }
 extern "C" {
-    pub static mut months: [*const ::std::os::raw::c_char; 0usize];
+    pub static months: [*const ::std::os::raw::c_char; 0usize];
 }
 extern "C" {
-    pub static mut days: [*const ::std::os::raw::c_char; 0usize];
+    pub static days: [*const ::std::os::raw::c_char; 0usize];
 }
 extern "C" {
     pub static mut day_tab: [[::std::os::raw::c_int; 13usize]; 2usize];
@@ -30438,7 +30549,7 @@ extern "C" {
         dterr: ::std::os::raw::c_int,
         str_: *const ::std::os::raw::c_char,
         datatype: *const ::std::os::raw::c_char,
-    );
+    ) -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -38404,7 +38515,7 @@ impl Default for pg_enc2name {
     }
 }
 extern "C" {
-    pub static mut pg_enc2name_tbl: [pg_enc2name; 0usize];
+    pub static pg_enc2name_tbl: [pg_enc2name; 0usize];
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -38422,7 +38533,7 @@ impl Default for pg_enc2gettext {
     }
 }
 extern "C" {
-    pub static mut pg_enc2gettext_tbl: [pg_enc2gettext; 0usize];
+    pub static pg_enc2gettext_tbl: [pg_enc2gettext; 0usize];
 }
 pub type mb2wchar_with_len_converter = ::std::option::Option<
     unsafe extern "C" fn(
@@ -38464,7 +38575,7 @@ pub struct pg_wchar_tbl {
     pub maxmblen: ::std::os::raw::c_int,
 }
 extern "C" {
-    pub static mut pg_wchar_table: [pg_wchar_tbl; 0usize];
+    pub static pg_wchar_table: [pg_wchar_tbl; 0usize];
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -38902,7 +39013,7 @@ extern "C" {
         encoding: ::std::os::raw::c_int,
         mbstr: *const ::std::os::raw::c_char,
         len: ::std::os::raw::c_int,
-    );
+    ) -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -38911,7 +39022,7 @@ extern "C" {
         dest_encoding: ::std::os::raw::c_int,
         mbstr: *const ::std::os::raw::c_char,
         len: ::std::os::raw::c_int,
-    );
+    ) -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -43086,6 +43197,39 @@ extern "C" {
 extern "C" {
     pub fn get_parse_rowmark(qry: *mut Query, rtindex: Index) -> *mut RowMarkClause;
 }
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn scanstr(s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn downcase_truncate_identifier(
+        ident: *const ::std::os::raw::c_char,
+        len: ::std::os::raw::c_int,
+        warn: bool,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn downcase_identifier(
+        ident: *const ::std::os::raw::c_char,
+        len: ::std::os::raw::c_int,
+        warn: bool,
+        truncate: bool,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn truncate_identifier(
+        ident: *mut ::std::os::raw::c_char,
+        len: ::std::os::raw::c_int,
+        warn: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn scanner_isspace(ch: ::std::os::raw::c_char) -> bool;
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ExpandedRecordHeader {
@@ -44916,7 +45060,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn plpgsql_yyerror(message: *const ::std::os::raw::c_char);
+    pub fn plpgsql_yyerror(message: *const ::std::os::raw::c_char) -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -46421,7 +46565,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn proc_exit(code: ::std::os::raw::c_int);
+    pub fn proc_exit(code: ::std::os::raw::c_int) -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -46453,6 +46597,190 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn CreateSharedMemoryAndSemaphores();
+}
+pub const XLTW_Oper_XLTW_None: XLTW_Oper = 0;
+pub const XLTW_Oper_XLTW_Update: XLTW_Oper = 1;
+pub const XLTW_Oper_XLTW_Delete: XLTW_Oper = 2;
+pub const XLTW_Oper_XLTW_Lock: XLTW_Oper = 3;
+pub const XLTW_Oper_XLTW_LockUpdated: XLTW_Oper = 4;
+pub const XLTW_Oper_XLTW_InsertIndex: XLTW_Oper = 5;
+pub const XLTW_Oper_XLTW_InsertIndexUnique: XLTW_Oper = 6;
+pub const XLTW_Oper_XLTW_FetchUpdated: XLTW_Oper = 7;
+pub const XLTW_Oper_XLTW_RecheckExclusionConstr: XLTW_Oper = 8;
+pub type XLTW_Oper = ::std::os::raw::c_uint;
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RelationInitLockInfo(relation: Relation);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockRelationOid(relid: Oid, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ConditionalLockRelationOid(relid: Oid, lockmode: LOCKMODE) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockRelationId(relid: *mut LockRelId, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockRelationOid(relid: Oid, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockRelation(relation: Relation, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ConditionalLockRelation(relation: Relation, lockmode: LOCKMODE) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockRelation(relation: Relation, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn CheckRelationLockedByMe(
+        relation: Relation,
+        lockmode: LOCKMODE,
+        orstronger: bool,
+    ) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockHasWaitersRelation(relation: Relation, lockmode: LOCKMODE) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockRelationIdForSession(relid: *mut LockRelId, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockRelationIdForSession(relid: *mut LockRelId, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockRelationForExtension(relation: Relation, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockRelationForExtension(relation: Relation, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ConditionalLockRelationForExtension(relation: Relation, lockmode: LOCKMODE) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RelationExtensionLockWaiterCount(relation: Relation) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockDatabaseFrozenIds(lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockPage(relation: Relation, blkno: BlockNumber, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ConditionalLockPage(relation: Relation, blkno: BlockNumber, lockmode: LOCKMODE) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockPage(relation: Relation, blkno: BlockNumber, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockTuple(relation: Relation, tid: ItemPointer, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ConditionalLockTuple(relation: Relation, tid: ItemPointer, lockmode: LOCKMODE) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockTuple(relation: Relation, tid: ItemPointer, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XactLockTableInsert(xid: TransactionId);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XactLockTableDelete(xid: TransactionId);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XactLockTableWait(xid: TransactionId, rel: Relation, ctid: ItemPointer, oper: XLTW_Oper);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ConditionalXactLockTableWait(xid: TransactionId) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn WaitForLockers(heaplocktag: LOCKTAG, lockmode: LOCKMODE, progress: bool);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn WaitForLockersMultiple(locktags: *mut List, lockmode: LOCKMODE, progress: bool);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SpeculativeInsertionLockAcquire(xid: TransactionId) -> uint32;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SpeculativeInsertionLockRelease(xid: TransactionId);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SpeculativeInsertionWait(xid: TransactionId, token: uint32);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockDatabaseObject(classid: Oid, objid: Oid, objsubid: uint16, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockDatabaseObject(classid: Oid, objid: Oid, objsubid: uint16, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockSharedObject(classid: Oid, objid: Oid, objsubid: uint16, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockSharedObject(classid: Oid, objid: Oid, objsubid: uint16, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockSharedObjectForSession(
+        classid: Oid,
+        objid: Oid,
+        objsubid: uint16,
+        lockmode: LOCKMODE,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockSharedObjectForSession(
+        classid: Oid,
+        objid: Oid,
+        objsubid: uint16,
+        lockmode: LOCKMODE,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DescribeLockTag(buf: StringInfo, tag: *const LOCKTAG);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetLockNameFromTagType(locktag_type: uint16) -> *const ::std::os::raw::c_char;
 }
 pub const ProcSignalReason_PROCSIG_CATCHUP_INTERRUPT: ProcSignalReason = 0;
 pub const ProcSignalReason_PROCSIG_NOTIFY_INTERRUPT: ProcSignalReason = 1;
@@ -47008,7 +47336,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn quickdie(postgres_signal_arg: ::std::os::raw::c_int);
+    pub fn quickdie(postgres_signal_arg: ::std::os::raw::c_int) -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -47016,7 +47344,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn FloatExceptionHandler(postgres_signal_arg: ::std::os::raw::c_int);
+    pub fn FloatExceptionHandler(postgres_signal_arg: ::std::os::raw::c_int) -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -47046,7 +47374,7 @@ extern "C" {
         argv: *mut *mut ::std::os::raw::c_char,
         dbname: *const ::std::os::raw::c_char,
         username: *const ::std::os::raw::c_char,
-    );
+    ) -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -58785,15 +59113,15 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn float_overflow_error();
+    pub fn float_overflow_error() -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn float_underflow_error();
+    pub fn float_underflow_error() -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn float_zero_divide_error();
+    pub fn float_zero_divide_error() -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {

--- a/pgrx-pg-sys/src/pg14.rs
+++ b/pgrx-pg-sys/src/pg14.rs
@@ -2202,6 +2202,13 @@ pub const CATALOG_VERSION_NO: u32 = 202107181;
 pub const OIDCHARS: u32 = 10;
 pub const FORKNAMECHARS: u32 = 4;
 pub const InvalidBackendId: i32 = -1;
+pub const XLR_NORMAL_MAX_BLOCK_ID: u32 = 4;
+pub const XLR_NORMAL_RDATAS: u32 = 20;
+pub const REGBUF_FORCE_IMAGE: u32 = 1;
+pub const REGBUF_NO_IMAGE: u32 = 2;
+pub const REGBUF_WILL_INIT: u32 = 6;
+pub const REGBUF_STANDARD: u32 = 8;
+pub const REGBUF_KEEP_DATA: u32 = 16;
 pub const XLR_INFO_MASK: u32 = 15;
 pub const XLR_RMGR_INFO_MASK: u32 = 240;
 pub const XLR_SPECIAL_REL_UPDATE: u32 = 1;
@@ -2220,28 +2227,6 @@ pub const XLR_BLOCK_ID_DATA_SHORT: u32 = 255;
 pub const XLR_BLOCK_ID_DATA_LONG: u32 = 254;
 pub const XLR_BLOCK_ID_ORIGIN: u32 = 253;
 pub const XLR_BLOCK_ID_TOPLEVEL_XID: u32 = 252;
-pub const GIN_COMPARE_PROC: u32 = 1;
-pub const GIN_EXTRACTVALUE_PROC: u32 = 2;
-pub const GIN_EXTRACTQUERY_PROC: u32 = 3;
-pub const GIN_CONSISTENT_PROC: u32 = 4;
-pub const GIN_COMPARE_PARTIAL_PROC: u32 = 5;
-pub const GIN_TRICONSISTENT_PROC: u32 = 6;
-pub const GIN_OPTIONS_PROC: u32 = 7;
-pub const GINNProcs: u32 = 7;
-pub const GIN_SEARCH_MODE_DEFAULT: u32 = 0;
-pub const GIN_SEARCH_MODE_INCLUDE_EMPTY: u32 = 1;
-pub const GIN_SEARCH_MODE_ALL: u32 = 2;
-pub const GIN_SEARCH_MODE_EVERYTHING: u32 = 3;
-pub const GIN_FALSE: u32 = 0;
-pub const GIN_TRUE: u32 = 1;
-pub const GIN_MAYBE: u32 = 2;
-pub const XLR_NORMAL_MAX_BLOCK_ID: u32 = 4;
-pub const XLR_NORMAL_RDATAS: u32 = 20;
-pub const REGBUF_FORCE_IMAGE: u32 = 1;
-pub const REGBUF_NO_IMAGE: u32 = 2;
-pub const REGBUF_WILL_INIT: u32 = 6;
-pub const REGBUF_STANDARD: u32 = 8;
-pub const REGBUF_KEEP_DATA: u32 = 16;
 pub const SYNC_METHOD_FSYNC: u32 = 0;
 pub const SYNC_METHOD_FDATASYNC: u32 = 1;
 pub const SYNC_METHOD_OPEN: u32 = 2;
@@ -2266,87 +2251,20 @@ pub const BACKUP_LABEL_OLD: &[u8; 17usize] = b"backup_label.old\0";
 pub const TABLESPACE_MAP: &[u8; 15usize] = b"tablespace_map\0";
 pub const TABLESPACE_MAP_OLD: &[u8; 19usize] = b"tablespace_map.old\0";
 pub const PROMOTE_SIGNAL_FILE: &[u8; 8usize] = b"promote\0";
-pub const GIST_CONSISTENT_PROC: u32 = 1;
-pub const GIST_UNION_PROC: u32 = 2;
-pub const GIST_COMPRESS_PROC: u32 = 3;
-pub const GIST_DECOMPRESS_PROC: u32 = 4;
-pub const GIST_PENALTY_PROC: u32 = 5;
-pub const GIST_PICKSPLIT_PROC: u32 = 6;
-pub const GIST_EQUAL_PROC: u32 = 7;
-pub const GIST_DISTANCE_PROC: u32 = 8;
-pub const GIST_FETCH_PROC: u32 = 9;
-pub const GIST_OPTIONS_PROC: u32 = 10;
-pub const GIST_SORTSUPPORT_PROC: u32 = 11;
-pub const GISTNProcs: u32 = 11;
-pub const F_LEAF: u32 = 1;
-pub const F_DELETED: u32 = 2;
-pub const F_TUPLES_DELETED: u32 = 4;
-pub const F_FOLLOW_RIGHT: u32 = 8;
-pub const F_HAS_GARBAGE: u32 = 16;
-pub const GIST_PAGE_ID: u32 = 65409;
-pub const SHAREDINVALCATALOG_ID: i32 = -1;
-pub const SHAREDINVALRELCACHE_ID: i32 = -2;
-pub const SHAREDINVALSMGR_ID: i32 = -3;
-pub const SHAREDINVALRELMAP_ID: i32 = -4;
-pub const SHAREDINVALSNAPSHOT_ID: i32 = -5;
-pub const GIDSIZE: u32 = 200;
-pub const XACT_READ_UNCOMMITTED: u32 = 0;
-pub const XACT_READ_COMMITTED: u32 = 1;
-pub const XACT_REPEATABLE_READ: u32 = 2;
-pub const XACT_SERIALIZABLE: u32 = 3;
-pub const XACT_FLAGS_ACCESSEDTEMPNAMESPACE: u32 = 1;
-pub const XACT_FLAGS_ACQUIREDACCESSEXCLUSIVELOCK: u32 = 2;
-pub const XACT_FLAGS_NEEDIMMEDIATECOMMIT: u32 = 4;
-pub const XACT_FLAGS_PIPELINING: u32 = 8;
-pub const XLOG_XACT_COMMIT: u32 = 0;
-pub const XLOG_XACT_PREPARE: u32 = 16;
-pub const XLOG_XACT_ABORT: u32 = 32;
-pub const XLOG_XACT_COMMIT_PREPARED: u32 = 48;
-pub const XLOG_XACT_ABORT_PREPARED: u32 = 64;
-pub const XLOG_XACT_ASSIGNMENT: u32 = 80;
-pub const XLOG_XACT_INVALIDATIONS: u32 = 96;
-pub const XLOG_XACT_OPMASK: u32 = 112;
-pub const XLOG_XACT_HAS_INFO: u32 = 128;
-pub const XACT_XINFO_HAS_DBINFO: u32 = 1;
-pub const XACT_XINFO_HAS_SUBXACTS: u32 = 2;
-pub const XACT_XINFO_HAS_RELFILENODES: u32 = 4;
-pub const XACT_XINFO_HAS_INVALS: u32 = 8;
-pub const XACT_XINFO_HAS_TWOPHASE: u32 = 16;
-pub const XACT_XINFO_HAS_ORIGIN: u32 = 32;
-pub const XACT_XINFO_HAS_AE_LOCKS: u32 = 64;
-pub const XACT_XINFO_HAS_GID: u32 = 128;
-pub const XACT_COMPLETION_APPLY_FEEDBACK: u32 = 536870912;
-pub const XACT_COMPLETION_UPDATE_RELCACHE_FILE: u32 = 1073741824;
-pub const XACT_COMPLETION_FORCE_SYNC_COMMIT: u32 = 2147483648;
-pub const EOH_HEADER_MAGIC: i32 = -1;
-pub const MAXDIM: u32 = 6;
-pub const EA_MAGIC: u32 = 689375833;
-pub const PG_AUTOCONF_FILENAME: &[u8; 21usize] = b"postgresql.auto.conf\0";
-pub const GUC_QUALIFIER_SEPARATOR: u8 = 46u8;
-pub const GUC_LIST_INPUT: u32 = 1;
-pub const GUC_LIST_QUOTE: u32 = 2;
-pub const GUC_NO_SHOW_ALL: u32 = 4;
-pub const GUC_NO_RESET_ALL: u32 = 8;
-pub const GUC_REPORT: u32 = 16;
-pub const GUC_NOT_IN_SAMPLE: u32 = 32;
-pub const GUC_DISALLOW_IN_FILE: u32 = 64;
-pub const GUC_CUSTOM_PLACEHOLDER: u32 = 128;
-pub const GUC_SUPERUSER_ONLY: u32 = 256;
-pub const GUC_IS_NAME: u32 = 512;
-pub const GUC_NOT_WHILE_SEC_REST: u32 = 1024;
-pub const GUC_DISALLOW_IN_AUTO_FILE: u32 = 2048;
-pub const GUC_UNIT_KB: u32 = 4096;
-pub const GUC_UNIT_BLOCKS: u32 = 8192;
-pub const GUC_UNIT_XBLOCKS: u32 = 12288;
-pub const GUC_UNIT_MB: u32 = 16384;
-pub const GUC_UNIT_BYTE: u32 = 32768;
-pub const GUC_UNIT_MEMORY: u32 = 61440;
-pub const GUC_UNIT_MS: u32 = 65536;
-pub const GUC_UNIT_S: u32 = 131072;
-pub const GUC_UNIT_MIN: u32 = 196608;
-pub const GUC_UNIT_TIME: u32 = 983040;
-pub const GUC_EXPLAIN: u32 = 1048576;
-pub const GUC_UNIT: u32 = 1044480;
+pub const XLOG_PAGE_MAGIC: u32 = 53517;
+pub const XLP_FIRST_IS_CONTRECORD: u32 = 1;
+pub const XLP_LONG_HEADER: u32 = 2;
+pub const XLP_BKP_REMOVABLE: u32 = 4;
+pub const XLP_FIRST_IS_OVERWRITE_CONTRECORD: u32 = 8;
+pub const XLP_ALL_FLAGS: u32 = 15;
+pub const WalSegMinSize: u32 = 1048576;
+pub const WalSegMaxSize: u32 = 1073741824;
+pub const DEFAULT_MIN_WAL_SEGS: u32 = 5;
+pub const DEFAULT_MAX_WAL_SEGS: u32 = 64;
+pub const XLOGDIR: &[u8; 7usize] = b"pg_wal\0";
+pub const XLOG_CONTROL_FILE: &[u8; 18usize] = b"global/pg_control\0";
+pub const MAXFNAMELEN: u32 = 64;
+pub const XLOG_FNAME_LEN: u32 = 24;
 pub const RelationRelationId: Oid = Oid(1259);
 pub const RelationRelation_Rowtype_Id: u32 = 83;
 pub const Anum_pg_class_oid: u32 = 1;
@@ -2444,6 +2362,104 @@ pub const PublicationObjectIndexId: u32 = 6110;
 pub const PublicationNameIndexId: u32 = 6111;
 pub const HEAP_MIN_FILLFACTOR: u32 = 10;
 pub const HEAP_DEFAULT_FILLFACTOR: u32 = 100;
+pub const MAX_GENERIC_XLOG_PAGES: u32 = 4;
+pub const GENERIC_XLOG_FULL_IMAGE: u32 = 1;
+pub const GIN_COMPARE_PROC: u32 = 1;
+pub const GIN_EXTRACTVALUE_PROC: u32 = 2;
+pub const GIN_EXTRACTQUERY_PROC: u32 = 3;
+pub const GIN_CONSISTENT_PROC: u32 = 4;
+pub const GIN_COMPARE_PARTIAL_PROC: u32 = 5;
+pub const GIN_TRICONSISTENT_PROC: u32 = 6;
+pub const GIN_OPTIONS_PROC: u32 = 7;
+pub const GINNProcs: u32 = 7;
+pub const GIN_SEARCH_MODE_DEFAULT: u32 = 0;
+pub const GIN_SEARCH_MODE_INCLUDE_EMPTY: u32 = 1;
+pub const GIN_SEARCH_MODE_ALL: u32 = 2;
+pub const GIN_SEARCH_MODE_EVERYTHING: u32 = 3;
+pub const GIN_FALSE: u32 = 0;
+pub const GIN_TRUE: u32 = 1;
+pub const GIN_MAYBE: u32 = 2;
+pub const GIST_CONSISTENT_PROC: u32 = 1;
+pub const GIST_UNION_PROC: u32 = 2;
+pub const GIST_COMPRESS_PROC: u32 = 3;
+pub const GIST_DECOMPRESS_PROC: u32 = 4;
+pub const GIST_PENALTY_PROC: u32 = 5;
+pub const GIST_PICKSPLIT_PROC: u32 = 6;
+pub const GIST_EQUAL_PROC: u32 = 7;
+pub const GIST_DISTANCE_PROC: u32 = 8;
+pub const GIST_FETCH_PROC: u32 = 9;
+pub const GIST_OPTIONS_PROC: u32 = 10;
+pub const GIST_SORTSUPPORT_PROC: u32 = 11;
+pub const GISTNProcs: u32 = 11;
+pub const F_LEAF: u32 = 1;
+pub const F_DELETED: u32 = 2;
+pub const F_TUPLES_DELETED: u32 = 4;
+pub const F_FOLLOW_RIGHT: u32 = 8;
+pub const F_HAS_GARBAGE: u32 = 16;
+pub const GIST_PAGE_ID: u32 = 65409;
+pub const SHAREDINVALCATALOG_ID: i32 = -1;
+pub const SHAREDINVALRELCACHE_ID: i32 = -2;
+pub const SHAREDINVALSMGR_ID: i32 = -3;
+pub const SHAREDINVALRELMAP_ID: i32 = -4;
+pub const SHAREDINVALSNAPSHOT_ID: i32 = -5;
+pub const GIDSIZE: u32 = 200;
+pub const XACT_READ_UNCOMMITTED: u32 = 0;
+pub const XACT_READ_COMMITTED: u32 = 1;
+pub const XACT_REPEATABLE_READ: u32 = 2;
+pub const XACT_SERIALIZABLE: u32 = 3;
+pub const XACT_FLAGS_ACCESSEDTEMPNAMESPACE: u32 = 1;
+pub const XACT_FLAGS_ACQUIREDACCESSEXCLUSIVELOCK: u32 = 2;
+pub const XACT_FLAGS_NEEDIMMEDIATECOMMIT: u32 = 4;
+pub const XACT_FLAGS_PIPELINING: u32 = 8;
+pub const XLOG_XACT_COMMIT: u32 = 0;
+pub const XLOG_XACT_PREPARE: u32 = 16;
+pub const XLOG_XACT_ABORT: u32 = 32;
+pub const XLOG_XACT_COMMIT_PREPARED: u32 = 48;
+pub const XLOG_XACT_ABORT_PREPARED: u32 = 64;
+pub const XLOG_XACT_ASSIGNMENT: u32 = 80;
+pub const XLOG_XACT_INVALIDATIONS: u32 = 96;
+pub const XLOG_XACT_OPMASK: u32 = 112;
+pub const XLOG_XACT_HAS_INFO: u32 = 128;
+pub const XACT_XINFO_HAS_DBINFO: u32 = 1;
+pub const XACT_XINFO_HAS_SUBXACTS: u32 = 2;
+pub const XACT_XINFO_HAS_RELFILENODES: u32 = 4;
+pub const XACT_XINFO_HAS_INVALS: u32 = 8;
+pub const XACT_XINFO_HAS_TWOPHASE: u32 = 16;
+pub const XACT_XINFO_HAS_ORIGIN: u32 = 32;
+pub const XACT_XINFO_HAS_AE_LOCKS: u32 = 64;
+pub const XACT_XINFO_HAS_GID: u32 = 128;
+pub const XACT_COMPLETION_APPLY_FEEDBACK: u32 = 536870912;
+pub const XACT_COMPLETION_UPDATE_RELCACHE_FILE: u32 = 1073741824;
+pub const XACT_COMPLETION_FORCE_SYNC_COMMIT: u32 = 2147483648;
+pub const EOH_HEADER_MAGIC: i32 = -1;
+pub const MAXDIM: u32 = 6;
+pub const EA_MAGIC: u32 = 689375833;
+pub const PG_AUTOCONF_FILENAME: &[u8; 21usize] = b"postgresql.auto.conf\0";
+pub const GUC_QUALIFIER_SEPARATOR: u8 = 46u8;
+pub const GUC_LIST_INPUT: u32 = 1;
+pub const GUC_LIST_QUOTE: u32 = 2;
+pub const GUC_NO_SHOW_ALL: u32 = 4;
+pub const GUC_NO_RESET_ALL: u32 = 8;
+pub const GUC_REPORT: u32 = 16;
+pub const GUC_NOT_IN_SAMPLE: u32 = 32;
+pub const GUC_DISALLOW_IN_FILE: u32 = 64;
+pub const GUC_CUSTOM_PLACEHOLDER: u32 = 128;
+pub const GUC_SUPERUSER_ONLY: u32 = 256;
+pub const GUC_IS_NAME: u32 = 512;
+pub const GUC_NOT_WHILE_SEC_REST: u32 = 1024;
+pub const GUC_DISALLOW_IN_AUTO_FILE: u32 = 2048;
+pub const GUC_UNIT_KB: u32 = 4096;
+pub const GUC_UNIT_BLOCKS: u32 = 8192;
+pub const GUC_UNIT_XBLOCKS: u32 = 12288;
+pub const GUC_UNIT_MB: u32 = 16384;
+pub const GUC_UNIT_BYTE: u32 = 32768;
+pub const GUC_UNIT_MEMORY: u32 = 61440;
+pub const GUC_UNIT_MS: u32 = 65536;
+pub const GUC_UNIT_S: u32 = 131072;
+pub const GUC_UNIT_MIN: u32 = 196608;
+pub const GUC_UNIT_TIME: u32 = 983040;
+pub const GUC_EXPLAIN: u32 = 1048576;
+pub const GUC_UNIT: u32 = 1044480;
 pub const DEFAULT_TABLE_ACCESS_METHOD: &[u8; 5usize] = b"heap\0";
 pub const TABLE_INSERT_SKIP_FSM: u32 = 2;
 pub const TABLE_INSERT_FROZEN: u32 = 4;
@@ -4182,7 +4198,7 @@ extern "C" {
         errorType: *const ::std::os::raw::c_char,
         fileName: *const ::std::os::raw::c_char,
         lineNumber: ::std::os::raw::c_int,
-    );
+    ) -> !;
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -6279,7 +6295,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn ReThrowError(edata: *mut ErrorData);
+    pub fn ReThrowError(edata: *mut ErrorData) -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -16735,11 +16751,7 @@ impl Default for Query {
         }
     }
 }
-#[doc = "\tSupporting data structures for Parse Trees"]
-#[doc = ""]
-#[doc = "\tMost of these node types appear in raw parsetrees output by the grammar,"]
-#[doc = "\tand get transformed to something else by the analyzer.  A few of them"]
-#[doc = "\tare used as-is in transformed querytrees."]
+#[doc = "\tSupporting data structures for Parse Trees\n\n\tMost of these node types appear in raw parsetrees output by the grammar,\n\tand get transformed to something else by the analyzer.  A few of them\n\tare used as-is in transformed querytrees."]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct TypeName {
@@ -17979,17 +17991,7 @@ pub const ObjectType_OBJECT_TSTEMPLATE: ObjectType = 46;
 pub const ObjectType_OBJECT_TYPE: ObjectType = 47;
 pub const ObjectType_OBJECT_USER_MAPPING: ObjectType = 48;
 pub const ObjectType_OBJECT_VIEW: ObjectType = 49;
-#[doc = "\t\tOther Statements (no optimizations required)"]
-#[doc = ""]
-#[doc = "\t\tThese are not touched by parser/analyze.c except to put them into"]
-#[doc = "\t\tthe utilityStmt field of a Query.  This is eventually passed to"]
-#[doc = "\t\tProcessUtility (by-passing rewriting and planning).  Some of the"]
-#[doc = "\t\tstatements do need attention from parse analysis, and this is"]
-#[doc = "\t\tdone by routines in parser/parse_utilcmd.c after ProcessUtility"]
-#[doc = "\t\treceives the command for execution."]
-#[doc = "\t\tDECLARE CURSOR, EXPLAIN, and CREATE TABLE AS are special cases:"]
-#[doc = "\t\tthey contain optimizable statements, which get processed normally"]
-#[doc = "\t\tby parser/analyze.c."]
+#[doc = "\t\tOther Statements (no optimizations required)\n\n\t\tThese are not touched by parser/analyze.c except to put them into\n\t\tthe utilityStmt field of a Query.  This is eventually passed to\n\t\tProcessUtility (by-passing rewriting and planning).  Some of the\n\t\tstatements do need attention from parse analysis, and this is\n\t\tdone by routines in parser/parse_utilcmd.c after ProcessUtility\n\t\treceives the command for execution.\n\t\tDECLARE CURSOR, EXPLAIN, and CREATE TABLE AS are special cases:\n\t\tthey contain optimizable statements, which get processed normally\n\t\tby parser/analyze.c."]
 pub type ObjectType = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -22301,56 +22303,7 @@ extern "C" {
     pub fn pg_tzenumerate_end(dir: *mut pg_tzenum);
 }
 extern "C" {
-    #[doc = "\t  System interrupt and critical section handling"]
-    #[doc = ""]
-    #[doc = " There are two types of interrupts that a running backend needs to accept"]
-    #[doc = " without messing up its state: QueryCancel (SIGINT) and ProcDie (SIGTERM)."]
-    #[doc = " In both cases, we need to be able to clean up the current transaction"]
-    #[doc = " gracefully, so we can't respond to the interrupt instantaneously ---"]
-    #[doc = " there's no guarantee that internal data structures would be self-consistent"]
-    #[doc = " if the code is interrupted at an arbitrary instant.  Instead, the signal"]
-    #[doc = " handlers set flags that are checked periodically during execution."]
-    #[doc = ""]
-    #[doc = " The CHECK_FOR_INTERRUPTS() macro is called at strategically located spots"]
-    #[doc = " where it is normally safe to accept a cancel or die interrupt.  In some"]
-    #[doc = " cases, we invoke CHECK_FOR_INTERRUPTS() inside low-level subroutines that"]
-    #[doc = " might sometimes be called in contexts that do *not* want to allow a cancel"]
-    #[doc = " or die interrupt.  The HOLD_INTERRUPTS() and RESUME_INTERRUPTS() macros"]
-    #[doc = " allow code to ensure that no cancel or die interrupt will be accepted,"]
-    #[doc = " even if CHECK_FOR_INTERRUPTS() gets called in a subroutine.  The interrupt"]
-    #[doc = " will be held off until CHECK_FOR_INTERRUPTS() is done outside any"]
-    #[doc = " HOLD_INTERRUPTS() ... RESUME_INTERRUPTS() section."]
-    #[doc = ""]
-    #[doc = " There is also a mechanism to prevent query cancel interrupts, while still"]
-    #[doc = " allowing die interrupts: HOLD_CANCEL_INTERRUPTS() and"]
-    #[doc = " RESUME_CANCEL_INTERRUPTS()."]
-    #[doc = ""]
-    #[doc = " Note that ProcessInterrupts() has also acquired a number of tasks that"]
-    #[doc = " do not necessarily cause a query-cancel-or-die response.  Hence, it's"]
-    #[doc = " possible that it will just clear InterruptPending and return."]
-    #[doc = ""]
-    #[doc = " INTERRUPTS_PENDING_CONDITION() can be checked to see whether an"]
-    #[doc = " interrupt needs to be serviced, without trying to do so immediately."]
-    #[doc = " Some callers are also interested in INTERRUPTS_CAN_BE_PROCESSED(),"]
-    #[doc = " which tells whether ProcessInterrupts is sure to clear the interrupt."]
-    #[doc = ""]
-    #[doc = " Special mechanisms are used to let an interrupt be accepted when we are"]
-    #[doc = " waiting for a lock or when we are waiting for command input (but, of"]
-    #[doc = " course, only if the interrupt holdoff counter is zero).  See the"]
-    #[doc = " related code for details."]
-    #[doc = ""]
-    #[doc = " A lost connection is handled similarly, although the loss of connection"]
-    #[doc = " does not raise a signal, but is detected when we fail to write to the"]
-    #[doc = " socket. If there was a signal for a broken connection, we could make use of"]
-    #[doc = " it by setting ClientConnectionLost in the signal handler."]
-    #[doc = ""]
-    #[doc = " A related, but conceptually distinct, mechanism is the \"critical section\""]
-    #[doc = " mechanism.  A critical section not only holds off cancel/die interrupts,"]
-    #[doc = " but causes any ereport(ERROR) or ereport(FATAL) to become ereport(PANIC)"]
-    #[doc = " --- that is, a system-wide reset is forced.  Needless to say, only really"]
-    #[doc = " *critical* code should be marked as a critical section!\tCurrently, this"]
-    #[doc = " mechanism is only used for XLOG-related code."]
-    #[doc = ""]
+    #[doc = "\t  System interrupt and critical section handling\n\n There are two types of interrupts that a running backend needs to accept\n without messing up its state: QueryCancel (SIGINT) and ProcDie (SIGTERM).\n In both cases, we need to be able to clean up the current transaction\n gracefully, so we can't respond to the interrupt instantaneously ---\n there's no guarantee that internal data structures would be self-consistent\n if the code is interrupted at an arbitrary instant.  Instead, the signal\n handlers set flags that are checked periodically during execution.\n\n The CHECK_FOR_INTERRUPTS() macro is called at strategically located spots\n where it is normally safe to accept a cancel or die interrupt.  In some\n cases, we invoke CHECK_FOR_INTERRUPTS() inside low-level subroutines that\n might sometimes be called in contexts that do *not* want to allow a cancel\n or die interrupt.  The HOLD_INTERRUPTS() and RESUME_INTERRUPTS() macros\n allow code to ensure that no cancel or die interrupt will be accepted,\n even if CHECK_FOR_INTERRUPTS() gets called in a subroutine.  The interrupt\n will be held off until CHECK_FOR_INTERRUPTS() is done outside any\n HOLD_INTERRUPTS() ... RESUME_INTERRUPTS() section.\n\n There is also a mechanism to prevent query cancel interrupts, while still\n allowing die interrupts: HOLD_CANCEL_INTERRUPTS() and\n RESUME_CANCEL_INTERRUPTS().\n\n Note that ProcessInterrupts() has also acquired a number of tasks that\n do not necessarily cause a query-cancel-or-die response.  Hence, it's\n possible that it will just clear InterruptPending and return.\n\n INTERRUPTS_PENDING_CONDITION() can be checked to see whether an\n interrupt needs to be serviced, without trying to do so immediately.\n Some callers are also interested in INTERRUPTS_CAN_BE_PROCESSED(),\n which tells whether ProcessInterrupts is sure to clear the interrupt.\n\n Special mechanisms are used to let an interrupt be accepted when we are\n waiting for a lock or when we are waiting for command input (but, of\n course, only if the interrupt holdoff counter is zero).  See the\n related code for details.\n\n A lost connection is handled similarly, although the loss of connection\n does not raise a signal, but is detected when we fail to write to the\n socket. If there was a signal for a broken connection, we could make use of\n it by setting ClientConnectionLost in the signal handler.\n\n A related, but conceptually distinct, mechanism is the \"critical section\"\n mechanism.  A critical section not only holds off cancel/die interrupts,\n but causes any ereport(ERROR) or ereport(FATAL) to become ereport(PANIC)\n --- that is, a system-wide reset is forced.  Needless to say, only really\n *critical* code should be marked as a critical section!\tCurrently, this\n mechanism is only used for XLOG-related code.\n"]
     pub static mut InterruptPending: sig_atomic_t;
 }
 extern "C" {
@@ -22700,8 +22653,7 @@ extern "C" {
 pub const ProcessingMode_BootstrapProcessing: ProcessingMode = 0;
 pub const ProcessingMode_InitProcessing: ProcessingMode = 1;
 pub const ProcessingMode_NormalProcessing: ProcessingMode = 2;
-#[doc = "\t  pmod.h --\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t *"]
-#[doc = "\t\t\tPOSTGRES processing mode definitions.                            *"]
+#[doc = "\t  pmod.h --\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t *\n\t\t\tPOSTGRES processing mode definitions.                            *"]
 pub type ProcessingMode = ::std::os::raw::c_uint;
 extern "C" {
     pub static mut Mode: ProcessingMode;
@@ -22722,8 +22674,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    #[doc = "\t  pinit.h --\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t *"]
-    #[doc = "\t\t\tPOSTGRES initialization and cleanup definitions.                 *"]
+    #[doc = "\t  pinit.h --\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t *\n\t\t\tPOSTGRES initialization and cleanup definitions.                 *"]
     pub fn pg_split_opts(
         argv: *mut *mut ::std::os::raw::c_char,
         argcp: *mut ::std::os::raw::c_int,
@@ -22841,7 +22792,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn PgArchiverMain();
+    pub fn PgArchiverMain() -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -25042,32 +24993,6 @@ pub const RmgrIds_RM_GENERIC_ID: RmgrIds = 20;
 pub const RmgrIds_RM_LOGICALMSG_ID: RmgrIds = 21;
 pub const RmgrIds_RM_NEXT_ID: RmgrIds = 22;
 pub type RmgrIds = ::std::os::raw::c_uint;
-pub type pg_crc32c = uint32;
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn pg_comp_crc32c_sb8(
-        crc: pg_crc32c,
-        data: *const ::std::os::raw::c_void,
-        len: usize,
-    ) -> pg_crc32c;
-}
-extern "C" {
-    pub static mut pg_comp_crc32c: ::std::option::Option<
-        unsafe extern "C" fn(
-            crc: pg_crc32c,
-            data: *const ::std::os::raw::c_void,
-            len: usize,
-        ) -> pg_crc32c,
-    >;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn pg_comp_crc32c_sse42(
-        crc: pg_crc32c,
-        data: *const ::std::os::raw::c_void,
-        len: usize,
-    ) -> pg_crc32c;
-}
 pub const ForkNumber_InvalidForkNumber: ForkNumber = -1;
 pub const ForkNumber_MAIN_FORKNUM: ForkNumber = 0;
 pub const ForkNumber_FSM_FORKNUM: ForkNumber = 1;
@@ -25075,7 +25000,7 @@ pub const ForkNumber_VISIBILITYMAP_FORKNUM: ForkNumber = 2;
 pub const ForkNumber_INIT_FORKNUM: ForkNumber = 3;
 pub type ForkNumber = ::std::os::raw::c_int;
 extern "C" {
-    pub static mut forkNames: [*const ::std::os::raw::c_char; 0usize];
+    pub static forkNames: [*const ::std::os::raw::c_char; 0usize];
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -25139,6 +25064,129 @@ impl Default for RelFileNodeBackend {
             s.assume_init()
         }
     }
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XLogBeginInsert();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XLogSetRecordFlags(flags: uint8);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XLogInsert(rmid: RmgrId, info: uint8) -> XLogRecPtr;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XLogEnsureRecordSpace(
+        max_block_id: ::std::os::raw::c_int,
+        ndatas: ::std::os::raw::c_int,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XLogRegisterData(data: *mut ::std::os::raw::c_char, len: ::std::os::raw::c_int);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XLogRegisterBuffer(block_id: uint8, buffer: Buffer, flags: uint8);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XLogRegisterBlock(
+        block_id: uint8,
+        rnode: *mut RelFileNode,
+        forknum: ForkNumber,
+        blknum: BlockNumber,
+        page: *mut ::std::os::raw::c_char,
+        flags: uint8,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XLogRegisterBufData(
+        block_id: uint8,
+        data: *mut ::std::os::raw::c_char,
+        len: ::std::os::raw::c_int,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XLogResetInsertion();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XLogCheckBufferNeedsBackup(buffer: Buffer) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn log_newpage(
+        rnode: *mut RelFileNode,
+        forkNum: ForkNumber,
+        blk: BlockNumber,
+        page: *mut ::std::os::raw::c_char,
+        page_std: bool,
+    ) -> XLogRecPtr;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn log_newpages(
+        rnode: *mut RelFileNode,
+        forkNum: ForkNumber,
+        num_pages: ::std::os::raw::c_int,
+        blknos: *mut BlockNumber,
+        pages: *mut *mut ::std::os::raw::c_char,
+        page_std: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn log_newpage_buffer(buffer: Buffer, page_std: bool) -> XLogRecPtr;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn log_newpage_range(
+        rel: Relation,
+        forkNum: ForkNumber,
+        startblk: BlockNumber,
+        endblk: BlockNumber,
+        page_std: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XLogSaveBufferForHint(buffer: Buffer, buffer_std: bool) -> XLogRecPtr;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn InitXLogInsert();
+}
+pub type pg_crc32c = uint32;
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn pg_comp_crc32c_sb8(
+        crc: pg_crc32c,
+        data: *const ::std::os::raw::c_void,
+        len: usize,
+    ) -> pg_crc32c;
+}
+extern "C" {
+    pub static mut pg_comp_crc32c: ::std::option::Option<
+        unsafe extern "C" fn(
+            crc: pg_crc32c,
+            data: *const ::std::os::raw::c_void,
+            len: usize,
+        ) -> pg_crc32c,
+    >;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn pg_comp_crc32c_sse42(
+        crc: pg_crc32c,
+        data: *const ::std::os::raw::c_void,
+        len: usize,
+    ) -> pg_crc32c;
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -25393,128 +25441,6 @@ extern "C" {
         blknum: *mut BlockNumber,
     ) -> bool;
 }
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct GinStatsData {
-    pub nPendingPages: BlockNumber,
-    pub nTotalPages: BlockNumber,
-    pub nEntryPages: BlockNumber,
-    pub nDataPages: BlockNumber,
-    pub nEntries: int64,
-    pub ginVersion: int32,
-}
-pub type GinTernaryValue = ::std::os::raw::c_char;
-extern "C" {
-    pub static mut GinFuzzySearchLimit: ::std::os::raw::c_int;
-}
-extern "C" {
-    pub static mut gin_pending_list_limit: ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn ginGetStats(index: Relation, stats: *mut GinStatsData);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn ginUpdateStats(index: Relation, stats: *const GinStatsData, is_build: bool);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn XLogBeginInsert();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn XLogSetRecordFlags(flags: uint8);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn XLogInsert(rmid: RmgrId, info: uint8) -> XLogRecPtr;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn XLogEnsureRecordSpace(
-        max_block_id: ::std::os::raw::c_int,
-        ndatas: ::std::os::raw::c_int,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn XLogRegisterData(data: *mut ::std::os::raw::c_char, len: ::std::os::raw::c_int);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn XLogRegisterBuffer(block_id: uint8, buffer: Buffer, flags: uint8);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn XLogRegisterBlock(
-        block_id: uint8,
-        rnode: *mut RelFileNode,
-        forknum: ForkNumber,
-        blknum: BlockNumber,
-        page: *mut ::std::os::raw::c_char,
-        flags: uint8,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn XLogRegisterBufData(
-        block_id: uint8,
-        data: *mut ::std::os::raw::c_char,
-        len: ::std::os::raw::c_int,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn XLogResetInsertion();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn XLogCheckBufferNeedsBackup(buffer: Buffer) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn log_newpage(
-        rnode: *mut RelFileNode,
-        forkNum: ForkNumber,
-        blk: BlockNumber,
-        page: *mut ::std::os::raw::c_char,
-        page_std: bool,
-    ) -> XLogRecPtr;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn log_newpages(
-        rnode: *mut RelFileNode,
-        forkNum: ForkNumber,
-        num_pages: ::std::os::raw::c_int,
-        blknos: *mut BlockNumber,
-        pages: *mut *mut ::std::os::raw::c_char,
-        page_std: bool,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn log_newpage_buffer(buffer: Buffer, page_std: bool) -> XLogRecPtr;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn log_newpage_range(
-        rel: Relation,
-        forkNum: ForkNumber,
-        startblk: BlockNumber,
-        endblk: BlockNumber,
-        page_std: bool,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn XLogSaveBufferForHint(buffer: Buffer, buffer_std: bool) -> XLogRecPtr;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn InitXLogInsert();
-}
 extern "C" {
     pub static mut sync_method: ::std::os::raw::c_int;
 }
@@ -25725,11 +25651,6 @@ pub const WALAvailability_WALAVAIL_EXTENDED: WALAvailability = 2;
 pub const WALAvailability_WALAVAIL_UNRESERVED: WALAvailability = 3;
 pub const WALAvailability_WALAVAIL_REMOVED: WALAvailability = 4;
 pub type WALAvailability = ::std::os::raw::c_uint;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct XLogRecData {
-    _unused: [u8; 0],
-}
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn XLogInsertRecord(
@@ -26013,6 +25934,904 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn get_backup_status() -> SessionBackupState;
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct XLogPageHeaderData {
+    pub xlp_magic: uint16,
+    pub xlp_info: uint16,
+    pub xlp_tli: TimeLineID,
+    pub xlp_pageaddr: XLogRecPtr,
+    pub xlp_rem_len: uint32,
+}
+pub type XLogPageHeader = *mut XLogPageHeaderData;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct XLogLongPageHeaderData {
+    pub std: XLogPageHeaderData,
+    pub xlp_sysid: uint64,
+    pub xlp_seg_size: uint32,
+    pub xlp_xlog_blcksz: uint32,
+}
+pub type XLogLongPageHeader = *mut XLogLongPageHeaderData;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct xl_parameter_change {
+    pub MaxConnections: ::std::os::raw::c_int,
+    pub max_worker_processes: ::std::os::raw::c_int,
+    pub max_wal_senders: ::std::os::raw::c_int,
+    pub max_prepared_xacts: ::std::os::raw::c_int,
+    pub max_locks_per_xact: ::std::os::raw::c_int,
+    pub wal_level: ::std::os::raw::c_int,
+    pub wal_log_hints: bool,
+    pub track_commit_timestamp: bool,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct xl_restore_point {
+    pub rp_time: TimestampTz,
+    pub rp_name: [::std::os::raw::c_char; 64usize],
+}
+impl Default for xl_restore_point {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct xl_overwrite_contrecord {
+    pub overwritten_lsn: XLogRecPtr,
+    pub overwrite_time: TimestampTz,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct xl_end_of_recovery {
+    pub end_time: TimestampTz,
+    pub ThisTimeLineID: TimeLineID,
+    pub PrevTimeLineID: TimeLineID,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct XLogRecData {
+    pub next: *mut XLogRecData,
+    pub data: *mut ::std::os::raw::c_char,
+    pub len: uint32,
+}
+impl Default for XLogRecData {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub const RecoveryTargetAction_RECOVERY_TARGET_ACTION_PAUSE: RecoveryTargetAction = 0;
+pub const RecoveryTargetAction_RECOVERY_TARGET_ACTION_PROMOTE: RecoveryTargetAction = 1;
+pub const RecoveryTargetAction_RECOVERY_TARGET_ACTION_SHUTDOWN: RecoveryTargetAction = 2;
+pub type RecoveryTargetAction = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct RmgrData {
+    pub rm_name: *const ::std::os::raw::c_char,
+    pub rm_redo: ::std::option::Option<unsafe extern "C" fn(record: *mut XLogReaderState)>,
+    pub rm_desc:
+        ::std::option::Option<unsafe extern "C" fn(buf: StringInfo, record: *mut XLogReaderState)>,
+    pub rm_identify:
+        ::std::option::Option<unsafe extern "C" fn(info: uint8) -> *const ::std::os::raw::c_char>,
+    pub rm_startup: ::std::option::Option<unsafe extern "C" fn()>,
+    pub rm_cleanup: ::std::option::Option<unsafe extern "C" fn()>,
+    pub rm_mask: ::std::option::Option<
+        unsafe extern "C" fn(pagedata: *mut ::std::os::raw::c_char, blkno: BlockNumber),
+    >,
+}
+impl Default for RmgrData {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+extern "C" {
+    pub static RmgrTable: [RmgrData; 0usize];
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetLastSegSwitchData(lastSwitchLSN: *mut XLogRecPtr) -> pg_time_t;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RequestXLogSwitch(mark_unimportant: bool) -> XLogRecPtr;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetOldestRestartPoint(oldrecptr: *mut XLogRecPtr, oldtli: *mut TimeLineID);
+}
+extern "C" {
+    pub static mut ArchiveRecoveryRequested: bool;
+}
+extern "C" {
+    pub static mut InArchiveRecovery: bool;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct FormData_pg_class {
+    pub oid: Oid,
+    pub relname: NameData,
+    pub relnamespace: Oid,
+    pub reltype: Oid,
+    pub reloftype: Oid,
+    pub relowner: Oid,
+    pub relam: Oid,
+    pub relfilenode: Oid,
+    pub reltablespace: Oid,
+    pub relpages: int32,
+    pub reltuples: float4,
+    pub relallvisible: int32,
+    pub reltoastrelid: Oid,
+    pub relhasindex: bool,
+    pub relisshared: bool,
+    pub relpersistence: ::std::os::raw::c_char,
+    pub relkind: ::std::os::raw::c_char,
+    pub relnatts: int16,
+    pub relchecks: int16,
+    pub relhasrules: bool,
+    pub relhastriggers: bool,
+    pub relhassubclass: bool,
+    pub relrowsecurity: bool,
+    pub relforcerowsecurity: bool,
+    pub relispopulated: bool,
+    pub relreplident: ::std::os::raw::c_char,
+    pub relispartition: bool,
+    pub relrewrite: Oid,
+    pub relfrozenxid: TransactionId,
+    pub relminmxid: TransactionId,
+}
+impl Default for FormData_pg_class {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type Form_pg_class = *mut FormData_pg_class;
+#[repr(C)]
+#[derive(Debug)]
+pub struct FormData_pg_index {
+    pub indexrelid: Oid,
+    pub indrelid: Oid,
+    pub indnatts: int16,
+    pub indnkeyatts: int16,
+    pub indisunique: bool,
+    pub indisprimary: bool,
+    pub indisexclusion: bool,
+    pub indimmediate: bool,
+    pub indisclustered: bool,
+    pub indisvalid: bool,
+    pub indcheckxmin: bool,
+    pub indisready: bool,
+    pub indislive: bool,
+    pub indisreplident: bool,
+    pub indkey: int2vector,
+}
+impl Default for FormData_pg_index {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type Form_pg_index = *mut FormData_pg_index;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ObjectAddress {
+    pub classId: Oid,
+    pub objectId: Oid,
+    pub objectSubId: int32,
+}
+impl Default for ObjectAddress {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+extern "C" {
+    pub static InvalidObjectAddress: ObjectAddress;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_object_address(
+        objtype: ObjectType,
+        object: *mut Node,
+        relp: *mut Relation,
+        lockmode: LOCKMODE,
+        missing_ok: bool,
+    ) -> ObjectAddress;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_object_address_rv(
+        objtype: ObjectType,
+        rel: *mut RangeVar,
+        object: *mut List,
+        relp: *mut Relation,
+        lockmode: LOCKMODE,
+        missing_ok: bool,
+    ) -> ObjectAddress;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn check_object_ownership(
+        roleid: Oid,
+        objtype: ObjectType,
+        address: ObjectAddress,
+        object: *mut Node,
+        relation: Relation,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_object_namespace(address: *const ObjectAddress) -> Oid;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn is_objectclass_supported(class_id: Oid) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_object_class_descr(class_id: Oid) -> *const ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_object_oid_index(class_id: Oid) -> Oid;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_object_catcache_oid(class_id: Oid) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_object_catcache_name(class_id: Oid) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_object_attnum_oid(class_id: Oid) -> AttrNumber;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_object_attnum_name(class_id: Oid) -> AttrNumber;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_object_attnum_namespace(class_id: Oid) -> AttrNumber;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_object_attnum_owner(class_id: Oid) -> AttrNumber;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_object_attnum_acl(class_id: Oid) -> AttrNumber;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_object_type(class_id: Oid, object_id: Oid) -> ObjectType;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_object_namensp_unique(class_id: Oid) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_catalog_object_by_oid(
+        catalog: Relation,
+        oidcol: AttrNumber,
+        objectId: Oid,
+    ) -> HeapTuple;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn getObjectDescription(
+        object: *const ObjectAddress,
+        missing_ok: bool,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn getObjectDescriptionOids(classid: Oid, objid: Oid) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn read_objtype_from_string(
+        objtype: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn getObjectTypeDescription(
+        object: *const ObjectAddress,
+        missing_ok: bool,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn getObjectIdentity(
+        address: *const ObjectAddress,
+        missing_ok: bool,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn getObjectIdentityParts(
+        address: *const ObjectAddress,
+        objname: *mut *mut List,
+        objargs: *mut *mut List,
+        missing_ok: bool,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn strlist_to_textarray(list: *mut List) -> *mut ArrayType;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_relkind_objtype(relkind: ::std::os::raw::c_char) -> ObjectType;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct FormData_pg_publication {
+    pub oid: Oid,
+    pub pubname: NameData,
+    pub pubowner: Oid,
+    pub puballtables: bool,
+    pub pubinsert: bool,
+    pub pubupdate: bool,
+    pub pubdelete: bool,
+    pub pubtruncate: bool,
+    pub pubviaroot: bool,
+}
+impl Default for FormData_pg_publication {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type Form_pg_publication = *mut FormData_pg_publication;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct PublicationActions {
+    pub pubinsert: bool,
+    pub pubupdate: bool,
+    pub pubdelete: bool,
+    pub pubtruncate: bool,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct Publication {
+    pub oid: Oid,
+    pub name: *mut ::std::os::raw::c_char,
+    pub alltables: bool,
+    pub pubviaroot: bool,
+    pub pubactions: PublicationActions,
+}
+impl Default for Publication {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetPublication(pubid: Oid) -> *mut Publication;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetPublicationByName(
+        pubname: *const ::std::os::raw::c_char,
+        missing_ok: bool,
+    ) -> *mut Publication;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetRelationPublications(relid: Oid) -> *mut List;
+}
+pub const PublicationPartOpt_PUBLICATION_PART_ROOT: PublicationPartOpt = 0;
+pub const PublicationPartOpt_PUBLICATION_PART_LEAF: PublicationPartOpt = 1;
+pub const PublicationPartOpt_PUBLICATION_PART_ALL: PublicationPartOpt = 2;
+pub type PublicationPartOpt = ::std::os::raw::c_uint;
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetPublicationRelations(pubid: Oid, pub_partopt: PublicationPartOpt) -> *mut List;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetAllTablesPublications() -> *mut List;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetAllTablesPublicationRelations(pubviaroot: bool) -> *mut List;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn is_publishable_relation(rel: Relation) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn publication_add_relation(
+        pubid: Oid,
+        targetrel: Relation,
+        if_not_exists: bool,
+    ) -> ObjectAddress;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetPubPartitionOptionRelations(
+        result: *mut List,
+        pub_partopt: PublicationPartOpt,
+        relid: Oid,
+    ) -> *mut List;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_publication_oid(pubname: *const ::std::os::raw::c_char, missing_ok: bool) -> Oid;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_publication_name(pubid: Oid, missing_ok: bool) -> *mut ::std::os::raw::c_char;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct RewriteRule {
+    pub ruleId: Oid,
+    pub event: CmdType,
+    pub qual: *mut Node,
+    pub actions: *mut List,
+    pub enabled: ::std::os::raw::c_char,
+    pub isInstead: bool,
+}
+impl Default for RewriteRule {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct RuleLock {
+    pub numLocks: ::std::os::raw::c_int,
+    pub rules: *mut *mut RewriteRule,
+}
+impl Default for RuleLock {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct SMgrRelationData {
+    pub smgr_rnode: RelFileNodeBackend,
+    pub smgr_owner: *mut *mut SMgrRelationData,
+    pub smgr_targblock: BlockNumber,
+    pub smgr_cached_nblocks: [BlockNumber; 4usize],
+    pub smgr_which: ::std::os::raw::c_int,
+    pub md_num_open_segs: [::std::os::raw::c_int; 4usize],
+    pub md_seg_fds: [*mut _MdfdVec; 4usize],
+    pub node: dlist_node,
+}
+impl Default for SMgrRelationData {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type SMgrRelation = *mut SMgrRelationData;
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrinit();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgropen(rnode: RelFileNode, backend: BackendId) -> SMgrRelation;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrexists(reln: SMgrRelation, forknum: ForkNumber) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrsetowner(owner: *mut SMgrRelation, reln: SMgrRelation);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrclearowner(owner: *mut SMgrRelation, reln: SMgrRelation);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrclose(reln: SMgrRelation);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrcloseall();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrclosenode(rnode: RelFileNodeBackend);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrcreate(reln: SMgrRelation, forknum: ForkNumber, isRedo: bool);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrdosyncall(rels: *mut SMgrRelation, nrels: ::std::os::raw::c_int);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrdounlinkall(rels: *mut SMgrRelation, nrels: ::std::os::raw::c_int, isRedo: bool);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrextend(
+        reln: SMgrRelation,
+        forknum: ForkNumber,
+        blocknum: BlockNumber,
+        buffer: *mut ::std::os::raw::c_char,
+        skipFsync: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrprefetch(reln: SMgrRelation, forknum: ForkNumber, blocknum: BlockNumber) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrread(
+        reln: SMgrRelation,
+        forknum: ForkNumber,
+        blocknum: BlockNumber,
+        buffer: *mut ::std::os::raw::c_char,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrwrite(
+        reln: SMgrRelation,
+        forknum: ForkNumber,
+        blocknum: BlockNumber,
+        buffer: *mut ::std::os::raw::c_char,
+        skipFsync: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrwriteback(
+        reln: SMgrRelation,
+        forknum: ForkNumber,
+        blocknum: BlockNumber,
+        nblocks: BlockNumber,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrnblocks(reln: SMgrRelation, forknum: ForkNumber) -> BlockNumber;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrnblocks_cached(reln: SMgrRelation, forknum: ForkNumber) -> BlockNumber;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrtruncate(
+        reln: SMgrRelation,
+        forknum: *mut ForkNumber,
+        nforks: ::std::os::raw::c_int,
+        nblocks: *mut BlockNumber,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrimmedsync(reln: SMgrRelation, forknum: ForkNumber);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn AtEOXact_SMgr();
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct LockRelId {
+    pub relId: Oid,
+    pub dbId: Oid,
+}
+impl Default for LockRelId {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct LockInfoData {
+    pub lockRelId: LockRelId,
+}
+impl Default for LockInfoData {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type LockInfo = *mut LockInfoData;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct RelationData {
+    pub rd_node: RelFileNode,
+    pub rd_smgr: SMgrRelation,
+    pub rd_refcnt: ::std::os::raw::c_int,
+    pub rd_backend: BackendId,
+    pub rd_islocaltemp: bool,
+    pub rd_isnailed: bool,
+    pub rd_isvalid: bool,
+    pub rd_indexvalid: bool,
+    pub rd_statvalid: bool,
+    pub rd_createSubid: SubTransactionId,
+    pub rd_newRelfilenodeSubid: SubTransactionId,
+    pub rd_firstRelfilenodeSubid: SubTransactionId,
+    pub rd_droppedSubid: SubTransactionId,
+    pub rd_rel: Form_pg_class,
+    pub rd_att: TupleDesc,
+    pub rd_id: Oid,
+    pub rd_lockInfo: LockInfoData,
+    pub rd_rules: *mut RuleLock,
+    pub rd_rulescxt: MemoryContext,
+    pub trigdesc: *mut TriggerDesc,
+    pub rd_rsdesc: *mut RowSecurityDesc,
+    pub rd_fkeylist: *mut List,
+    pub rd_fkeyvalid: bool,
+    pub rd_partkey: PartitionKey,
+    pub rd_partkeycxt: MemoryContext,
+    pub rd_partdesc: PartitionDesc,
+    pub rd_pdcxt: MemoryContext,
+    pub rd_partdesc_nodetached: PartitionDesc,
+    pub rd_pddcxt: MemoryContext,
+    pub rd_partdesc_nodetached_xmin: TransactionId,
+    pub rd_partcheck: *mut List,
+    pub rd_partcheckvalid: bool,
+    pub rd_partcheckcxt: MemoryContext,
+    pub rd_indexlist: *mut List,
+    pub rd_pkindex: Oid,
+    pub rd_replidindex: Oid,
+    pub rd_statlist: *mut List,
+    pub rd_indexattr: *mut Bitmapset,
+    pub rd_keyattr: *mut Bitmapset,
+    pub rd_pkattr: *mut Bitmapset,
+    pub rd_idattr: *mut Bitmapset,
+    pub rd_pubactions: *mut PublicationActions,
+    pub rd_options: *mut bytea,
+    pub rd_amhandler: Oid,
+    pub rd_tableam: *const TableAmRoutine,
+    pub rd_index: Form_pg_index,
+    pub rd_indextuple: *mut HeapTupleData,
+    pub rd_indexcxt: MemoryContext,
+    pub rd_indam: *mut IndexAmRoutine,
+    pub rd_opfamily: *mut Oid,
+    pub rd_opcintype: *mut Oid,
+    pub rd_support: *mut RegProcedure,
+    pub rd_supportinfo: *mut FmgrInfo,
+    pub rd_indoption: *mut int16,
+    pub rd_indexprs: *mut List,
+    pub rd_indpred: *mut List,
+    pub rd_exclops: *mut Oid,
+    pub rd_exclprocs: *mut Oid,
+    pub rd_exclstrats: *mut uint16,
+    pub rd_indcollation: *mut Oid,
+    pub rd_opcoptions: *mut *mut bytea,
+    pub rd_amcache: *mut ::std::os::raw::c_void,
+    pub rd_fdwroutine: *mut FdwRoutine,
+    pub rd_toastoid: Oid,
+    pub pgstat_info: *mut PgStat_TableStatus,
+}
+impl Default for RelationData {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ForeignKeyCacheInfo {
+    pub type_: NodeTag,
+    pub conoid: Oid,
+    pub conrelid: Oid,
+    pub confrelid: Oid,
+    pub nkeys: ::std::os::raw::c_int,
+    pub conkey: [AttrNumber; 32usize],
+    pub confkey: [AttrNumber; 32usize],
+    pub conpfeqop: [Oid; 32usize],
+}
+impl Default for ForeignKeyCacheInfo {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct AutoVacOpts {
+    pub enabled: bool,
+    pub vacuum_threshold: ::std::os::raw::c_int,
+    pub vacuum_ins_threshold: ::std::os::raw::c_int,
+    pub analyze_threshold: ::std::os::raw::c_int,
+    pub vacuum_cost_limit: ::std::os::raw::c_int,
+    pub freeze_min_age: ::std::os::raw::c_int,
+    pub freeze_max_age: ::std::os::raw::c_int,
+    pub freeze_table_age: ::std::os::raw::c_int,
+    pub multixact_freeze_min_age: ::std::os::raw::c_int,
+    pub multixact_freeze_max_age: ::std::os::raw::c_int,
+    pub multixact_freeze_table_age: ::std::os::raw::c_int,
+    pub log_min_duration: ::std::os::raw::c_int,
+    pub vacuum_cost_delay: float8,
+    pub vacuum_scale_factor: float8,
+    pub vacuum_ins_scale_factor: float8,
+    pub analyze_scale_factor: float8,
+}
+pub const StdRdOptIndexCleanup_STDRD_OPTION_VACUUM_INDEX_CLEANUP_AUTO: StdRdOptIndexCleanup = 0;
+pub const StdRdOptIndexCleanup_STDRD_OPTION_VACUUM_INDEX_CLEANUP_OFF: StdRdOptIndexCleanup = 1;
+pub const StdRdOptIndexCleanup_STDRD_OPTION_VACUUM_INDEX_CLEANUP_ON: StdRdOptIndexCleanup = 2;
+pub type StdRdOptIndexCleanup = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct StdRdOptions {
+    pub vl_len_: int32,
+    pub fillfactor: ::std::os::raw::c_int,
+    pub toast_tuple_target: ::std::os::raw::c_int,
+    pub autovacuum: AutoVacOpts,
+    pub user_catalog_table: bool,
+    pub parallel_workers: ::std::os::raw::c_int,
+    pub vacuum_index_cleanup: StdRdOptIndexCleanup,
+    pub vacuum_truncate: bool,
+}
+impl Default for StdRdOptions {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub const ViewOptCheckOption_VIEW_OPTION_CHECK_OPTION_NOT_SET: ViewOptCheckOption = 0;
+pub const ViewOptCheckOption_VIEW_OPTION_CHECK_OPTION_LOCAL: ViewOptCheckOption = 1;
+pub const ViewOptCheckOption_VIEW_OPTION_CHECK_OPTION_CASCADED: ViewOptCheckOption = 2;
+pub type ViewOptCheckOption = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ViewOptions {
+    pub vl_len_: int32,
+    pub security_barrier: bool,
+    pub check_option: ViewOptCheckOption,
+}
+impl Default for ViewOptions {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RelationIncrementReferenceCount(rel: Relation);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RelationDecrementReferenceCount(rel: Relation);
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct GenericXLogState {
+    _unused: [u8; 0],
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GenericXLogStart(relation: Relation) -> *mut GenericXLogState;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GenericXLogRegisterBuffer(
+        state: *mut GenericXLogState,
+        buffer: Buffer,
+        flags: ::std::os::raw::c_int,
+    ) -> Page;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GenericXLogFinish(state: *mut GenericXLogState) -> XLogRecPtr;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GenericXLogAbort(state: *mut GenericXLogState);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn generic_redo(record: *mut XLogReaderState);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn generic_identify(info: uint8) -> *const ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn generic_desc(buf: StringInfo, record: *mut XLogReaderState);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn generic_mask(pagedata: *mut ::std::os::raw::c_char, blkno: BlockNumber);
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct GinStatsData {
+    pub nPendingPages: BlockNumber,
+    pub nTotalPages: BlockNumber,
+    pub nEntryPages: BlockNumber,
+    pub nDataPages: BlockNumber,
+    pub nEntries: int64,
+    pub ginVersion: int32,
+}
+pub type GinTernaryValue = ::std::os::raw::c_char;
+extern "C" {
+    pub static mut GinFuzzySearchLimit: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut gin_pending_list_limit: ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ginGetStats(index: Relation, stats: *mut GinStatsData);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ginUpdateStats(index: Relation, stats: *const GinStatsData, is_build: bool);
 }
 pub type GistNSN = XLogRecPtr;
 pub type PageGistNSN = PageXLogRecPtr;
@@ -28227,714 +29046,6 @@ extern "C" {
         extra: *mut ::std::os::raw::c_void,
     );
 }
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct FormData_pg_class {
-    pub oid: Oid,
-    pub relname: NameData,
-    pub relnamespace: Oid,
-    pub reltype: Oid,
-    pub reloftype: Oid,
-    pub relowner: Oid,
-    pub relam: Oid,
-    pub relfilenode: Oid,
-    pub reltablespace: Oid,
-    pub relpages: int32,
-    pub reltuples: float4,
-    pub relallvisible: int32,
-    pub reltoastrelid: Oid,
-    pub relhasindex: bool,
-    pub relisshared: bool,
-    pub relpersistence: ::std::os::raw::c_char,
-    pub relkind: ::std::os::raw::c_char,
-    pub relnatts: int16,
-    pub relchecks: int16,
-    pub relhasrules: bool,
-    pub relhastriggers: bool,
-    pub relhassubclass: bool,
-    pub relrowsecurity: bool,
-    pub relforcerowsecurity: bool,
-    pub relispopulated: bool,
-    pub relreplident: ::std::os::raw::c_char,
-    pub relispartition: bool,
-    pub relrewrite: Oid,
-    pub relfrozenxid: TransactionId,
-    pub relminmxid: TransactionId,
-}
-impl Default for FormData_pg_class {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type Form_pg_class = *mut FormData_pg_class;
-#[repr(C)]
-#[derive(Debug)]
-pub struct FormData_pg_index {
-    pub indexrelid: Oid,
-    pub indrelid: Oid,
-    pub indnatts: int16,
-    pub indnkeyatts: int16,
-    pub indisunique: bool,
-    pub indisprimary: bool,
-    pub indisexclusion: bool,
-    pub indimmediate: bool,
-    pub indisclustered: bool,
-    pub indisvalid: bool,
-    pub indcheckxmin: bool,
-    pub indisready: bool,
-    pub indislive: bool,
-    pub indisreplident: bool,
-    pub indkey: int2vector,
-}
-impl Default for FormData_pg_index {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type Form_pg_index = *mut FormData_pg_index;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct ObjectAddress {
-    pub classId: Oid,
-    pub objectId: Oid,
-    pub objectSubId: int32,
-}
-impl Default for ObjectAddress {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-extern "C" {
-    pub static InvalidObjectAddress: ObjectAddress;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_object_address(
-        objtype: ObjectType,
-        object: *mut Node,
-        relp: *mut Relation,
-        lockmode: LOCKMODE,
-        missing_ok: bool,
-    ) -> ObjectAddress;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_object_address_rv(
-        objtype: ObjectType,
-        rel: *mut RangeVar,
-        object: *mut List,
-        relp: *mut Relation,
-        lockmode: LOCKMODE,
-        missing_ok: bool,
-    ) -> ObjectAddress;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn check_object_ownership(
-        roleid: Oid,
-        objtype: ObjectType,
-        address: ObjectAddress,
-        object: *mut Node,
-        relation: Relation,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_object_namespace(address: *const ObjectAddress) -> Oid;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn is_objectclass_supported(class_id: Oid) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_object_class_descr(class_id: Oid) -> *const ::std::os::raw::c_char;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_object_oid_index(class_id: Oid) -> Oid;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_object_catcache_oid(class_id: Oid) -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_object_catcache_name(class_id: Oid) -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_object_attnum_oid(class_id: Oid) -> AttrNumber;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_object_attnum_name(class_id: Oid) -> AttrNumber;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_object_attnum_namespace(class_id: Oid) -> AttrNumber;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_object_attnum_owner(class_id: Oid) -> AttrNumber;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_object_attnum_acl(class_id: Oid) -> AttrNumber;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_object_type(class_id: Oid, object_id: Oid) -> ObjectType;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_object_namensp_unique(class_id: Oid) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_catalog_object_by_oid(
-        catalog: Relation,
-        oidcol: AttrNumber,
-        objectId: Oid,
-    ) -> HeapTuple;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn getObjectDescription(
-        object: *const ObjectAddress,
-        missing_ok: bool,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn getObjectDescriptionOids(classid: Oid, objid: Oid) -> *mut ::std::os::raw::c_char;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn read_objtype_from_string(
-        objtype: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn getObjectTypeDescription(
-        object: *const ObjectAddress,
-        missing_ok: bool,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn getObjectIdentity(
-        address: *const ObjectAddress,
-        missing_ok: bool,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn getObjectIdentityParts(
-        address: *const ObjectAddress,
-        objname: *mut *mut List,
-        objargs: *mut *mut List,
-        missing_ok: bool,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn strlist_to_textarray(list: *mut List) -> *mut ArrayType;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_relkind_objtype(relkind: ::std::os::raw::c_char) -> ObjectType;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct FormData_pg_publication {
-    pub oid: Oid,
-    pub pubname: NameData,
-    pub pubowner: Oid,
-    pub puballtables: bool,
-    pub pubinsert: bool,
-    pub pubupdate: bool,
-    pub pubdelete: bool,
-    pub pubtruncate: bool,
-    pub pubviaroot: bool,
-}
-impl Default for FormData_pg_publication {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type Form_pg_publication = *mut FormData_pg_publication;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct PublicationActions {
-    pub pubinsert: bool,
-    pub pubupdate: bool,
-    pub pubdelete: bool,
-    pub pubtruncate: bool,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct Publication {
-    pub oid: Oid,
-    pub name: *mut ::std::os::raw::c_char,
-    pub alltables: bool,
-    pub pubviaroot: bool,
-    pub pubactions: PublicationActions,
-}
-impl Default for Publication {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetPublication(pubid: Oid) -> *mut Publication;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetPublicationByName(
-        pubname: *const ::std::os::raw::c_char,
-        missing_ok: bool,
-    ) -> *mut Publication;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetRelationPublications(relid: Oid) -> *mut List;
-}
-pub const PublicationPartOpt_PUBLICATION_PART_ROOT: PublicationPartOpt = 0;
-pub const PublicationPartOpt_PUBLICATION_PART_LEAF: PublicationPartOpt = 1;
-pub const PublicationPartOpt_PUBLICATION_PART_ALL: PublicationPartOpt = 2;
-pub type PublicationPartOpt = ::std::os::raw::c_uint;
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetPublicationRelations(pubid: Oid, pub_partopt: PublicationPartOpt) -> *mut List;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetAllTablesPublications() -> *mut List;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetAllTablesPublicationRelations(pubviaroot: bool) -> *mut List;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn is_publishable_relation(rel: Relation) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn publication_add_relation(
-        pubid: Oid,
-        targetrel: Relation,
-        if_not_exists: bool,
-    ) -> ObjectAddress;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetPubPartitionOptionRelations(
-        result: *mut List,
-        pub_partopt: PublicationPartOpt,
-        relid: Oid,
-    ) -> *mut List;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_publication_oid(pubname: *const ::std::os::raw::c_char, missing_ok: bool) -> Oid;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_publication_name(pubid: Oid, missing_ok: bool) -> *mut ::std::os::raw::c_char;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct RewriteRule {
-    pub ruleId: Oid,
-    pub event: CmdType,
-    pub qual: *mut Node,
-    pub actions: *mut List,
-    pub enabled: ::std::os::raw::c_char,
-    pub isInstead: bool,
-}
-impl Default for RewriteRule {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct RuleLock {
-    pub numLocks: ::std::os::raw::c_int,
-    pub rules: *mut *mut RewriteRule,
-}
-impl Default for RuleLock {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct SMgrRelationData {
-    pub smgr_rnode: RelFileNodeBackend,
-    pub smgr_owner: *mut *mut SMgrRelationData,
-    pub smgr_targblock: BlockNumber,
-    pub smgr_cached_nblocks: [BlockNumber; 4usize],
-    pub smgr_which: ::std::os::raw::c_int,
-    pub md_num_open_segs: [::std::os::raw::c_int; 4usize],
-    pub md_seg_fds: [*mut _MdfdVec; 4usize],
-    pub node: dlist_node,
-}
-impl Default for SMgrRelationData {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type SMgrRelation = *mut SMgrRelationData;
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrinit();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgropen(rnode: RelFileNode, backend: BackendId) -> SMgrRelation;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrexists(reln: SMgrRelation, forknum: ForkNumber) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrsetowner(owner: *mut SMgrRelation, reln: SMgrRelation);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrclearowner(owner: *mut SMgrRelation, reln: SMgrRelation);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrclose(reln: SMgrRelation);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrcloseall();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrclosenode(rnode: RelFileNodeBackend);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrcreate(reln: SMgrRelation, forknum: ForkNumber, isRedo: bool);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrdosyncall(rels: *mut SMgrRelation, nrels: ::std::os::raw::c_int);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrdounlinkall(rels: *mut SMgrRelation, nrels: ::std::os::raw::c_int, isRedo: bool);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrextend(
-        reln: SMgrRelation,
-        forknum: ForkNumber,
-        blocknum: BlockNumber,
-        buffer: *mut ::std::os::raw::c_char,
-        skipFsync: bool,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrprefetch(reln: SMgrRelation, forknum: ForkNumber, blocknum: BlockNumber) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrread(
-        reln: SMgrRelation,
-        forknum: ForkNumber,
-        blocknum: BlockNumber,
-        buffer: *mut ::std::os::raw::c_char,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrwrite(
-        reln: SMgrRelation,
-        forknum: ForkNumber,
-        blocknum: BlockNumber,
-        buffer: *mut ::std::os::raw::c_char,
-        skipFsync: bool,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrwriteback(
-        reln: SMgrRelation,
-        forknum: ForkNumber,
-        blocknum: BlockNumber,
-        nblocks: BlockNumber,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrnblocks(reln: SMgrRelation, forknum: ForkNumber) -> BlockNumber;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrnblocks_cached(reln: SMgrRelation, forknum: ForkNumber) -> BlockNumber;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrtruncate(
-        reln: SMgrRelation,
-        forknum: *mut ForkNumber,
-        nforks: ::std::os::raw::c_int,
-        nblocks: *mut BlockNumber,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrimmedsync(reln: SMgrRelation, forknum: ForkNumber);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn AtEOXact_SMgr();
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct LockRelId {
-    pub relId: Oid,
-    pub dbId: Oid,
-}
-impl Default for LockRelId {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct LockInfoData {
-    pub lockRelId: LockRelId,
-}
-impl Default for LockInfoData {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type LockInfo = *mut LockInfoData;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct RelationData {
-    pub rd_node: RelFileNode,
-    pub rd_smgr: SMgrRelation,
-    pub rd_refcnt: ::std::os::raw::c_int,
-    pub rd_backend: BackendId,
-    pub rd_islocaltemp: bool,
-    pub rd_isnailed: bool,
-    pub rd_isvalid: bool,
-    pub rd_indexvalid: bool,
-    pub rd_statvalid: bool,
-    pub rd_createSubid: SubTransactionId,
-    pub rd_newRelfilenodeSubid: SubTransactionId,
-    pub rd_firstRelfilenodeSubid: SubTransactionId,
-    pub rd_droppedSubid: SubTransactionId,
-    pub rd_rel: Form_pg_class,
-    pub rd_att: TupleDesc,
-    pub rd_id: Oid,
-    pub rd_lockInfo: LockInfoData,
-    pub rd_rules: *mut RuleLock,
-    pub rd_rulescxt: MemoryContext,
-    pub trigdesc: *mut TriggerDesc,
-    pub rd_rsdesc: *mut RowSecurityDesc,
-    pub rd_fkeylist: *mut List,
-    pub rd_fkeyvalid: bool,
-    pub rd_partkey: PartitionKey,
-    pub rd_partkeycxt: MemoryContext,
-    pub rd_partdesc: PartitionDesc,
-    pub rd_pdcxt: MemoryContext,
-    pub rd_partdesc_nodetached: PartitionDesc,
-    pub rd_pddcxt: MemoryContext,
-    pub rd_partdesc_nodetached_xmin: TransactionId,
-    pub rd_partcheck: *mut List,
-    pub rd_partcheckvalid: bool,
-    pub rd_partcheckcxt: MemoryContext,
-    pub rd_indexlist: *mut List,
-    pub rd_pkindex: Oid,
-    pub rd_replidindex: Oid,
-    pub rd_statlist: *mut List,
-    pub rd_indexattr: *mut Bitmapset,
-    pub rd_keyattr: *mut Bitmapset,
-    pub rd_pkattr: *mut Bitmapset,
-    pub rd_idattr: *mut Bitmapset,
-    pub rd_pubactions: *mut PublicationActions,
-    pub rd_options: *mut bytea,
-    pub rd_amhandler: Oid,
-    pub rd_tableam: *const TableAmRoutine,
-    pub rd_index: Form_pg_index,
-    pub rd_indextuple: *mut HeapTupleData,
-    pub rd_indexcxt: MemoryContext,
-    pub rd_indam: *mut IndexAmRoutine,
-    pub rd_opfamily: *mut Oid,
-    pub rd_opcintype: *mut Oid,
-    pub rd_support: *mut RegProcedure,
-    pub rd_supportinfo: *mut FmgrInfo,
-    pub rd_indoption: *mut int16,
-    pub rd_indexprs: *mut List,
-    pub rd_indpred: *mut List,
-    pub rd_exclops: *mut Oid,
-    pub rd_exclprocs: *mut Oid,
-    pub rd_exclstrats: *mut uint16,
-    pub rd_indcollation: *mut Oid,
-    pub rd_opcoptions: *mut *mut bytea,
-    pub rd_amcache: *mut ::std::os::raw::c_void,
-    pub rd_fdwroutine: *mut FdwRoutine,
-    pub rd_toastoid: Oid,
-    pub pgstat_info: *mut PgStat_TableStatus,
-}
-impl Default for RelationData {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct ForeignKeyCacheInfo {
-    pub type_: NodeTag,
-    pub conoid: Oid,
-    pub conrelid: Oid,
-    pub confrelid: Oid,
-    pub nkeys: ::std::os::raw::c_int,
-    pub conkey: [AttrNumber; 32usize],
-    pub confkey: [AttrNumber; 32usize],
-    pub conpfeqop: [Oid; 32usize],
-}
-impl Default for ForeignKeyCacheInfo {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct AutoVacOpts {
-    pub enabled: bool,
-    pub vacuum_threshold: ::std::os::raw::c_int,
-    pub vacuum_ins_threshold: ::std::os::raw::c_int,
-    pub analyze_threshold: ::std::os::raw::c_int,
-    pub vacuum_cost_limit: ::std::os::raw::c_int,
-    pub freeze_min_age: ::std::os::raw::c_int,
-    pub freeze_max_age: ::std::os::raw::c_int,
-    pub freeze_table_age: ::std::os::raw::c_int,
-    pub multixact_freeze_min_age: ::std::os::raw::c_int,
-    pub multixact_freeze_max_age: ::std::os::raw::c_int,
-    pub multixact_freeze_table_age: ::std::os::raw::c_int,
-    pub log_min_duration: ::std::os::raw::c_int,
-    pub vacuum_cost_delay: float8,
-    pub vacuum_scale_factor: float8,
-    pub vacuum_ins_scale_factor: float8,
-    pub analyze_scale_factor: float8,
-}
-pub const StdRdOptIndexCleanup_STDRD_OPTION_VACUUM_INDEX_CLEANUP_AUTO: StdRdOptIndexCleanup = 0;
-pub const StdRdOptIndexCleanup_STDRD_OPTION_VACUUM_INDEX_CLEANUP_OFF: StdRdOptIndexCleanup = 1;
-pub const StdRdOptIndexCleanup_STDRD_OPTION_VACUUM_INDEX_CLEANUP_ON: StdRdOptIndexCleanup = 2;
-pub type StdRdOptIndexCleanup = ::std::os::raw::c_uint;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct StdRdOptions {
-    pub vl_len_: int32,
-    pub fillfactor: ::std::os::raw::c_int,
-    pub toast_tuple_target: ::std::os::raw::c_int,
-    pub autovacuum: AutoVacOpts,
-    pub user_catalog_table: bool,
-    pub parallel_workers: ::std::os::raw::c_int,
-    pub vacuum_index_cleanup: StdRdOptIndexCleanup,
-    pub vacuum_truncate: bool,
-}
-impl Default for StdRdOptions {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub const ViewOptCheckOption_VIEW_OPTION_CHECK_OPTION_NOT_SET: ViewOptCheckOption = 0;
-pub const ViewOptCheckOption_VIEW_OPTION_CHECK_OPTION_LOCAL: ViewOptCheckOption = 1;
-pub const ViewOptCheckOption_VIEW_OPTION_CHECK_OPTION_CASCADED: ViewOptCheckOption = 2;
-pub type ViewOptCheckOption = ::std::os::raw::c_uint;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct ViewOptions {
-    pub vl_len_: int32,
-    pub security_barrier: bool,
-    pub check_option: ViewOptCheckOption,
-}
-impl Default for ViewOptions {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn RelationIncrementReferenceCount(rel: Relation);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn RelationDecrementReferenceCount(rel: Relation);
-}
 extern "C" {
     pub static mut default_table_access_method: *mut ::std::os::raw::c_char;
 }
@@ -30406,7 +30517,7 @@ pub const LockTagType_LOCKTAG_USERLOCK: LockTagType = 9;
 pub const LockTagType_LOCKTAG_ADVISORY: LockTagType = 10;
 pub type LockTagType = ::std::os::raw::c_uint;
 extern "C" {
-    pub static mut LockTagTypeNames: [*const ::std::os::raw::c_char; 0usize];
+    pub static LockTagTypeNames: [*const ::std::os::raw::c_char; 0usize];
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -30774,7 +30885,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn DeadLockReport();
+    pub fn DeadLockReport() -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -39329,7 +39440,7 @@ impl Default for pg_enc2name {
     }
 }
 extern "C" {
-    pub static mut pg_enc2name_tbl: [pg_enc2name; 0usize];
+    pub static pg_enc2name_tbl: [pg_enc2name; 0usize];
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -39347,7 +39458,7 @@ impl Default for pg_enc2gettext {
     }
 }
 extern "C" {
-    pub static mut pg_enc2gettext_tbl: [pg_enc2gettext; 0usize];
+    pub static pg_enc2gettext_tbl: [pg_enc2gettext; 0usize];
 }
 pub type mb2wchar_with_len_converter = ::std::option::Option<
     unsafe extern "C" fn(
@@ -39396,7 +39507,7 @@ pub struct pg_wchar_tbl {
     pub maxmblen: ::std::os::raw::c_int,
 }
 extern "C" {
-    pub static mut pg_wchar_table: [pg_wchar_tbl; 0usize];
+    pub static pg_wchar_table: [pg_wchar_tbl; 0usize];
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -39857,7 +39968,7 @@ extern "C" {
         encoding: ::std::os::raw::c_int,
         mbstr: *const ::std::os::raw::c_char,
         len: ::std::os::raw::c_int,
-    );
+    ) -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -39866,7 +39977,7 @@ extern "C" {
         dest_encoding: ::std::os::raw::c_int,
         mbstr: *const ::std::os::raw::c_char,
         len: ::std::os::raw::c_int,
-    );
+    ) -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -44146,6 +44257,35 @@ extern "C" {
 extern "C" {
     pub fn get_parse_rowmark(qry: *mut Query, rtindex: Index) -> *mut RowMarkClause;
 }
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn downcase_truncate_identifier(
+        ident: *const ::std::os::raw::c_char,
+        len: ::std::os::raw::c_int,
+        warn: bool,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn downcase_identifier(
+        ident: *const ::std::os::raw::c_char,
+        len: ::std::os::raw::c_int,
+        warn: bool,
+        truncate: bool,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn truncate_identifier(
+        ident: *mut ::std::os::raw::c_char,
+        len: ::std::os::raw::c_int,
+        warn: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn scanner_isspace(ch: ::std::os::raw::c_char) -> bool;
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ExpandedRecordHeader {
@@ -45938,7 +46078,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn plpgsql_yyerror(message: *const ::std::os::raw::c_char);
+    pub fn plpgsql_yyerror(message: *const ::std::os::raw::c_char) -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -47349,7 +47489,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn WalReceiverMain();
+    pub fn WalReceiverMain() -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -48426,7 +48566,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn proc_exit(code: ::std::os::raw::c_int);
+    pub fn proc_exit(code: ::std::os::raw::c_int) -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -48462,6 +48602,190 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn CreateSharedMemoryAndSemaphores();
+}
+pub const XLTW_Oper_XLTW_None: XLTW_Oper = 0;
+pub const XLTW_Oper_XLTW_Update: XLTW_Oper = 1;
+pub const XLTW_Oper_XLTW_Delete: XLTW_Oper = 2;
+pub const XLTW_Oper_XLTW_Lock: XLTW_Oper = 3;
+pub const XLTW_Oper_XLTW_LockUpdated: XLTW_Oper = 4;
+pub const XLTW_Oper_XLTW_InsertIndex: XLTW_Oper = 5;
+pub const XLTW_Oper_XLTW_InsertIndexUnique: XLTW_Oper = 6;
+pub const XLTW_Oper_XLTW_FetchUpdated: XLTW_Oper = 7;
+pub const XLTW_Oper_XLTW_RecheckExclusionConstr: XLTW_Oper = 8;
+pub type XLTW_Oper = ::std::os::raw::c_uint;
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RelationInitLockInfo(relation: Relation);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockRelationOid(relid: Oid, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ConditionalLockRelationOid(relid: Oid, lockmode: LOCKMODE) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockRelationId(relid: *mut LockRelId, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockRelationOid(relid: Oid, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockRelation(relation: Relation, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ConditionalLockRelation(relation: Relation, lockmode: LOCKMODE) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockRelation(relation: Relation, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn CheckRelationLockedByMe(
+        relation: Relation,
+        lockmode: LOCKMODE,
+        orstronger: bool,
+    ) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockHasWaitersRelation(relation: Relation, lockmode: LOCKMODE) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockRelationIdForSession(relid: *mut LockRelId, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockRelationIdForSession(relid: *mut LockRelId, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockRelationForExtension(relation: Relation, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockRelationForExtension(relation: Relation, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ConditionalLockRelationForExtension(relation: Relation, lockmode: LOCKMODE) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RelationExtensionLockWaiterCount(relation: Relation) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockDatabaseFrozenIds(lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockPage(relation: Relation, blkno: BlockNumber, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ConditionalLockPage(relation: Relation, blkno: BlockNumber, lockmode: LOCKMODE) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockPage(relation: Relation, blkno: BlockNumber, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockTuple(relation: Relation, tid: ItemPointer, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ConditionalLockTuple(relation: Relation, tid: ItemPointer, lockmode: LOCKMODE) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockTuple(relation: Relation, tid: ItemPointer, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XactLockTableInsert(xid: TransactionId);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XactLockTableDelete(xid: TransactionId);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XactLockTableWait(xid: TransactionId, rel: Relation, ctid: ItemPointer, oper: XLTW_Oper);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ConditionalXactLockTableWait(xid: TransactionId) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn WaitForLockers(heaplocktag: LOCKTAG, lockmode: LOCKMODE, progress: bool);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn WaitForLockersMultiple(locktags: *mut List, lockmode: LOCKMODE, progress: bool);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SpeculativeInsertionLockAcquire(xid: TransactionId) -> uint32;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SpeculativeInsertionLockRelease(xid: TransactionId);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SpeculativeInsertionWait(xid: TransactionId, token: uint32);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockDatabaseObject(classid: Oid, objid: Oid, objsubid: uint16, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockDatabaseObject(classid: Oid, objid: Oid, objsubid: uint16, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockSharedObject(classid: Oid, objid: Oid, objsubid: uint16, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockSharedObject(classid: Oid, objid: Oid, objsubid: uint16, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockSharedObjectForSession(
+        classid: Oid,
+        objid: Oid,
+        objsubid: uint16,
+        lockmode: LOCKMODE,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockSharedObjectForSession(
+        classid: Oid,
+        objid: Oid,
+        objsubid: uint16,
+        lockmode: LOCKMODE,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DescribeLockTag(buf: StringInfo, tag: *const LOCKTAG);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetLockNameFromTagType(locktag_type: uint16) -> *const ::std::os::raw::c_char;
 }
 pub const ProcSignalReason_PROCSIG_CATCHUP_INTERRUPT: ProcSignalReason = 0;
 pub const ProcSignalReason_PROCSIG_NOTIFY_INTERRUPT: ProcSignalReason = 1;
@@ -49053,7 +49377,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn quickdie(postgres_signal_arg: ::std::os::raw::c_int);
+    pub fn quickdie(postgres_signal_arg: ::std::os::raw::c_int) -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -49061,7 +49385,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn FloatExceptionHandler(postgres_signal_arg: ::std::os::raw::c_int);
+    pub fn FloatExceptionHandler(postgres_signal_arg: ::std::os::raw::c_int) -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -49091,7 +49415,7 @@ extern "C" {
         argv: *mut *mut ::std::os::raw::c_char,
         dbname: *const ::std::os::raw::c_char,
         username: *const ::std::os::raw::c_char,
-    );
+    ) -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -61435,10 +61759,10 @@ impl Default for DynamicZoneAbbrev {
     }
 }
 extern "C" {
-    pub static mut months: [*const ::std::os::raw::c_char; 0usize];
+    pub static months: [*const ::std::os::raw::c_char; 0usize];
 }
 extern "C" {
-    pub static mut days: [*const ::std::os::raw::c_char; 0usize];
+    pub static days: [*const ::std::os::raw::c_char; 0usize];
 }
 extern "C" {
     pub static mut day_tab: [[::std::os::raw::c_int; 13usize]; 2usize];
@@ -61538,7 +61862,7 @@ extern "C" {
         dterr: ::std::os::raw::c_int,
         str_: *const ::std::os::raw::c_char,
         datatype: *const ::std::os::raw::c_char,
-    );
+    ) -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -61680,15 +62004,15 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn float_overflow_error();
+    pub fn float_overflow_error() -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn float_underflow_error();
+    pub fn float_underflow_error() -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn float_zero_divide_error();
+    pub fn float_zero_divide_error() -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {

--- a/pgrx-pg-sys/src/pg15.rs
+++ b/pgrx-pg-sys/src/pg15.rs
@@ -2246,21 +2246,6 @@ pub const XLR_BLOCK_ID_DATA_SHORT: u32 = 255;
 pub const XLR_BLOCK_ID_DATA_LONG: u32 = 254;
 pub const XLR_BLOCK_ID_ORIGIN: u32 = 253;
 pub const XLR_BLOCK_ID_TOPLEVEL_XID: u32 = 252;
-pub const GIN_COMPARE_PROC: u32 = 1;
-pub const GIN_EXTRACTVALUE_PROC: u32 = 2;
-pub const GIN_EXTRACTQUERY_PROC: u32 = 3;
-pub const GIN_CONSISTENT_PROC: u32 = 4;
-pub const GIN_COMPARE_PARTIAL_PROC: u32 = 5;
-pub const GIN_TRICONSISTENT_PROC: u32 = 6;
-pub const GIN_OPTIONS_PROC: u32 = 7;
-pub const GINNProcs: u32 = 7;
-pub const GIN_SEARCH_MODE_DEFAULT: u32 = 0;
-pub const GIN_SEARCH_MODE_INCLUDE_EMPTY: u32 = 1;
-pub const GIN_SEARCH_MODE_ALL: u32 = 2;
-pub const GIN_SEARCH_MODE_EVERYTHING: u32 = 3;
-pub const GIN_FALSE: u32 = 0;
-pub const GIN_TRUE: u32 = 1;
-pub const GIN_MAYBE: u32 = 2;
 pub const SYNC_METHOD_FSYNC: u32 = 0;
 pub const SYNC_METHOD_FDATASYNC: u32 = 1;
 pub const SYNC_METHOD_OPEN: u32 = 2;
@@ -2284,89 +2269,27 @@ pub const BACKUP_LABEL_OLD: &[u8; 17usize] = b"backup_label.old\0";
 pub const TABLESPACE_MAP: &[u8; 15usize] = b"tablespace_map\0";
 pub const TABLESPACE_MAP_OLD: &[u8; 19usize] = b"tablespace_map.old\0";
 pub const PROMOTE_SIGNAL_FILE: &[u8; 8usize] = b"promote\0";
-pub const GIST_CONSISTENT_PROC: u32 = 1;
-pub const GIST_UNION_PROC: u32 = 2;
-pub const GIST_COMPRESS_PROC: u32 = 3;
-pub const GIST_DECOMPRESS_PROC: u32 = 4;
-pub const GIST_PENALTY_PROC: u32 = 5;
-pub const GIST_PICKSPLIT_PROC: u32 = 6;
-pub const GIST_EQUAL_PROC: u32 = 7;
-pub const GIST_DISTANCE_PROC: u32 = 8;
-pub const GIST_FETCH_PROC: u32 = 9;
-pub const GIST_OPTIONS_PROC: u32 = 10;
-pub const GIST_SORTSUPPORT_PROC: u32 = 11;
-pub const GISTNProcs: u32 = 11;
-pub const F_LEAF: u32 = 1;
-pub const F_DELETED: u32 = 2;
-pub const F_TUPLES_DELETED: u32 = 4;
-pub const F_FOLLOW_RIGHT: u32 = 8;
-pub const F_HAS_GARBAGE: u32 = 16;
-pub const GIST_PAGE_ID: u32 = 65409;
-pub const SHAREDINVALCATALOG_ID: i32 = -1;
-pub const SHAREDINVALRELCACHE_ID: i32 = -2;
-pub const SHAREDINVALSMGR_ID: i32 = -3;
-pub const SHAREDINVALRELMAP_ID: i32 = -4;
-pub const SHAREDINVALSNAPSHOT_ID: i32 = -5;
-pub const GIDSIZE: u32 = 200;
-pub const XACT_READ_UNCOMMITTED: u32 = 0;
-pub const XACT_READ_COMMITTED: u32 = 1;
-pub const XACT_REPEATABLE_READ: u32 = 2;
-pub const XACT_SERIALIZABLE: u32 = 3;
-pub const XACT_FLAGS_ACCESSEDTEMPNAMESPACE: u32 = 1;
-pub const XACT_FLAGS_ACQUIREDACCESSEXCLUSIVELOCK: u32 = 2;
-pub const XACT_FLAGS_NEEDIMMEDIATECOMMIT: u32 = 4;
-pub const XACT_FLAGS_PIPELINING: u32 = 8;
-pub const XLOG_XACT_COMMIT: u32 = 0;
-pub const XLOG_XACT_PREPARE: u32 = 16;
-pub const XLOG_XACT_ABORT: u32 = 32;
-pub const XLOG_XACT_COMMIT_PREPARED: u32 = 48;
-pub const XLOG_XACT_ABORT_PREPARED: u32 = 64;
-pub const XLOG_XACT_ASSIGNMENT: u32 = 80;
-pub const XLOG_XACT_INVALIDATIONS: u32 = 96;
-pub const XLOG_XACT_OPMASK: u32 = 112;
-pub const XLOG_XACT_HAS_INFO: u32 = 128;
-pub const XACT_XINFO_HAS_DBINFO: u32 = 1;
-pub const XACT_XINFO_HAS_SUBXACTS: u32 = 2;
-pub const XACT_XINFO_HAS_RELFILENODES: u32 = 4;
-pub const XACT_XINFO_HAS_INVALS: u32 = 8;
-pub const XACT_XINFO_HAS_TWOPHASE: u32 = 16;
-pub const XACT_XINFO_HAS_ORIGIN: u32 = 32;
-pub const XACT_XINFO_HAS_AE_LOCKS: u32 = 64;
-pub const XACT_XINFO_HAS_GID: u32 = 128;
-pub const XACT_XINFO_HAS_DROPPED_STATS: u32 = 256;
-pub const XACT_COMPLETION_APPLY_FEEDBACK: u32 = 536870912;
-pub const XACT_COMPLETION_UPDATE_RELCACHE_FILE: u32 = 1073741824;
-pub const XACT_COMPLETION_FORCE_SYNC_COMMIT: u32 = 2147483648;
-pub const EOH_HEADER_MAGIC: i32 = -1;
-pub const MAXDIM: u32 = 6;
-pub const EA_MAGIC: u32 = 689375833;
-pub const PG_AUTOCONF_FILENAME: &[u8; 21usize] = b"postgresql.auto.conf\0";
-pub const GUC_QUALIFIER_SEPARATOR: u8 = 46u8;
-pub const GUC_LIST_INPUT: u32 = 1;
-pub const GUC_LIST_QUOTE: u32 = 2;
-pub const GUC_NO_SHOW_ALL: u32 = 4;
-pub const GUC_NO_RESET_ALL: u32 = 8;
-pub const GUC_REPORT: u32 = 16;
-pub const GUC_NOT_IN_SAMPLE: u32 = 32;
-pub const GUC_DISALLOW_IN_FILE: u32 = 64;
-pub const GUC_CUSTOM_PLACEHOLDER: u32 = 128;
-pub const GUC_SUPERUSER_ONLY: u32 = 256;
-pub const GUC_IS_NAME: u32 = 512;
-pub const GUC_NOT_WHILE_SEC_REST: u32 = 1024;
-pub const GUC_DISALLOW_IN_AUTO_FILE: u32 = 2048;
-pub const GUC_UNIT_KB: u32 = 4096;
-pub const GUC_UNIT_BLOCKS: u32 = 8192;
-pub const GUC_UNIT_XBLOCKS: u32 = 12288;
-pub const GUC_UNIT_MB: u32 = 16384;
-pub const GUC_UNIT_BYTE: u32 = 32768;
-pub const GUC_UNIT_MEMORY: u32 = 61440;
-pub const GUC_UNIT_MS: u32 = 65536;
-pub const GUC_UNIT_S: u32 = 131072;
-pub const GUC_UNIT_MIN: u32 = 196608;
-pub const GUC_UNIT_TIME: u32 = 983040;
-pub const GUC_EXPLAIN: u32 = 1048576;
-pub const GUC_RUNTIME_COMPUTED: u32 = 2097152;
-pub const GUC_UNIT: u32 = 1044480;
+pub const XLOG_PAGE_MAGIC: u32 = 53520;
+pub const XLP_FIRST_IS_CONTRECORD: u32 = 1;
+pub const XLP_LONG_HEADER: u32 = 2;
+pub const XLP_BKP_REMOVABLE: u32 = 4;
+pub const XLP_FIRST_IS_OVERWRITE_CONTRECORD: u32 = 8;
+pub const XLP_ALL_FLAGS: u32 = 15;
+pub const WalSegMinSize: u32 = 1048576;
+pub const WalSegMaxSize: u32 = 1073741824;
+pub const DEFAULT_MIN_WAL_SEGS: u32 = 5;
+pub const DEFAULT_MAX_WAL_SEGS: u32 = 64;
+pub const XLOGDIR: &[u8; 7usize] = b"pg_wal\0";
+pub const XLOG_CONTROL_FILE: &[u8; 18usize] = b"global/pg_control\0";
+pub const MAXFNAMELEN: u32 = 64;
+pub const XLOG_FNAME_LEN: u32 = 24;
+pub const XLR_NORMAL_MAX_BLOCK_ID: u32 = 4;
+pub const XLR_NORMAL_RDATAS: u32 = 20;
+pub const REGBUF_FORCE_IMAGE: u32 = 1;
+pub const REGBUF_NO_IMAGE: u32 = 2;
+pub const REGBUF_WILL_INIT: u32 = 6;
+pub const REGBUF_STANDARD: u32 = 8;
+pub const REGBUF_KEEP_DATA: u32 = 16;
 pub const RelationRelationId: Oid = Oid(1259);
 pub const RelationRelation_Rowtype_Id: u32 = 83;
 pub const ClassOidIndexId: u32 = 2662;
@@ -2465,6 +2388,106 @@ pub const Anum_pg_publication_pubviaroot: u32 = 9;
 pub const Natts_pg_publication: u32 = 9;
 pub const HEAP_MIN_FILLFACTOR: u32 = 10;
 pub const HEAP_DEFAULT_FILLFACTOR: u32 = 100;
+pub const MAX_GENERIC_XLOG_PAGES: u32 = 4;
+pub const GENERIC_XLOG_FULL_IMAGE: u32 = 1;
+pub const GIN_COMPARE_PROC: u32 = 1;
+pub const GIN_EXTRACTVALUE_PROC: u32 = 2;
+pub const GIN_EXTRACTQUERY_PROC: u32 = 3;
+pub const GIN_CONSISTENT_PROC: u32 = 4;
+pub const GIN_COMPARE_PARTIAL_PROC: u32 = 5;
+pub const GIN_TRICONSISTENT_PROC: u32 = 6;
+pub const GIN_OPTIONS_PROC: u32 = 7;
+pub const GINNProcs: u32 = 7;
+pub const GIN_SEARCH_MODE_DEFAULT: u32 = 0;
+pub const GIN_SEARCH_MODE_INCLUDE_EMPTY: u32 = 1;
+pub const GIN_SEARCH_MODE_ALL: u32 = 2;
+pub const GIN_SEARCH_MODE_EVERYTHING: u32 = 3;
+pub const GIN_FALSE: u32 = 0;
+pub const GIN_TRUE: u32 = 1;
+pub const GIN_MAYBE: u32 = 2;
+pub const GIST_CONSISTENT_PROC: u32 = 1;
+pub const GIST_UNION_PROC: u32 = 2;
+pub const GIST_COMPRESS_PROC: u32 = 3;
+pub const GIST_DECOMPRESS_PROC: u32 = 4;
+pub const GIST_PENALTY_PROC: u32 = 5;
+pub const GIST_PICKSPLIT_PROC: u32 = 6;
+pub const GIST_EQUAL_PROC: u32 = 7;
+pub const GIST_DISTANCE_PROC: u32 = 8;
+pub const GIST_FETCH_PROC: u32 = 9;
+pub const GIST_OPTIONS_PROC: u32 = 10;
+pub const GIST_SORTSUPPORT_PROC: u32 = 11;
+pub const GISTNProcs: u32 = 11;
+pub const F_LEAF: u32 = 1;
+pub const F_DELETED: u32 = 2;
+pub const F_TUPLES_DELETED: u32 = 4;
+pub const F_FOLLOW_RIGHT: u32 = 8;
+pub const F_HAS_GARBAGE: u32 = 16;
+pub const GIST_PAGE_ID: u32 = 65409;
+pub const SHAREDINVALCATALOG_ID: i32 = -1;
+pub const SHAREDINVALRELCACHE_ID: i32 = -2;
+pub const SHAREDINVALSMGR_ID: i32 = -3;
+pub const SHAREDINVALRELMAP_ID: i32 = -4;
+pub const SHAREDINVALSNAPSHOT_ID: i32 = -5;
+pub const GIDSIZE: u32 = 200;
+pub const XACT_READ_UNCOMMITTED: u32 = 0;
+pub const XACT_READ_COMMITTED: u32 = 1;
+pub const XACT_REPEATABLE_READ: u32 = 2;
+pub const XACT_SERIALIZABLE: u32 = 3;
+pub const XACT_FLAGS_ACCESSEDTEMPNAMESPACE: u32 = 1;
+pub const XACT_FLAGS_ACQUIREDACCESSEXCLUSIVELOCK: u32 = 2;
+pub const XACT_FLAGS_NEEDIMMEDIATECOMMIT: u32 = 4;
+pub const XACT_FLAGS_PIPELINING: u32 = 8;
+pub const XLOG_XACT_COMMIT: u32 = 0;
+pub const XLOG_XACT_PREPARE: u32 = 16;
+pub const XLOG_XACT_ABORT: u32 = 32;
+pub const XLOG_XACT_COMMIT_PREPARED: u32 = 48;
+pub const XLOG_XACT_ABORT_PREPARED: u32 = 64;
+pub const XLOG_XACT_ASSIGNMENT: u32 = 80;
+pub const XLOG_XACT_INVALIDATIONS: u32 = 96;
+pub const XLOG_XACT_OPMASK: u32 = 112;
+pub const XLOG_XACT_HAS_INFO: u32 = 128;
+pub const XACT_XINFO_HAS_DBINFO: u32 = 1;
+pub const XACT_XINFO_HAS_SUBXACTS: u32 = 2;
+pub const XACT_XINFO_HAS_RELFILENODES: u32 = 4;
+pub const XACT_XINFO_HAS_INVALS: u32 = 8;
+pub const XACT_XINFO_HAS_TWOPHASE: u32 = 16;
+pub const XACT_XINFO_HAS_ORIGIN: u32 = 32;
+pub const XACT_XINFO_HAS_AE_LOCKS: u32 = 64;
+pub const XACT_XINFO_HAS_GID: u32 = 128;
+pub const XACT_XINFO_HAS_DROPPED_STATS: u32 = 256;
+pub const XACT_COMPLETION_APPLY_FEEDBACK: u32 = 536870912;
+pub const XACT_COMPLETION_UPDATE_RELCACHE_FILE: u32 = 1073741824;
+pub const XACT_COMPLETION_FORCE_SYNC_COMMIT: u32 = 2147483648;
+pub const EOH_HEADER_MAGIC: i32 = -1;
+pub const MAXDIM: u32 = 6;
+pub const EA_MAGIC: u32 = 689375833;
+pub const PG_AUTOCONF_FILENAME: &[u8; 21usize] = b"postgresql.auto.conf\0";
+pub const GUC_QUALIFIER_SEPARATOR: u8 = 46u8;
+pub const GUC_LIST_INPUT: u32 = 1;
+pub const GUC_LIST_QUOTE: u32 = 2;
+pub const GUC_NO_SHOW_ALL: u32 = 4;
+pub const GUC_NO_RESET_ALL: u32 = 8;
+pub const GUC_REPORT: u32 = 16;
+pub const GUC_NOT_IN_SAMPLE: u32 = 32;
+pub const GUC_DISALLOW_IN_FILE: u32 = 64;
+pub const GUC_CUSTOM_PLACEHOLDER: u32 = 128;
+pub const GUC_SUPERUSER_ONLY: u32 = 256;
+pub const GUC_IS_NAME: u32 = 512;
+pub const GUC_NOT_WHILE_SEC_REST: u32 = 1024;
+pub const GUC_DISALLOW_IN_AUTO_FILE: u32 = 2048;
+pub const GUC_UNIT_KB: u32 = 4096;
+pub const GUC_UNIT_BLOCKS: u32 = 8192;
+pub const GUC_UNIT_XBLOCKS: u32 = 12288;
+pub const GUC_UNIT_MB: u32 = 16384;
+pub const GUC_UNIT_BYTE: u32 = 32768;
+pub const GUC_UNIT_MEMORY: u32 = 61440;
+pub const GUC_UNIT_MS: u32 = 65536;
+pub const GUC_UNIT_S: u32 = 131072;
+pub const GUC_UNIT_MIN: u32 = 196608;
+pub const GUC_UNIT_TIME: u32 = 983040;
+pub const GUC_EXPLAIN: u32 = 1048576;
+pub const GUC_RUNTIME_COMPUTED: u32 = 2097152;
+pub const GUC_UNIT: u32 = 1044480;
 pub const DEFAULT_TABLE_ACCESS_METHOD: &[u8; 5usize] = b"heap\0";
 pub const TABLE_INSERT_SKIP_FSM: u32 = 2;
 pub const TABLE_INSERT_FROZEN: u32 = 4;
@@ -4219,7 +4242,7 @@ extern "C" {
         errorType: *const ::std::os::raw::c_char,
         fileName: *const ::std::os::raw::c_char,
         lineNumber: ::std::os::raw::c_int,
-    );
+    ) -> !;
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -5782,7 +5805,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn ReThrowError(edata: *mut ErrorData);
+    pub fn ReThrowError(edata: *mut ErrorData) -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -10880,11 +10903,7 @@ impl Default for Query {
         }
     }
 }
-#[doc = "\tSupporting data structures for Parse Trees"]
-#[doc = ""]
-#[doc = "\tMost of these node types appear in raw parsetrees output by the grammar,"]
-#[doc = "\tand get transformed to something else by the analyzer.  A few of them"]
-#[doc = "\tare used as-is in transformed querytrees."]
+#[doc = "\tSupporting data structures for Parse Trees\n\n\tMost of these node types appear in raw parsetrees output by the grammar,\n\tand get transformed to something else by the analyzer.  A few of them\n\tare used as-is in transformed querytrees."]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct TypeName {
@@ -12208,17 +12227,7 @@ pub const ObjectType_OBJECT_TSTEMPLATE: ObjectType = 48;
 pub const ObjectType_OBJECT_TYPE: ObjectType = 49;
 pub const ObjectType_OBJECT_USER_MAPPING: ObjectType = 50;
 pub const ObjectType_OBJECT_VIEW: ObjectType = 51;
-#[doc = "\t\tOther Statements (no optimizations required)"]
-#[doc = ""]
-#[doc = "\t\tThese are not touched by parser/analyze.c except to put them into"]
-#[doc = "\t\tthe utilityStmt field of a Query.  This is eventually passed to"]
-#[doc = "\t\tProcessUtility (by-passing rewriting and planning).  Some of the"]
-#[doc = "\t\tstatements do need attention from parse analysis, and this is"]
-#[doc = "\t\tdone by routines in parser/parse_utilcmd.c after ProcessUtility"]
-#[doc = "\t\treceives the command for execution."]
-#[doc = "\t\tDECLARE CURSOR, EXPLAIN, and CREATE TABLE AS are special cases:"]
-#[doc = "\t\tthey contain optimizable statements, which get processed normally"]
-#[doc = "\t\tby parser/analyze.c."]
+#[doc = "\t\tOther Statements (no optimizations required)\n\n\t\tThese are not touched by parser/analyze.c except to put them into\n\t\tthe utilityStmt field of a Query.  This is eventually passed to\n\t\tProcessUtility (by-passing rewriting and planning).  Some of the\n\t\tstatements do need attention from parse analysis, and this is\n\t\tdone by routines in parser/parse_utilcmd.c after ProcessUtility\n\t\treceives the command for execution.\n\t\tDECLARE CURSOR, EXPLAIN, and CREATE TABLE AS are special cases:\n\t\tthey contain optimizable statements, which get processed normally\n\t\tby parser/analyze.c."]
 pub type ObjectType = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -22208,56 +22217,7 @@ extern "C" {
     pub fn pg_tzenumerate_end(dir: *mut pg_tzenum);
 }
 extern "C" {
-    #[doc = "\t  System interrupt and critical section handling"]
-    #[doc = ""]
-    #[doc = " There are two types of interrupts that a running backend needs to accept"]
-    #[doc = " without messing up its state: QueryCancel (SIGINT) and ProcDie (SIGTERM)."]
-    #[doc = " In both cases, we need to be able to clean up the current transaction"]
-    #[doc = " gracefully, so we can't respond to the interrupt instantaneously ---"]
-    #[doc = " there's no guarantee that internal data structures would be self-consistent"]
-    #[doc = " if the code is interrupted at an arbitrary instant.  Instead, the signal"]
-    #[doc = " handlers set flags that are checked periodically during execution."]
-    #[doc = ""]
-    #[doc = " The CHECK_FOR_INTERRUPTS() macro is called at strategically located spots"]
-    #[doc = " where it is normally safe to accept a cancel or die interrupt.  In some"]
-    #[doc = " cases, we invoke CHECK_FOR_INTERRUPTS() inside low-level subroutines that"]
-    #[doc = " might sometimes be called in contexts that do *not* want to allow a cancel"]
-    #[doc = " or die interrupt.  The HOLD_INTERRUPTS() and RESUME_INTERRUPTS() macros"]
-    #[doc = " allow code to ensure that no cancel or die interrupt will be accepted,"]
-    #[doc = " even if CHECK_FOR_INTERRUPTS() gets called in a subroutine.  The interrupt"]
-    #[doc = " will be held off until CHECK_FOR_INTERRUPTS() is done outside any"]
-    #[doc = " HOLD_INTERRUPTS() ... RESUME_INTERRUPTS() section."]
-    #[doc = ""]
-    #[doc = " There is also a mechanism to prevent query cancel interrupts, while still"]
-    #[doc = " allowing die interrupts: HOLD_CANCEL_INTERRUPTS() and"]
-    #[doc = " RESUME_CANCEL_INTERRUPTS()."]
-    #[doc = ""]
-    #[doc = " Note that ProcessInterrupts() has also acquired a number of tasks that"]
-    #[doc = " do not necessarily cause a query-cancel-or-die response.  Hence, it's"]
-    #[doc = " possible that it will just clear InterruptPending and return."]
-    #[doc = ""]
-    #[doc = " INTERRUPTS_PENDING_CONDITION() can be checked to see whether an"]
-    #[doc = " interrupt needs to be serviced, without trying to do so immediately."]
-    #[doc = " Some callers are also interested in INTERRUPTS_CAN_BE_PROCESSED(),"]
-    #[doc = " which tells whether ProcessInterrupts is sure to clear the interrupt."]
-    #[doc = ""]
-    #[doc = " Special mechanisms are used to let an interrupt be accepted when we are"]
-    #[doc = " waiting for a lock or when we are waiting for command input (but, of"]
-    #[doc = " course, only if the interrupt holdoff counter is zero).  See the"]
-    #[doc = " related code for details."]
-    #[doc = ""]
-    #[doc = " A lost connection is handled similarly, although the loss of connection"]
-    #[doc = " does not raise a signal, but is detected when we fail to write to the"]
-    #[doc = " socket. If there was a signal for a broken connection, we could make use of"]
-    #[doc = " it by setting ClientConnectionLost in the signal handler."]
-    #[doc = ""]
-    #[doc = " A related, but conceptually distinct, mechanism is the \"critical section\""]
-    #[doc = " mechanism.  A critical section not only holds off cancel/die interrupts,"]
-    #[doc = " but causes any ereport(ERROR) or ereport(FATAL) to become ereport(PANIC)"]
-    #[doc = " --- that is, a system-wide reset is forced.  Needless to say, only really"]
-    #[doc = " *critical* code should be marked as a critical section!\tCurrently, this"]
-    #[doc = " mechanism is only used for XLOG-related code."]
-    #[doc = ""]
+    #[doc = "\t  System interrupt and critical section handling\n\n There are two types of interrupts that a running backend needs to accept\n without messing up its state: QueryCancel (SIGINT) and ProcDie (SIGTERM).\n In both cases, we need to be able to clean up the current transaction\n gracefully, so we can't respond to the interrupt instantaneously ---\n there's no guarantee that internal data structures would be self-consistent\n if the code is interrupted at an arbitrary instant.  Instead, the signal\n handlers set flags that are checked periodically during execution.\n\n The CHECK_FOR_INTERRUPTS() macro is called at strategically located spots\n where it is normally safe to accept a cancel or die interrupt.  In some\n cases, we invoke CHECK_FOR_INTERRUPTS() inside low-level subroutines that\n might sometimes be called in contexts that do *not* want to allow a cancel\n or die interrupt.  The HOLD_INTERRUPTS() and RESUME_INTERRUPTS() macros\n allow code to ensure that no cancel or die interrupt will be accepted,\n even if CHECK_FOR_INTERRUPTS() gets called in a subroutine.  The interrupt\n will be held off until CHECK_FOR_INTERRUPTS() is done outside any\n HOLD_INTERRUPTS() ... RESUME_INTERRUPTS() section.\n\n There is also a mechanism to prevent query cancel interrupts, while still\n allowing die interrupts: HOLD_CANCEL_INTERRUPTS() and\n RESUME_CANCEL_INTERRUPTS().\n\n Note that ProcessInterrupts() has also acquired a number of tasks that\n do not necessarily cause a query-cancel-or-die response.  Hence, it's\n possible that it will just clear InterruptPending and return.\n\n INTERRUPTS_PENDING_CONDITION() can be checked to see whether an\n interrupt needs to be serviced, without trying to do so immediately.\n Some callers are also interested in INTERRUPTS_CAN_BE_PROCESSED(),\n which tells whether ProcessInterrupts is sure to clear the interrupt.\n\n Special mechanisms are used to let an interrupt be accepted when we are\n waiting for a lock or when we are waiting for command input (but, of\n course, only if the interrupt holdoff counter is zero).  See the\n related code for details.\n\n A lost connection is handled similarly, although the loss of connection\n does not raise a signal, but is detected when we fail to write to the\n socket. If there was a signal for a broken connection, we could make use of\n it by setting ClientConnectionLost in the signal handler.\n\n A related, but conceptually distinct, mechanism is the \"critical section\"\n mechanism.  A critical section not only holds off cancel/die interrupts,\n but causes any ereport(ERROR) or ereport(FATAL) to become ereport(PANIC)\n --- that is, a system-wide reset is forced.  Needless to say, only really\n *critical* code should be marked as a critical section!\tCurrently, this\n mechanism is only used for XLOG-related code.\n"]
     pub static mut InterruptPending: sig_atomic_t;
 }
 extern "C" {
@@ -22609,8 +22569,7 @@ extern "C" {
 pub const ProcessingMode_BootstrapProcessing: ProcessingMode = 0;
 pub const ProcessingMode_InitProcessing: ProcessingMode = 1;
 pub const ProcessingMode_NormalProcessing: ProcessingMode = 2;
-#[doc = "\t  pmod.h --\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t *"]
-#[doc = "\t\t\tPOSTGRES processing mode definitions.                            *"]
+#[doc = "\t  pmod.h --\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t *\n\t\t\tPOSTGRES processing mode definitions.                            *"]
 pub type ProcessingMode = ::std::os::raw::c_uint;
 extern "C" {
     pub static mut Mode: ProcessingMode;
@@ -22629,8 +22588,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    #[doc = "\t  pinit.h --\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t *"]
-    #[doc = "\t\t\tPOSTGRES initialization and cleanup definitions.                 *"]
+    #[doc = "\t  pinit.h --\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t *\n\t\t\tPOSTGRES initialization and cleanup definitions.                 *"]
     pub fn pg_split_opts(
         argv: *mut *mut ::std::os::raw::c_char,
         argcp: *mut ::std::os::raw::c_int,
@@ -22751,7 +22709,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn PgArchiverMain();
+    pub fn PgArchiverMain() -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -25024,7 +24982,7 @@ pub const ForkNumber_VISIBILITYMAP_FORKNUM: ForkNumber = 2;
 pub const ForkNumber_INIT_FORKNUM: ForkNumber = 3;
 pub type ForkNumber = ::std::os::raw::c_int;
 extern "C" {
-    pub static mut forkNames: [*const ::std::os::raw::c_char; 0usize];
+    pub static forkNames: [*const ::std::os::raw::c_char; 0usize];
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -25425,31 +25383,6 @@ extern "C" {
         prefetch_buffer: *mut Buffer,
     ) -> bool;
 }
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct GinStatsData {
-    pub nPendingPages: BlockNumber,
-    pub nTotalPages: BlockNumber,
-    pub nEntryPages: BlockNumber,
-    pub nDataPages: BlockNumber,
-    pub nEntries: int64,
-    pub ginVersion: int32,
-}
-pub type GinTernaryValue = ::std::os::raw::c_char;
-extern "C" {
-    pub static mut GinFuzzySearchLimit: ::std::os::raw::c_int;
-}
-extern "C" {
-    pub static mut gin_pending_list_limit: ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn ginGetStats(index: Relation, stats: *mut GinStatsData);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn ginUpdateStats(index: Relation, stats: *const GinStatsData, is_build: bool);
-}
 extern "C" {
     pub static mut sync_method: ::std::os::raw::c_int;
 }
@@ -25573,11 +25506,6 @@ pub const WALAvailability_WALAVAIL_EXTENDED: WALAvailability = 2;
 pub const WALAvailability_WALAVAIL_UNRESERVED: WALAvailability = 3;
 pub const WALAvailability_WALAVAIL_REMOVED: WALAvailability = 4;
 pub type WALAvailability = ::std::os::raw::c_uint;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct XLogRecData {
-    _unused: [u8; 0],
-}
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn XLogInsertRecord(
@@ -25821,6 +25749,1133 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn get_backup_status() -> SessionBackupState;
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct XLogPageHeaderData {
+    pub xlp_magic: uint16,
+    pub xlp_info: uint16,
+    pub xlp_tli: TimeLineID,
+    pub xlp_pageaddr: XLogRecPtr,
+    pub xlp_rem_len: uint32,
+}
+pub type XLogPageHeader = *mut XLogPageHeaderData;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct XLogLongPageHeaderData {
+    pub std: XLogPageHeaderData,
+    pub xlp_sysid: uint64,
+    pub xlp_seg_size: uint32,
+    pub xlp_xlog_blcksz: uint32,
+}
+pub type XLogLongPageHeader = *mut XLogLongPageHeaderData;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct xl_parameter_change {
+    pub MaxConnections: ::std::os::raw::c_int,
+    pub max_worker_processes: ::std::os::raw::c_int,
+    pub max_wal_senders: ::std::os::raw::c_int,
+    pub max_prepared_xacts: ::std::os::raw::c_int,
+    pub max_locks_per_xact: ::std::os::raw::c_int,
+    pub wal_level: ::std::os::raw::c_int,
+    pub wal_log_hints: bool,
+    pub track_commit_timestamp: bool,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct xl_restore_point {
+    pub rp_time: TimestampTz,
+    pub rp_name: [::std::os::raw::c_char; 64usize],
+}
+impl Default for xl_restore_point {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct xl_overwrite_contrecord {
+    pub overwritten_lsn: XLogRecPtr,
+    pub overwrite_time: TimestampTz,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct xl_end_of_recovery {
+    pub end_time: TimestampTz,
+    pub ThisTimeLineID: TimeLineID,
+    pub PrevTimeLineID: TimeLineID,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct XLogRecData {
+    pub next: *mut XLogRecData,
+    pub data: *mut ::std::os::raw::c_char,
+    pub len: uint32,
+}
+impl Default for XLogRecData {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub const RecoveryTargetAction_RECOVERY_TARGET_ACTION_PAUSE: RecoveryTargetAction = 0;
+pub const RecoveryTargetAction_RECOVERY_TARGET_ACTION_PROMOTE: RecoveryTargetAction = 1;
+pub const RecoveryTargetAction_RECOVERY_TARGET_ACTION_SHUTDOWN: RecoveryTargetAction = 2;
+pub type RecoveryTargetAction = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct XLogRecordBuffer {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct RmgrData {
+    pub rm_name: *const ::std::os::raw::c_char,
+    pub rm_redo: ::std::option::Option<unsafe extern "C" fn(record: *mut XLogReaderState)>,
+    pub rm_desc:
+        ::std::option::Option<unsafe extern "C" fn(buf: StringInfo, record: *mut XLogReaderState)>,
+    pub rm_identify:
+        ::std::option::Option<unsafe extern "C" fn(info: uint8) -> *const ::std::os::raw::c_char>,
+    pub rm_startup: ::std::option::Option<unsafe extern "C" fn()>,
+    pub rm_cleanup: ::std::option::Option<unsafe extern "C" fn()>,
+    pub rm_mask: ::std::option::Option<
+        unsafe extern "C" fn(pagedata: *mut ::std::os::raw::c_char, blkno: BlockNumber),
+    >,
+    pub rm_decode: ::std::option::Option<
+        unsafe extern "C" fn(ctx: *mut LogicalDecodingContext, buf: *mut XLogRecordBuffer),
+    >,
+}
+impl Default for RmgrData {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+extern "C" {
+    pub static mut RmgrTable: [RmgrData; 0usize];
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RmgrStartup();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RmgrCleanup();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RmgrNotFound(rmid: RmgrId);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RegisterCustomRmgr(rmid: RmgrId, rmgr: *mut RmgrData);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetLastSegSwitchData(lastSwitchLSN: *mut XLogRecPtr) -> pg_time_t;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RequestXLogSwitch(mark_unimportant: bool) -> XLogRecPtr;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetOldestRestartPoint(oldrecptr: *mut XLogRecPtr, oldtli: *mut TimeLineID);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XLogRecGetBlockRefInfo(
+        record: *mut XLogReaderState,
+        pretty: bool,
+        detailed_format: bool,
+        buf: StringInfo,
+        fpi_len: *mut uint32,
+    );
+}
+extern "C" {
+    pub static mut ArchiveRecoveryRequested: bool;
+}
+extern "C" {
+    pub static mut InArchiveRecovery: bool;
+}
+extern "C" {
+    pub static mut StandbyMode: bool;
+}
+extern "C" {
+    pub static mut recoveryRestoreCommand: *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XLogBeginInsert();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XLogSetRecordFlags(flags: uint8);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XLogInsert(rmid: RmgrId, info: uint8) -> XLogRecPtr;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XLogEnsureRecordSpace(
+        max_block_id: ::std::os::raw::c_int,
+        ndatas: ::std::os::raw::c_int,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XLogRegisterData(data: *mut ::std::os::raw::c_char, len: ::std::os::raw::c_int);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XLogRegisterBuffer(block_id: uint8, buffer: Buffer, flags: uint8);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XLogRegisterBlock(
+        block_id: uint8,
+        rnode: *mut RelFileNode,
+        forknum: ForkNumber,
+        blknum: BlockNumber,
+        page: *mut ::std::os::raw::c_char,
+        flags: uint8,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XLogRegisterBufData(
+        block_id: uint8,
+        data: *mut ::std::os::raw::c_char,
+        len: ::std::os::raw::c_int,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XLogResetInsertion();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XLogCheckBufferNeedsBackup(buffer: Buffer) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn log_newpage(
+        rnode: *mut RelFileNode,
+        forkNum: ForkNumber,
+        blk: BlockNumber,
+        page: *mut ::std::os::raw::c_char,
+        page_std: bool,
+    ) -> XLogRecPtr;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn log_newpages(
+        rnode: *mut RelFileNode,
+        forkNum: ForkNumber,
+        num_pages: ::std::os::raw::c_int,
+        blknos: *mut BlockNumber,
+        pages: *mut *mut ::std::os::raw::c_char,
+        page_std: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn log_newpage_buffer(buffer: Buffer, page_std: bool) -> XLogRecPtr;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn log_newpage_range(
+        rel: Relation,
+        forkNum: ForkNumber,
+        startblk: BlockNumber,
+        endblk: BlockNumber,
+        page_std: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XLogSaveBufferForHint(buffer: Buffer, buffer_std: bool) -> XLogRecPtr;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn InitXLogInsert();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn errdetail_relkind_not_supported(
+        relkind: ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct FormData_pg_class {
+    pub oid: Oid,
+    pub relname: NameData,
+    pub relnamespace: Oid,
+    pub reltype: Oid,
+    pub reloftype: Oid,
+    pub relowner: Oid,
+    pub relam: Oid,
+    pub relfilenode: Oid,
+    pub reltablespace: Oid,
+    pub relpages: int32,
+    pub reltuples: float4,
+    pub relallvisible: int32,
+    pub reltoastrelid: Oid,
+    pub relhasindex: bool,
+    pub relisshared: bool,
+    pub relpersistence: ::std::os::raw::c_char,
+    pub relkind: ::std::os::raw::c_char,
+    pub relnatts: int16,
+    pub relchecks: int16,
+    pub relhasrules: bool,
+    pub relhastriggers: bool,
+    pub relhassubclass: bool,
+    pub relrowsecurity: bool,
+    pub relforcerowsecurity: bool,
+    pub relispopulated: bool,
+    pub relreplident: ::std::os::raw::c_char,
+    pub relispartition: bool,
+    pub relrewrite: Oid,
+    pub relfrozenxid: TransactionId,
+    pub relminmxid: TransactionId,
+}
+impl Default for FormData_pg_class {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type Form_pg_class = *mut FormData_pg_class;
+#[repr(C)]
+#[derive(Debug)]
+pub struct FormData_pg_index {
+    pub indexrelid: Oid,
+    pub indrelid: Oid,
+    pub indnatts: int16,
+    pub indnkeyatts: int16,
+    pub indisunique: bool,
+    pub indnullsnotdistinct: bool,
+    pub indisprimary: bool,
+    pub indisexclusion: bool,
+    pub indimmediate: bool,
+    pub indisclustered: bool,
+    pub indisvalid: bool,
+    pub indcheckxmin: bool,
+    pub indisready: bool,
+    pub indislive: bool,
+    pub indisreplident: bool,
+    pub indkey: int2vector,
+}
+impl Default for FormData_pg_index {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type Form_pg_index = *mut FormData_pg_index;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ObjectAddress {
+    pub classId: Oid,
+    pub objectId: Oid,
+    pub objectSubId: int32,
+}
+impl Default for ObjectAddress {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+extern "C" {
+    pub static InvalidObjectAddress: ObjectAddress;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_object_address(
+        objtype: ObjectType,
+        object: *mut Node,
+        relp: *mut Relation,
+        lockmode: LOCKMODE,
+        missing_ok: bool,
+    ) -> ObjectAddress;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_object_address_rv(
+        objtype: ObjectType,
+        rel: *mut RangeVar,
+        object: *mut List,
+        relp: *mut Relation,
+        lockmode: LOCKMODE,
+        missing_ok: bool,
+    ) -> ObjectAddress;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn check_object_ownership(
+        roleid: Oid,
+        objtype: ObjectType,
+        address: ObjectAddress,
+        object: *mut Node,
+        relation: Relation,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_object_namespace(address: *const ObjectAddress) -> Oid;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn is_objectclass_supported(class_id: Oid) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_object_class_descr(class_id: Oid) -> *const ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_object_oid_index(class_id: Oid) -> Oid;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_object_catcache_oid(class_id: Oid) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_object_catcache_name(class_id: Oid) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_object_attnum_oid(class_id: Oid) -> AttrNumber;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_object_attnum_name(class_id: Oid) -> AttrNumber;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_object_attnum_namespace(class_id: Oid) -> AttrNumber;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_object_attnum_owner(class_id: Oid) -> AttrNumber;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_object_attnum_acl(class_id: Oid) -> AttrNumber;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_object_type(class_id: Oid, object_id: Oid) -> ObjectType;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_object_namensp_unique(class_id: Oid) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_catalog_object_by_oid(
+        catalog: Relation,
+        oidcol: AttrNumber,
+        objectId: Oid,
+    ) -> HeapTuple;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn getObjectDescription(
+        object: *const ObjectAddress,
+        missing_ok: bool,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn getObjectDescriptionOids(classid: Oid, objid: Oid) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn read_objtype_from_string(
+        objtype: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn getObjectTypeDescription(
+        object: *const ObjectAddress,
+        missing_ok: bool,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn getObjectIdentity(
+        address: *const ObjectAddress,
+        missing_ok: bool,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn getObjectIdentityParts(
+        address: *const ObjectAddress,
+        objname: *mut *mut List,
+        objargs: *mut *mut List,
+        missing_ok: bool,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn strlist_to_textarray(list: *mut List) -> *mut ArrayType;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_relkind_objtype(relkind: ::std::os::raw::c_char) -> ObjectType;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct FormData_pg_publication {
+    pub oid: Oid,
+    pub pubname: NameData,
+    pub pubowner: Oid,
+    pub puballtables: bool,
+    pub pubinsert: bool,
+    pub pubupdate: bool,
+    pub pubdelete: bool,
+    pub pubtruncate: bool,
+    pub pubviaroot: bool,
+}
+impl Default for FormData_pg_publication {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type Form_pg_publication = *mut FormData_pg_publication;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct PublicationActions {
+    pub pubinsert: bool,
+    pub pubupdate: bool,
+    pub pubdelete: bool,
+    pub pubtruncate: bool,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct PublicationDesc {
+    pub pubactions: PublicationActions,
+    pub rf_valid_for_update: bool,
+    pub rf_valid_for_delete: bool,
+    pub cols_valid_for_update: bool,
+    pub cols_valid_for_delete: bool,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct Publication {
+    pub oid: Oid,
+    pub name: *mut ::std::os::raw::c_char,
+    pub alltables: bool,
+    pub pubviaroot: bool,
+    pub pubactions: PublicationActions,
+}
+impl Default for Publication {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PublicationRelInfo {
+    pub relation: Relation,
+    pub whereClause: *mut Node,
+    pub columns: *mut List,
+}
+impl Default for PublicationRelInfo {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetPublication(pubid: Oid) -> *mut Publication;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetPublicationByName(
+        pubname: *const ::std::os::raw::c_char,
+        missing_ok: bool,
+    ) -> *mut Publication;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetRelationPublications(relid: Oid) -> *mut List;
+}
+pub const PublicationPartOpt_PUBLICATION_PART_ROOT: PublicationPartOpt = 0;
+pub const PublicationPartOpt_PUBLICATION_PART_LEAF: PublicationPartOpt = 1;
+pub const PublicationPartOpt_PUBLICATION_PART_ALL: PublicationPartOpt = 2;
+pub type PublicationPartOpt = ::std::os::raw::c_uint;
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetPublicationRelations(pubid: Oid, pub_partopt: PublicationPartOpt) -> *mut List;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetAllTablesPublications() -> *mut List;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetAllTablesPublicationRelations(pubviaroot: bool) -> *mut List;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetPublicationSchemas(pubid: Oid) -> *mut List;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetSchemaPublications(schemaid: Oid) -> *mut List;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetSchemaPublicationRelations(
+        schemaid: Oid,
+        pub_partopt: PublicationPartOpt,
+    ) -> *mut List;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetAllSchemaPublicationRelations(
+        puboid: Oid,
+        pub_partopt: PublicationPartOpt,
+    ) -> *mut List;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetPubPartitionOptionRelations(
+        result: *mut List,
+        pub_partopt: PublicationPartOpt,
+        relid: Oid,
+    ) -> *mut List;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetTopMostAncestorInPublication(
+        puboid: Oid,
+        ancestors: *mut List,
+        ancestor_level: *mut ::std::os::raw::c_int,
+    ) -> Oid;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn is_publishable_relation(rel: Relation) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn is_schema_publication(pubid: Oid) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn publication_add_relation(
+        pubid: Oid,
+        pri: *mut PublicationRelInfo,
+        if_not_exists: bool,
+    ) -> ObjectAddress;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn publication_add_schema(pubid: Oid, schemaid: Oid, if_not_exists: bool) -> ObjectAddress;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn pub_collist_to_bitmapset(
+        columns: *mut Bitmapset,
+        pubcols: Datum,
+        mcxt: MemoryContext,
+    ) -> *mut Bitmapset;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_publication_oid(pubname: *const ::std::os::raw::c_char, missing_ok: bool) -> Oid;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_publication_name(pubid: Oid, missing_ok: bool) -> *mut ::std::os::raw::c_char;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct RewriteRule {
+    pub ruleId: Oid,
+    pub event: CmdType,
+    pub qual: *mut Node,
+    pub actions: *mut List,
+    pub enabled: ::std::os::raw::c_char,
+    pub isInstead: bool,
+}
+impl Default for RewriteRule {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct RuleLock {
+    pub numLocks: ::std::os::raw::c_int,
+    pub rules: *mut *mut RewriteRule,
+}
+impl Default for RuleLock {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct SMgrRelationData {
+    pub smgr_rnode: RelFileNodeBackend,
+    pub smgr_owner: *mut *mut SMgrRelationData,
+    pub smgr_targblock: BlockNumber,
+    pub smgr_cached_nblocks: [BlockNumber; 4usize],
+    pub smgr_which: ::std::os::raw::c_int,
+    pub md_num_open_segs: [::std::os::raw::c_int; 4usize],
+    pub md_seg_fds: [*mut _MdfdVec; 4usize],
+    pub node: dlist_node,
+}
+impl Default for SMgrRelationData {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type SMgrRelation = *mut SMgrRelationData;
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrinit();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgropen(rnode: RelFileNode, backend: BackendId) -> SMgrRelation;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrexists(reln: SMgrRelation, forknum: ForkNumber) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrsetowner(owner: *mut SMgrRelation, reln: SMgrRelation);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrclearowner(owner: *mut SMgrRelation, reln: SMgrRelation);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrclose(reln: SMgrRelation);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrcloseall();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrclosenode(rnode: RelFileNodeBackend);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrrelease(reln: SMgrRelation);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrreleaseall();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrcreate(reln: SMgrRelation, forknum: ForkNumber, isRedo: bool);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrdosyncall(rels: *mut SMgrRelation, nrels: ::std::os::raw::c_int);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrdounlinkall(rels: *mut SMgrRelation, nrels: ::std::os::raw::c_int, isRedo: bool);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrextend(
+        reln: SMgrRelation,
+        forknum: ForkNumber,
+        blocknum: BlockNumber,
+        buffer: *mut ::std::os::raw::c_char,
+        skipFsync: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrprefetch(reln: SMgrRelation, forknum: ForkNumber, blocknum: BlockNumber) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrread(
+        reln: SMgrRelation,
+        forknum: ForkNumber,
+        blocknum: BlockNumber,
+        buffer: *mut ::std::os::raw::c_char,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrwrite(
+        reln: SMgrRelation,
+        forknum: ForkNumber,
+        blocknum: BlockNumber,
+        buffer: *mut ::std::os::raw::c_char,
+        skipFsync: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrwriteback(
+        reln: SMgrRelation,
+        forknum: ForkNumber,
+        blocknum: BlockNumber,
+        nblocks: BlockNumber,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrnblocks(reln: SMgrRelation, forknum: ForkNumber) -> BlockNumber;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrnblocks_cached(reln: SMgrRelation, forknum: ForkNumber) -> BlockNumber;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrtruncate(
+        reln: SMgrRelation,
+        forknum: *mut ForkNumber,
+        nforks: ::std::os::raw::c_int,
+        nblocks: *mut BlockNumber,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn smgrimmedsync(reln: SMgrRelation, forknum: ForkNumber);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn AtEOXact_SMgr();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ProcessBarrierSmgrRelease() -> bool;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct LockRelId {
+    pub relId: Oid,
+    pub dbId: Oid,
+}
+impl Default for LockRelId {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct LockInfoData {
+    pub lockRelId: LockRelId,
+}
+impl Default for LockInfoData {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type LockInfo = *mut LockInfoData;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct RelationData {
+    pub rd_node: RelFileNode,
+    pub rd_smgr: SMgrRelation,
+    pub rd_refcnt: ::std::os::raw::c_int,
+    pub rd_backend: BackendId,
+    pub rd_islocaltemp: bool,
+    pub rd_isnailed: bool,
+    pub rd_isvalid: bool,
+    pub rd_indexvalid: bool,
+    pub rd_statvalid: bool,
+    pub rd_createSubid: SubTransactionId,
+    pub rd_newRelfilenodeSubid: SubTransactionId,
+    pub rd_firstRelfilenodeSubid: SubTransactionId,
+    pub rd_droppedSubid: SubTransactionId,
+    pub rd_rel: Form_pg_class,
+    pub rd_att: TupleDesc,
+    pub rd_id: Oid,
+    pub rd_lockInfo: LockInfoData,
+    pub rd_rules: *mut RuleLock,
+    pub rd_rulescxt: MemoryContext,
+    pub trigdesc: *mut TriggerDesc,
+    pub rd_rsdesc: *mut RowSecurityDesc,
+    pub rd_fkeylist: *mut List,
+    pub rd_fkeyvalid: bool,
+    pub rd_partkey: PartitionKey,
+    pub rd_partkeycxt: MemoryContext,
+    pub rd_partdesc: PartitionDesc,
+    pub rd_pdcxt: MemoryContext,
+    pub rd_partdesc_nodetached: PartitionDesc,
+    pub rd_pddcxt: MemoryContext,
+    pub rd_partdesc_nodetached_xmin: TransactionId,
+    pub rd_partcheck: *mut List,
+    pub rd_partcheckvalid: bool,
+    pub rd_partcheckcxt: MemoryContext,
+    pub rd_indexlist: *mut List,
+    pub rd_pkindex: Oid,
+    pub rd_replidindex: Oid,
+    pub rd_statlist: *mut List,
+    pub rd_indexattr: *mut Bitmapset,
+    pub rd_keyattr: *mut Bitmapset,
+    pub rd_pkattr: *mut Bitmapset,
+    pub rd_idattr: *mut Bitmapset,
+    pub rd_pubdesc: *mut PublicationDesc,
+    pub rd_options: *mut bytea,
+    pub rd_amhandler: Oid,
+    pub rd_tableam: *const TableAmRoutine,
+    pub rd_index: Form_pg_index,
+    pub rd_indextuple: *mut HeapTupleData,
+    pub rd_indexcxt: MemoryContext,
+    pub rd_indam: *mut IndexAmRoutine,
+    pub rd_opfamily: *mut Oid,
+    pub rd_opcintype: *mut Oid,
+    pub rd_support: *mut RegProcedure,
+    pub rd_supportinfo: *mut FmgrInfo,
+    pub rd_indoption: *mut int16,
+    pub rd_indexprs: *mut List,
+    pub rd_indpred: *mut List,
+    pub rd_exclops: *mut Oid,
+    pub rd_exclprocs: *mut Oid,
+    pub rd_exclstrats: *mut uint16,
+    pub rd_indcollation: *mut Oid,
+    pub rd_opcoptions: *mut *mut bytea,
+    pub rd_amcache: *mut ::std::os::raw::c_void,
+    pub rd_fdwroutine: *mut FdwRoutine,
+    pub rd_toastoid: Oid,
+    pub pgstat_enabled: bool,
+    pub pgstat_info: *mut PgStat_TableStatus,
+}
+impl Default for RelationData {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ForeignKeyCacheInfo {
+    pub type_: NodeTag,
+    pub conoid: Oid,
+    pub conrelid: Oid,
+    pub confrelid: Oid,
+    pub nkeys: ::std::os::raw::c_int,
+    pub conkey: [AttrNumber; 32usize],
+    pub confkey: [AttrNumber; 32usize],
+    pub conpfeqop: [Oid; 32usize],
+}
+impl Default for ForeignKeyCacheInfo {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct AutoVacOpts {
+    pub enabled: bool,
+    pub vacuum_threshold: ::std::os::raw::c_int,
+    pub vacuum_ins_threshold: ::std::os::raw::c_int,
+    pub analyze_threshold: ::std::os::raw::c_int,
+    pub vacuum_cost_limit: ::std::os::raw::c_int,
+    pub freeze_min_age: ::std::os::raw::c_int,
+    pub freeze_max_age: ::std::os::raw::c_int,
+    pub freeze_table_age: ::std::os::raw::c_int,
+    pub multixact_freeze_min_age: ::std::os::raw::c_int,
+    pub multixact_freeze_max_age: ::std::os::raw::c_int,
+    pub multixact_freeze_table_age: ::std::os::raw::c_int,
+    pub log_min_duration: ::std::os::raw::c_int,
+    pub vacuum_cost_delay: float8,
+    pub vacuum_scale_factor: float8,
+    pub vacuum_ins_scale_factor: float8,
+    pub analyze_scale_factor: float8,
+}
+pub const StdRdOptIndexCleanup_STDRD_OPTION_VACUUM_INDEX_CLEANUP_AUTO: StdRdOptIndexCleanup = 0;
+pub const StdRdOptIndexCleanup_STDRD_OPTION_VACUUM_INDEX_CLEANUP_OFF: StdRdOptIndexCleanup = 1;
+pub const StdRdOptIndexCleanup_STDRD_OPTION_VACUUM_INDEX_CLEANUP_ON: StdRdOptIndexCleanup = 2;
+pub type StdRdOptIndexCleanup = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct StdRdOptions {
+    pub vl_len_: int32,
+    pub fillfactor: ::std::os::raw::c_int,
+    pub toast_tuple_target: ::std::os::raw::c_int,
+    pub autovacuum: AutoVacOpts,
+    pub user_catalog_table: bool,
+    pub parallel_workers: ::std::os::raw::c_int,
+    pub vacuum_index_cleanup: StdRdOptIndexCleanup,
+    pub vacuum_truncate: bool,
+}
+impl Default for StdRdOptions {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub const ViewOptCheckOption_VIEW_OPTION_CHECK_OPTION_NOT_SET: ViewOptCheckOption = 0;
+pub const ViewOptCheckOption_VIEW_OPTION_CHECK_OPTION_LOCAL: ViewOptCheckOption = 1;
+pub const ViewOptCheckOption_VIEW_OPTION_CHECK_OPTION_CASCADED: ViewOptCheckOption = 2;
+pub type ViewOptCheckOption = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ViewOptions {
+    pub vl_len_: int32,
+    pub security_barrier: bool,
+    pub security_invoker: bool,
+    pub check_option: ViewOptCheckOption,
+}
+impl Default for ViewOptions {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RelationIncrementReferenceCount(rel: Relation);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RelationDecrementReferenceCount(rel: Relation);
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct GenericXLogState {
+    _unused: [u8; 0],
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GenericXLogStart(relation: Relation) -> *mut GenericXLogState;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GenericXLogRegisterBuffer(
+        state: *mut GenericXLogState,
+        buffer: Buffer,
+        flags: ::std::os::raw::c_int,
+    ) -> Page;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GenericXLogFinish(state: *mut GenericXLogState) -> XLogRecPtr;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GenericXLogAbort(state: *mut GenericXLogState);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn generic_redo(record: *mut XLogReaderState);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn generic_identify(info: uint8) -> *const ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn generic_desc(buf: StringInfo, record: *mut XLogReaderState);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn generic_mask(pagedata: *mut ::std::os::raw::c_char, blkno: BlockNumber);
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct GinStatsData {
+    pub nPendingPages: BlockNumber,
+    pub nTotalPages: BlockNumber,
+    pub nEntryPages: BlockNumber,
+    pub nDataPages: BlockNumber,
+    pub nEntries: int64,
+    pub ginVersion: int32,
+}
+pub type GinTernaryValue = ::std::os::raw::c_char;
+extern "C" {
+    pub static mut GinFuzzySearchLimit: ::std::os::raw::c_int;
+}
+extern "C" {
+    pub static mut gin_pending_list_limit: ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ginGetStats(index: Relation, stats: *mut GinStatsData);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ginUpdateStats(index: Relation, stats: *const GinStatsData, is_build: bool);
 }
 pub type GistNSN = XLogRecPtr;
 pub type PageGistNSN = PageXLogRecPtr;
@@ -28128,806 +29183,6 @@ extern "C" {
         extra: *mut ::std::os::raw::c_void,
     );
 }
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn errdetail_relkind_not_supported(
-        relkind: ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct FormData_pg_class {
-    pub oid: Oid,
-    pub relname: NameData,
-    pub relnamespace: Oid,
-    pub reltype: Oid,
-    pub reloftype: Oid,
-    pub relowner: Oid,
-    pub relam: Oid,
-    pub relfilenode: Oid,
-    pub reltablespace: Oid,
-    pub relpages: int32,
-    pub reltuples: float4,
-    pub relallvisible: int32,
-    pub reltoastrelid: Oid,
-    pub relhasindex: bool,
-    pub relisshared: bool,
-    pub relpersistence: ::std::os::raw::c_char,
-    pub relkind: ::std::os::raw::c_char,
-    pub relnatts: int16,
-    pub relchecks: int16,
-    pub relhasrules: bool,
-    pub relhastriggers: bool,
-    pub relhassubclass: bool,
-    pub relrowsecurity: bool,
-    pub relforcerowsecurity: bool,
-    pub relispopulated: bool,
-    pub relreplident: ::std::os::raw::c_char,
-    pub relispartition: bool,
-    pub relrewrite: Oid,
-    pub relfrozenxid: TransactionId,
-    pub relminmxid: TransactionId,
-}
-impl Default for FormData_pg_class {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type Form_pg_class = *mut FormData_pg_class;
-#[repr(C)]
-#[derive(Debug)]
-pub struct FormData_pg_index {
-    pub indexrelid: Oid,
-    pub indrelid: Oid,
-    pub indnatts: int16,
-    pub indnkeyatts: int16,
-    pub indisunique: bool,
-    pub indnullsnotdistinct: bool,
-    pub indisprimary: bool,
-    pub indisexclusion: bool,
-    pub indimmediate: bool,
-    pub indisclustered: bool,
-    pub indisvalid: bool,
-    pub indcheckxmin: bool,
-    pub indisready: bool,
-    pub indislive: bool,
-    pub indisreplident: bool,
-    pub indkey: int2vector,
-}
-impl Default for FormData_pg_index {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type Form_pg_index = *mut FormData_pg_index;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct ObjectAddress {
-    pub classId: Oid,
-    pub objectId: Oid,
-    pub objectSubId: int32,
-}
-impl Default for ObjectAddress {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-extern "C" {
-    pub static InvalidObjectAddress: ObjectAddress;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_object_address(
-        objtype: ObjectType,
-        object: *mut Node,
-        relp: *mut Relation,
-        lockmode: LOCKMODE,
-        missing_ok: bool,
-    ) -> ObjectAddress;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_object_address_rv(
-        objtype: ObjectType,
-        rel: *mut RangeVar,
-        object: *mut List,
-        relp: *mut Relation,
-        lockmode: LOCKMODE,
-        missing_ok: bool,
-    ) -> ObjectAddress;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn check_object_ownership(
-        roleid: Oid,
-        objtype: ObjectType,
-        address: ObjectAddress,
-        object: *mut Node,
-        relation: Relation,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_object_namespace(address: *const ObjectAddress) -> Oid;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn is_objectclass_supported(class_id: Oid) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_object_class_descr(class_id: Oid) -> *const ::std::os::raw::c_char;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_object_oid_index(class_id: Oid) -> Oid;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_object_catcache_oid(class_id: Oid) -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_object_catcache_name(class_id: Oid) -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_object_attnum_oid(class_id: Oid) -> AttrNumber;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_object_attnum_name(class_id: Oid) -> AttrNumber;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_object_attnum_namespace(class_id: Oid) -> AttrNumber;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_object_attnum_owner(class_id: Oid) -> AttrNumber;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_object_attnum_acl(class_id: Oid) -> AttrNumber;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_object_type(class_id: Oid, object_id: Oid) -> ObjectType;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_object_namensp_unique(class_id: Oid) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_catalog_object_by_oid(
-        catalog: Relation,
-        oidcol: AttrNumber,
-        objectId: Oid,
-    ) -> HeapTuple;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn getObjectDescription(
-        object: *const ObjectAddress,
-        missing_ok: bool,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn getObjectDescriptionOids(classid: Oid, objid: Oid) -> *mut ::std::os::raw::c_char;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn read_objtype_from_string(
-        objtype: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn getObjectTypeDescription(
-        object: *const ObjectAddress,
-        missing_ok: bool,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn getObjectIdentity(
-        address: *const ObjectAddress,
-        missing_ok: bool,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn getObjectIdentityParts(
-        address: *const ObjectAddress,
-        objname: *mut *mut List,
-        objargs: *mut *mut List,
-        missing_ok: bool,
-    ) -> *mut ::std::os::raw::c_char;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn strlist_to_textarray(list: *mut List) -> *mut ArrayType;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_relkind_objtype(relkind: ::std::os::raw::c_char) -> ObjectType;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct FormData_pg_publication {
-    pub oid: Oid,
-    pub pubname: NameData,
-    pub pubowner: Oid,
-    pub puballtables: bool,
-    pub pubinsert: bool,
-    pub pubupdate: bool,
-    pub pubdelete: bool,
-    pub pubtruncate: bool,
-    pub pubviaroot: bool,
-}
-impl Default for FormData_pg_publication {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type Form_pg_publication = *mut FormData_pg_publication;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct PublicationActions {
-    pub pubinsert: bool,
-    pub pubupdate: bool,
-    pub pubdelete: bool,
-    pub pubtruncate: bool,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct PublicationDesc {
-    pub pubactions: PublicationActions,
-    pub rf_valid_for_update: bool,
-    pub rf_valid_for_delete: bool,
-    pub cols_valid_for_update: bool,
-    pub cols_valid_for_delete: bool,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct Publication {
-    pub oid: Oid,
-    pub name: *mut ::std::os::raw::c_char,
-    pub alltables: bool,
-    pub pubviaroot: bool,
-    pub pubactions: PublicationActions,
-}
-impl Default for Publication {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct PublicationRelInfo {
-    pub relation: Relation,
-    pub whereClause: *mut Node,
-    pub columns: *mut List,
-}
-impl Default for PublicationRelInfo {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetPublication(pubid: Oid) -> *mut Publication;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetPublicationByName(
-        pubname: *const ::std::os::raw::c_char,
-        missing_ok: bool,
-    ) -> *mut Publication;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetRelationPublications(relid: Oid) -> *mut List;
-}
-pub const PublicationPartOpt_PUBLICATION_PART_ROOT: PublicationPartOpt = 0;
-pub const PublicationPartOpt_PUBLICATION_PART_LEAF: PublicationPartOpt = 1;
-pub const PublicationPartOpt_PUBLICATION_PART_ALL: PublicationPartOpt = 2;
-pub type PublicationPartOpt = ::std::os::raw::c_uint;
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetPublicationRelations(pubid: Oid, pub_partopt: PublicationPartOpt) -> *mut List;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetAllTablesPublications() -> *mut List;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetAllTablesPublicationRelations(pubviaroot: bool) -> *mut List;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetPublicationSchemas(pubid: Oid) -> *mut List;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetSchemaPublications(schemaid: Oid) -> *mut List;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetSchemaPublicationRelations(
-        schemaid: Oid,
-        pub_partopt: PublicationPartOpt,
-    ) -> *mut List;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetAllSchemaPublicationRelations(
-        puboid: Oid,
-        pub_partopt: PublicationPartOpt,
-    ) -> *mut List;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetPubPartitionOptionRelations(
-        result: *mut List,
-        pub_partopt: PublicationPartOpt,
-        relid: Oid,
-    ) -> *mut List;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetTopMostAncestorInPublication(
-        puboid: Oid,
-        ancestors: *mut List,
-        ancestor_level: *mut ::std::os::raw::c_int,
-    ) -> Oid;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn is_publishable_relation(rel: Relation) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn is_schema_publication(pubid: Oid) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn publication_add_relation(
-        pubid: Oid,
-        pri: *mut PublicationRelInfo,
-        if_not_exists: bool,
-    ) -> ObjectAddress;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn publication_add_schema(pubid: Oid, schemaid: Oid, if_not_exists: bool) -> ObjectAddress;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn pub_collist_to_bitmapset(
-        columns: *mut Bitmapset,
-        pubcols: Datum,
-        mcxt: MemoryContext,
-    ) -> *mut Bitmapset;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_publication_oid(pubname: *const ::std::os::raw::c_char, missing_ok: bool) -> Oid;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_publication_name(pubid: Oid, missing_ok: bool) -> *mut ::std::os::raw::c_char;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct RewriteRule {
-    pub ruleId: Oid,
-    pub event: CmdType,
-    pub qual: *mut Node,
-    pub actions: *mut List,
-    pub enabled: ::std::os::raw::c_char,
-    pub isInstead: bool,
-}
-impl Default for RewriteRule {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct RuleLock {
-    pub numLocks: ::std::os::raw::c_int,
-    pub rules: *mut *mut RewriteRule,
-}
-impl Default for RuleLock {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct SMgrRelationData {
-    pub smgr_rnode: RelFileNodeBackend,
-    pub smgr_owner: *mut *mut SMgrRelationData,
-    pub smgr_targblock: BlockNumber,
-    pub smgr_cached_nblocks: [BlockNumber; 4usize],
-    pub smgr_which: ::std::os::raw::c_int,
-    pub md_num_open_segs: [::std::os::raw::c_int; 4usize],
-    pub md_seg_fds: [*mut _MdfdVec; 4usize],
-    pub node: dlist_node,
-}
-impl Default for SMgrRelationData {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type SMgrRelation = *mut SMgrRelationData;
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrinit();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgropen(rnode: RelFileNode, backend: BackendId) -> SMgrRelation;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrexists(reln: SMgrRelation, forknum: ForkNumber) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrsetowner(owner: *mut SMgrRelation, reln: SMgrRelation);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrclearowner(owner: *mut SMgrRelation, reln: SMgrRelation);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrclose(reln: SMgrRelation);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrcloseall();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrclosenode(rnode: RelFileNodeBackend);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrrelease(reln: SMgrRelation);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrreleaseall();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrcreate(reln: SMgrRelation, forknum: ForkNumber, isRedo: bool);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrdosyncall(rels: *mut SMgrRelation, nrels: ::std::os::raw::c_int);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrdounlinkall(rels: *mut SMgrRelation, nrels: ::std::os::raw::c_int, isRedo: bool);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrextend(
-        reln: SMgrRelation,
-        forknum: ForkNumber,
-        blocknum: BlockNumber,
-        buffer: *mut ::std::os::raw::c_char,
-        skipFsync: bool,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrprefetch(reln: SMgrRelation, forknum: ForkNumber, blocknum: BlockNumber) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrread(
-        reln: SMgrRelation,
-        forknum: ForkNumber,
-        blocknum: BlockNumber,
-        buffer: *mut ::std::os::raw::c_char,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrwrite(
-        reln: SMgrRelation,
-        forknum: ForkNumber,
-        blocknum: BlockNumber,
-        buffer: *mut ::std::os::raw::c_char,
-        skipFsync: bool,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrwriteback(
-        reln: SMgrRelation,
-        forknum: ForkNumber,
-        blocknum: BlockNumber,
-        nblocks: BlockNumber,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrnblocks(reln: SMgrRelation, forknum: ForkNumber) -> BlockNumber;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrnblocks_cached(reln: SMgrRelation, forknum: ForkNumber) -> BlockNumber;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrtruncate(
-        reln: SMgrRelation,
-        forknum: *mut ForkNumber,
-        nforks: ::std::os::raw::c_int,
-        nblocks: *mut BlockNumber,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn smgrimmedsync(reln: SMgrRelation, forknum: ForkNumber);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn AtEOXact_SMgr();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn ProcessBarrierSmgrRelease() -> bool;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct LockRelId {
-    pub relId: Oid,
-    pub dbId: Oid,
-}
-impl Default for LockRelId {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct LockInfoData {
-    pub lockRelId: LockRelId,
-}
-impl Default for LockInfoData {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type LockInfo = *mut LockInfoData;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct RelationData {
-    pub rd_node: RelFileNode,
-    pub rd_smgr: SMgrRelation,
-    pub rd_refcnt: ::std::os::raw::c_int,
-    pub rd_backend: BackendId,
-    pub rd_islocaltemp: bool,
-    pub rd_isnailed: bool,
-    pub rd_isvalid: bool,
-    pub rd_indexvalid: bool,
-    pub rd_statvalid: bool,
-    pub rd_createSubid: SubTransactionId,
-    pub rd_newRelfilenodeSubid: SubTransactionId,
-    pub rd_firstRelfilenodeSubid: SubTransactionId,
-    pub rd_droppedSubid: SubTransactionId,
-    pub rd_rel: Form_pg_class,
-    pub rd_att: TupleDesc,
-    pub rd_id: Oid,
-    pub rd_lockInfo: LockInfoData,
-    pub rd_rules: *mut RuleLock,
-    pub rd_rulescxt: MemoryContext,
-    pub trigdesc: *mut TriggerDesc,
-    pub rd_rsdesc: *mut RowSecurityDesc,
-    pub rd_fkeylist: *mut List,
-    pub rd_fkeyvalid: bool,
-    pub rd_partkey: PartitionKey,
-    pub rd_partkeycxt: MemoryContext,
-    pub rd_partdesc: PartitionDesc,
-    pub rd_pdcxt: MemoryContext,
-    pub rd_partdesc_nodetached: PartitionDesc,
-    pub rd_pddcxt: MemoryContext,
-    pub rd_partdesc_nodetached_xmin: TransactionId,
-    pub rd_partcheck: *mut List,
-    pub rd_partcheckvalid: bool,
-    pub rd_partcheckcxt: MemoryContext,
-    pub rd_indexlist: *mut List,
-    pub rd_pkindex: Oid,
-    pub rd_replidindex: Oid,
-    pub rd_statlist: *mut List,
-    pub rd_indexattr: *mut Bitmapset,
-    pub rd_keyattr: *mut Bitmapset,
-    pub rd_pkattr: *mut Bitmapset,
-    pub rd_idattr: *mut Bitmapset,
-    pub rd_pubdesc: *mut PublicationDesc,
-    pub rd_options: *mut bytea,
-    pub rd_amhandler: Oid,
-    pub rd_tableam: *const TableAmRoutine,
-    pub rd_index: Form_pg_index,
-    pub rd_indextuple: *mut HeapTupleData,
-    pub rd_indexcxt: MemoryContext,
-    pub rd_indam: *mut IndexAmRoutine,
-    pub rd_opfamily: *mut Oid,
-    pub rd_opcintype: *mut Oid,
-    pub rd_support: *mut RegProcedure,
-    pub rd_supportinfo: *mut FmgrInfo,
-    pub rd_indoption: *mut int16,
-    pub rd_indexprs: *mut List,
-    pub rd_indpred: *mut List,
-    pub rd_exclops: *mut Oid,
-    pub rd_exclprocs: *mut Oid,
-    pub rd_exclstrats: *mut uint16,
-    pub rd_indcollation: *mut Oid,
-    pub rd_opcoptions: *mut *mut bytea,
-    pub rd_amcache: *mut ::std::os::raw::c_void,
-    pub rd_fdwroutine: *mut FdwRoutine,
-    pub rd_toastoid: Oid,
-    pub pgstat_enabled: bool,
-    pub pgstat_info: *mut PgStat_TableStatus,
-}
-impl Default for RelationData {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct ForeignKeyCacheInfo {
-    pub type_: NodeTag,
-    pub conoid: Oid,
-    pub conrelid: Oid,
-    pub confrelid: Oid,
-    pub nkeys: ::std::os::raw::c_int,
-    pub conkey: [AttrNumber; 32usize],
-    pub confkey: [AttrNumber; 32usize],
-    pub conpfeqop: [Oid; 32usize],
-}
-impl Default for ForeignKeyCacheInfo {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct AutoVacOpts {
-    pub enabled: bool,
-    pub vacuum_threshold: ::std::os::raw::c_int,
-    pub vacuum_ins_threshold: ::std::os::raw::c_int,
-    pub analyze_threshold: ::std::os::raw::c_int,
-    pub vacuum_cost_limit: ::std::os::raw::c_int,
-    pub freeze_min_age: ::std::os::raw::c_int,
-    pub freeze_max_age: ::std::os::raw::c_int,
-    pub freeze_table_age: ::std::os::raw::c_int,
-    pub multixact_freeze_min_age: ::std::os::raw::c_int,
-    pub multixact_freeze_max_age: ::std::os::raw::c_int,
-    pub multixact_freeze_table_age: ::std::os::raw::c_int,
-    pub log_min_duration: ::std::os::raw::c_int,
-    pub vacuum_cost_delay: float8,
-    pub vacuum_scale_factor: float8,
-    pub vacuum_ins_scale_factor: float8,
-    pub analyze_scale_factor: float8,
-}
-pub const StdRdOptIndexCleanup_STDRD_OPTION_VACUUM_INDEX_CLEANUP_AUTO: StdRdOptIndexCleanup = 0;
-pub const StdRdOptIndexCleanup_STDRD_OPTION_VACUUM_INDEX_CLEANUP_OFF: StdRdOptIndexCleanup = 1;
-pub const StdRdOptIndexCleanup_STDRD_OPTION_VACUUM_INDEX_CLEANUP_ON: StdRdOptIndexCleanup = 2;
-pub type StdRdOptIndexCleanup = ::std::os::raw::c_uint;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct StdRdOptions {
-    pub vl_len_: int32,
-    pub fillfactor: ::std::os::raw::c_int,
-    pub toast_tuple_target: ::std::os::raw::c_int,
-    pub autovacuum: AutoVacOpts,
-    pub user_catalog_table: bool,
-    pub parallel_workers: ::std::os::raw::c_int,
-    pub vacuum_index_cleanup: StdRdOptIndexCleanup,
-    pub vacuum_truncate: bool,
-}
-impl Default for StdRdOptions {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub const ViewOptCheckOption_VIEW_OPTION_CHECK_OPTION_NOT_SET: ViewOptCheckOption = 0;
-pub const ViewOptCheckOption_VIEW_OPTION_CHECK_OPTION_LOCAL: ViewOptCheckOption = 1;
-pub const ViewOptCheckOption_VIEW_OPTION_CHECK_OPTION_CASCADED: ViewOptCheckOption = 2;
-pub type ViewOptCheckOption = ::std::os::raw::c_uint;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct ViewOptions {
-    pub vl_len_: int32,
-    pub security_barrier: bool,
-    pub security_invoker: bool,
-    pub check_option: ViewOptCheckOption,
-}
-impl Default for ViewOptions {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn RelationIncrementReferenceCount(rel: Relation);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn RelationDecrementReferenceCount(rel: Relation);
-}
 extern "C" {
     pub static mut default_table_access_method: *mut ::std::os::raw::c_char;
 }
@@ -30396,7 +30651,7 @@ pub const LockTagType_LOCKTAG_USERLOCK: LockTagType = 9;
 pub const LockTagType_LOCKTAG_ADVISORY: LockTagType = 10;
 pub type LockTagType = ::std::os::raw::c_uint;
 extern "C" {
-    pub static mut LockTagTypeNames: [*const ::std::os::raw::c_char; 0usize];
+    pub static LockTagTypeNames: [*const ::std::os::raw::c_char; 0usize];
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -30764,7 +31019,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn DeadLockReport();
+    pub fn DeadLockReport() -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -33990,7 +34245,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn errorConflictingDefElem(defel: *mut DefElem, pstate: *mut ParseState);
+    pub fn errorConflictingDefElem(defel: *mut DefElem, pstate: *mut ParseState) -> !;
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -39560,7 +39815,7 @@ impl Default for pg_enc2name {
     }
 }
 extern "C" {
-    pub static mut pg_enc2name_tbl: [pg_enc2name; 0usize];
+    pub static pg_enc2name_tbl: [pg_enc2name; 0usize];
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -39578,7 +39833,7 @@ impl Default for pg_enc2gettext {
     }
 }
 extern "C" {
-    pub static mut pg_enc2gettext_tbl: [pg_enc2gettext; 0usize];
+    pub static pg_enc2gettext_tbl: [pg_enc2gettext; 0usize];
 }
 pub type mb2wchar_with_len_converter = ::std::option::Option<
     unsafe extern "C" fn(
@@ -39627,7 +39882,7 @@ pub struct pg_wchar_tbl {
     pub maxmblen: ::std::os::raw::c_int,
 }
 extern "C" {
-    pub static mut pg_wchar_table: [pg_wchar_tbl; 0usize];
+    pub static pg_wchar_table: [pg_wchar_tbl; 0usize];
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -40088,7 +40343,7 @@ extern "C" {
         encoding: ::std::os::raw::c_int,
         mbstr: *const ::std::os::raw::c_char,
         len: ::std::os::raw::c_int,
-    );
+    ) -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -40097,7 +40352,7 @@ extern "C" {
         dest_encoding: ::std::os::raw::c_int,
         mbstr: *const ::std::os::raw::c_char,
         len: ::std::os::raw::c_int,
-    );
+    ) -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -44432,6 +44687,35 @@ extern "C" {
 extern "C" {
     pub fn get_parse_rowmark(qry: *mut Query, rtindex: Index) -> *mut RowMarkClause;
 }
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn downcase_truncate_identifier(
+        ident: *const ::std::os::raw::c_char,
+        len: ::std::os::raw::c_int,
+        warn: bool,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn downcase_identifier(
+        ident: *const ::std::os::raw::c_char,
+        len: ::std::os::raw::c_int,
+        warn: bool,
+        truncate: bool,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn truncate_identifier(
+        ident: *mut ::std::os::raw::c_char,
+        len: ::std::os::raw::c_int,
+        warn: bool,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn scanner_isspace(ch: ::std::os::raw::c_char) -> bool;
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ExpandedRecordHeader {
@@ -46256,7 +46540,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn plpgsql_yyerror(message: *const ::std::os::raw::c_char);
+    pub fn plpgsql_yyerror(message: *const ::std::os::raw::c_char) -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -47825,7 +48109,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn WalReceiverMain();
+    pub fn WalReceiverMain() -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -48938,7 +49222,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn proc_exit(code: ::std::os::raw::c_int);
+    pub fn proc_exit(code: ::std::os::raw::c_int) -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -48982,6 +49266,194 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn InitializeShmemGUCs();
+}
+pub const XLTW_Oper_XLTW_None: XLTW_Oper = 0;
+pub const XLTW_Oper_XLTW_Update: XLTW_Oper = 1;
+pub const XLTW_Oper_XLTW_Delete: XLTW_Oper = 2;
+pub const XLTW_Oper_XLTW_Lock: XLTW_Oper = 3;
+pub const XLTW_Oper_XLTW_LockUpdated: XLTW_Oper = 4;
+pub const XLTW_Oper_XLTW_InsertIndex: XLTW_Oper = 5;
+pub const XLTW_Oper_XLTW_InsertIndexUnique: XLTW_Oper = 6;
+pub const XLTW_Oper_XLTW_FetchUpdated: XLTW_Oper = 7;
+pub const XLTW_Oper_XLTW_RecheckExclusionConstr: XLTW_Oper = 8;
+pub type XLTW_Oper = ::std::os::raw::c_uint;
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RelationInitLockInfo(relation: Relation);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockRelationOid(relid: Oid, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockRelationId(relid: *mut LockRelId, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ConditionalLockRelationOid(relid: Oid, lockmode: LOCKMODE) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockRelationId(relid: *mut LockRelId, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockRelationOid(relid: Oid, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockRelation(relation: Relation, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ConditionalLockRelation(relation: Relation, lockmode: LOCKMODE) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockRelation(relation: Relation, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn CheckRelationLockedByMe(
+        relation: Relation,
+        lockmode: LOCKMODE,
+        orstronger: bool,
+    ) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockHasWaitersRelation(relation: Relation, lockmode: LOCKMODE) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockRelationIdForSession(relid: *mut LockRelId, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockRelationIdForSession(relid: *mut LockRelId, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockRelationForExtension(relation: Relation, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockRelationForExtension(relation: Relation, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ConditionalLockRelationForExtension(relation: Relation, lockmode: LOCKMODE) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn RelationExtensionLockWaiterCount(relation: Relation) -> ::std::os::raw::c_int;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockDatabaseFrozenIds(lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockPage(relation: Relation, blkno: BlockNumber, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ConditionalLockPage(relation: Relation, blkno: BlockNumber, lockmode: LOCKMODE) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockPage(relation: Relation, blkno: BlockNumber, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockTuple(relation: Relation, tid: ItemPointer, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ConditionalLockTuple(relation: Relation, tid: ItemPointer, lockmode: LOCKMODE) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockTuple(relation: Relation, tid: ItemPointer, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XactLockTableInsert(xid: TransactionId);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XactLockTableDelete(xid: TransactionId);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn XactLockTableWait(xid: TransactionId, rel: Relation, ctid: ItemPointer, oper: XLTW_Oper);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ConditionalXactLockTableWait(xid: TransactionId) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn WaitForLockers(heaplocktag: LOCKTAG, lockmode: LOCKMODE, progress: bool);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn WaitForLockersMultiple(locktags: *mut List, lockmode: LOCKMODE, progress: bool);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SpeculativeInsertionLockAcquire(xid: TransactionId) -> uint32;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SpeculativeInsertionLockRelease(xid: TransactionId);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SpeculativeInsertionWait(xid: TransactionId, token: uint32);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockDatabaseObject(classid: Oid, objid: Oid, objsubid: uint16, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockDatabaseObject(classid: Oid, objid: Oid, objsubid: uint16, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockSharedObject(classid: Oid, objid: Oid, objsubid: uint16, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockSharedObject(classid: Oid, objid: Oid, objsubid: uint16, lockmode: LOCKMODE);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn LockSharedObjectForSession(
+        classid: Oid,
+        objid: Oid,
+        objsubid: uint16,
+        lockmode: LOCKMODE,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn UnlockSharedObjectForSession(
+        classid: Oid,
+        objid: Oid,
+        objsubid: uint16,
+        lockmode: LOCKMODE,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DescribeLockTag(buf: StringInfo, tag: *const LOCKTAG);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetLockNameFromTagType(locktag_type: uint16) -> *const ::std::os::raw::c_char;
 }
 pub const ProcSignalReason_PROCSIG_CATCHUP_INTERRUPT: ProcSignalReason = 0;
 pub const ProcSignalReason_PROCSIG_NOTIFY_INTERRUPT: ProcSignalReason = 1;
@@ -49572,7 +50044,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn quickdie(postgres_signal_arg: ::std::os::raw::c_int);
+    pub fn quickdie(postgres_signal_arg: ::std::os::raw::c_int) -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -49580,7 +50052,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn FloatExceptionHandler(postgres_signal_arg: ::std::os::raw::c_int);
+    pub fn FloatExceptionHandler(postgres_signal_arg: ::std::os::raw::c_int) -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -49609,14 +50081,14 @@ extern "C" {
         argc: ::std::os::raw::c_int,
         argv: *mut *mut ::std::os::raw::c_char,
         username: *const ::std::os::raw::c_char,
-    );
+    ) -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn PostgresMain(
         dbname: *const ::std::os::raw::c_char,
         username: *const ::std::os::raw::c_char,
-    );
+    ) -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -62104,10 +62576,10 @@ impl Default for DynamicZoneAbbrev {
     }
 }
 extern "C" {
-    pub static mut months: [*const ::std::os::raw::c_char; 0usize];
+    pub static months: [*const ::std::os::raw::c_char; 0usize];
 }
 extern "C" {
-    pub static mut days: [*const ::std::os::raw::c_char; 0usize];
+    pub static days: [*const ::std::os::raw::c_char; 0usize];
 }
 extern "C" {
     pub static mut day_tab: [[::std::os::raw::c_int; 13usize]; 2usize];
@@ -62205,7 +62677,7 @@ extern "C" {
         dterr: ::std::os::raw::c_int,
         str_: *const ::std::os::raw::c_char,
         datatype: *const ::std::os::raw::c_char,
-    );
+    ) -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -62346,15 +62818,15 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn float_overflow_error();
+    pub fn float_overflow_error() -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn float_underflow_error();
+    pub fn float_underflow_error() -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn float_zero_divide_error();
+    pub fn float_zero_divide_error() -> !;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {

--- a/pgrx-sql-entity-graph/Cargo.toml
+++ b/pgrx-sql-entity-graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx-sql-entity-graph"
-version = "0.8.4"
+version = "0.9.0"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Sql Entity Graph for `pgrx`"

--- a/pgrx-tests/Cargo.toml
+++ b/pgrx-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx-tests"
-version = "0.8.4"
+version = "0.9.0"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Test framework for 'pgrx'-based Postgres extensions"
@@ -37,8 +37,8 @@ clap-cargo = "0.10.0"
 owo-colors = "3.5.0"
 once_cell = "1.17.1"
 libc = "0.2.144"
-pgrx-macros = { path = "../pgrx-macros", version = "=0.8.4" }
-pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.8.4" }
+pgrx-macros = { path = "../pgrx-macros", version = "=0.9.0" }
+pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.9.0" }
 postgres = "0.19.5"
 regex = "1.8.3"
 serde = "1.0.163"
@@ -53,4 +53,4 @@ eyre = "0.6.8"  # testing functions that return `eyre::Result`
 [dependencies.pgrx]
 path = "../pgrx"
 default-features = false
-version = "=0.8.4"
+version = "=0.9.0"

--- a/pgrx/Cargo.toml
+++ b/pgrx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx"
-version = "0.8.4"
+version = "0.9.0"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "pgrx:  A Rust framework for creating Postgres extensions"
@@ -33,9 +33,9 @@ no-default-features = true
 rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-pgrx-macros = { path = "../pgrx-macros", version = "=0.8.4" }
-pgrx-pg-sys = { path = "../pgrx-pg-sys", version = "=0.8.4" }
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.8.4" }
+pgrx-macros = { path = "../pgrx-macros", version = "=0.9.0" }
+pgrx-pg-sys = { path = "../pgrx-pg-sys", version = "=0.9.0" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.9.0" }
 
 # used to internally impl things
 once_cell = "1.17.1" # polyfill until std::lazy::OnceCell stabilizes


### PR DESCRIPTION
Welcome to `pgrx` v0.9.0.  This is a big release as it brings significantly improved date and time support, which includes some breaking API changes for those types.

When upgrading, make sure to update your `Cargo.toml` files and also `cargo install cargo-pgrx --locked`.


## Improved Date, Time, Interval Support

v0.9.0 adds quite a bit of functionality around `pgrx`' date/time/interval handling (#1139).  The various `Date`, `Time`, `TimeWithTimeZone`, `Timestamp`, `TimestampWithTimeZone`, and `Interval` types can now:
   
   - be constructed through code in various ways
   - converted between each other where approporiate
   - have math operations performed on them (ie, adding a `date + time` results in a `Timestamp`, adding `time + interval` results in a new time, etc)
   - be formatted as strings for display purposes using Postgres output functions
   - be serialized/deserialized with `serde` as ISO-conforming "json" strings using Postgres formatting
   - have their individual parts extracted
   - much more!

In doing this, we've removed the `time-crate` feature flag.  `pgrx` has no plans to continue to support the external `time` crate or even `chronos`.  The new built-in functionality is very complete.  Should more work be required we'd prefer to do it here and rely on Postgres to do the actual date/time math code correctly.

There's also a new example (`pgrx-examples/datetime/`) showing off some of the new capabilities.

## Array Support

Arrays have gotten a little more love.  Arrays of non-null primitive types can now be represented as slices, which can help to drastically improve random access and iteration performance.

* Optimize zero-copy arrays around fixed-size types by @eeeebbbbrrrr in https://github.com/tcdi/pgrx/pull/1145
* Add Array slice support for primitive types (i8/16/32/64, f32/64) by @eeeebbbbrrrr in https://github.com/tcdi/pgrx/pull/1147
* don't free the backing Array Datum pointer on drop, even if it was detoasted by @eeeebbbbrrrr in https://github.com/tcdi/pgrx/pull/1149 (related to issue #971)
* Few small array changes by @thomcc in https://github.com/tcdi/pgrx/pull/1148


## Additional Bindings

* include generic xlog related api by @kemingy in https://github.com/tcdi/pgrx/pull/1135
* Add lock manager related api by @usamoi in https://github.com/tcdi/pgrx/pull/1140

## Stability/Correctness issues

* Within the NUMERIC support code, stop comparing function pointers by @eeeebbbbrrrr in https://github.com/tcdi/pgrx/pull/1138
* fix issue #1141:  immediately report FATAL and PANIC by @eeeebbbbrrrr in https://github.com/tcdi/pgrx/pull/1142
* Fix errant SQL generation for Aggregates by @phlay in https://github.com/tcdi/pgrx/pull/1134

## Testing Framework

* Wait for postmaster.pid during `cargo pgrx test` by @eeeebbbbrrrr in https://github.com/tcdi/pgrx/pull/1150

## Dependencies 

* upgrade all dependencies (except for `syn`) to their latest versions by @eeeebbbbrrrr in https://github.com/tcdi/pgrx/pull/1151

## New Contributors
* @kemingy made their first contribution in https://github.com/tcdi/pgrx/pull/1135
* @usamoi made their first contribution in https://github.com/tcdi/pgrx/pull/1140

**Full Changelog**: https://github.com/tcdi/pgrx/compare/v0.8.4...v0.9.0