### PR TITLE
Update version to 0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,7 +314,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-pgrx"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "atty",
  "cargo_metadata",
@@ -1182,12 +1182,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
 
 [[package]]
 name = "maplit"
@@ -1263,14 +1260,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
- "log",
  "wasi",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1382,15 +1378,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "9670a07f94779e00908f3e686eab508878ebb390ba6e604d3a284c00e8d0487b"
 
 [[package]]
 name = "openssl"
-version = "0.10.52"
+version = "0.10.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b8574602df80f7b85fdfc5392fa884a4e3b3f4f35402c070ab34c3d3f78d56"
+checksum = "12df40a956736488b7b44fe79fe12d4f245bb5b3f5a1f6095e499760015be392"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
@@ -1420,9 +1416,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.87"
+version = "0.9.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e17f59264b2809d77ae94f0e1ebabc434773f370d6ca667bd223ea10e06cc7e"
+checksum = "c2ce0f250f34a308dcfdbb351f511359857d4ed2134ba715a4eadd46e1ffd617"
 dependencies = [
  "cc",
  "libc",
@@ -1527,7 +1523,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "atomic-traits",
  "bitflags 2.3.1",
@@ -1551,7 +1547,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-macros"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "pgrx-sql-entity-graph",
  "proc-macro2",
@@ -1562,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-config"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "cargo_toml",
  "dirs",
@@ -1578,7 +1574,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-sys"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "bindgen",
  "eyre",
@@ -1598,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-sql-entity-graph"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "atty",
  "convert_case",
@@ -1614,7 +1610,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-tests"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "clap-cargo",
  "eyre",
@@ -2518,9 +2514,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.1"
+version = "1.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa32867d44e6f2ce3385e89dceb990188b8bb0fb25b0cf576647a6f98ac5105"
+checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
 dependencies = [
  "autocfg",
  "bytes",

--- a/cargo-pgrx/Cargo.toml
+++ b/cargo-pgrx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pgrx"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Cargo subcommand for 'pgrx' to make Postgres extension development easy"
@@ -23,8 +23,8 @@ semver = "1.0.17"
 owo-colors = { version = "3.5.0", features = [ "supports-colors" ] }
 env_proxy = "0.4.1"
 num_cpus = "1.15.0"
-pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.9.0" }
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.9.0" }
+pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.9.1" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.9.1" }
 prettyplease = "0.2.6"
 proc-macro2 = { version = "1.0.59", features = [ "span-locations" ] }
 quote = "1.0.28"
@@ -40,7 +40,7 @@ unescape = "0.1.0"
 fork = "0.1.21"
 libloading = "0.8.0"
 object = "0.31.1"
-once_cell = "1.17.1"
+once_cell = "1.17.2"
 eyre = "0.6.8"
 color-eyre = "0.6.2"
 tracing = "0.1"

--- a/cargo-pgrx/src/templates/cargo_toml
+++ b/cargo-pgrx/src/templates/cargo_toml
@@ -16,10 +16,10 @@ pg15 = ["pgrx/pg15", "pgrx-tests/pg15" ]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.9.0"
+pgrx = "=0.9.1"
 
 [dev-dependencies]
-pgrx-tests = "=0.9.0"
+pgrx-tests = "=0.9.1"
 
 [profile.dev]
 panic = "unwind"

--- a/nix/templates/default/Cargo.toml
+++ b/nix/templates/default/Cargo.toml
@@ -16,10 +16,10 @@ pg15 = ["pgrx/pg15", "pgrx-tests/pg15" ]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.9.0"
+pgrx = "=0.9.1"
 
 [dev-dependencies]
-pgrx-tests = "=0.9.0"
+pgrx-tests = "=0.9.1"
 tempfile = "3.2.0"
 once_cell = "1.7.2"
 

--- a/pgrx-macros/Cargo.toml
+++ b/pgrx-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx-macros"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Proc Macros for 'pgrx'"
@@ -21,7 +21,7 @@ rustc-args = ["--cfg", "docsrs"]
 no-schema-generation = ["pgrx-sql-entity-graph/no-schema-generation"]
 
 [dependencies]
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.9.0" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.9.1" }
 proc-macro2 = "1.0.59"
 quote = "1.0.28"
 syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsing" ] }

--- a/pgrx-pg-config/Cargo.toml
+++ b/pgrx-pg-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx-pg-config"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "A Postgres pg_config wrapper for 'pgrx'"

--- a/pgrx-pg-sys/Cargo.toml
+++ b/pgrx-pg-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx-pg-sys"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Generated Rust bindings for Postgres internals, for use with 'pgrx'"
@@ -29,8 +29,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 memoffset = "0.9.0"
-pgrx-macros = { path = "../pgrx-macros/", version = "=0.9.0" }
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph/", version = "=0.9.0" }
+pgrx-macros = { path = "../pgrx-macros/", version = "=0.9.1" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph/", version = "=0.9.1" }
 serde = { version = "1.0.163", features = [ "derive" ] } # impls on pub types
 # polyfill until #![feature(strict_provenance)] stabilizes
 sptr = "0.3"
@@ -38,10 +38,10 @@ libc = "0.2"
 
 [build-dependencies]
 bindgen = { version = "0.65.1", default-features = false, features = ["runtime"] }
-pgrx-pg-config= { path = "../pgrx-pg-config/", version = "=0.9.0" }
+pgrx-pg-config= { path = "../pgrx-pg-config/", version = "=0.9.1" }
 proc-macro2 = "1.0.59"
 quote = "1.0.28"
 syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsing" ] }
 eyre = "0.6.8"
 shlex = "1.1.0" # shell lexing, also used by many of our deps
-once_cell = "1.17.1"
+once_cell = "1.17.2"

--- a/pgrx-sql-entity-graph/Cargo.toml
+++ b/pgrx-sql-entity-graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx-sql-entity-graph"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Sql Entity Graph for `pgrx`"

--- a/pgrx-tests/Cargo.toml
+++ b/pgrx-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx-tests"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Test framework for 'pgrx'-based Postgres extensions"
@@ -35,10 +35,10 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 clap-cargo = "0.10.0"
 owo-colors = "3.5.0"
-once_cell = "1.17.1"
+once_cell = "1.17.2"
 libc = "0.2.144"
-pgrx-macros = { path = "../pgrx-macros", version = "=0.9.0" }
-pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.9.0" }
+pgrx-macros = { path = "../pgrx-macros", version = "=0.9.1" }
+pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.9.1" }
 postgres = "0.19.5"
 regex = "1.8.3"
 serde = "1.0.163"
@@ -53,4 +53,4 @@ eyre = "0.6.8"  # testing functions that return `eyre::Result`
 [dependencies.pgrx]
 path = "../pgrx"
 default-features = false
-version = "=0.9.0"
+version = "=0.9.1"

--- a/pgrx/Cargo.toml
+++ b/pgrx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "pgrx:  A Rust framework for creating Postgres extensions"
@@ -33,12 +33,12 @@ no-default-features = true
 rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-pgrx-macros = { path = "../pgrx-macros", version = "=0.9.0" }
-pgrx-pg-sys = { path = "../pgrx-pg-sys", version = "=0.9.0" }
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.9.0" }
+pgrx-macros = { path = "../pgrx-macros", version = "=0.9.1" }
+pgrx-pg-sys = { path = "../pgrx-pg-sys", version = "=0.9.1" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.9.1" }
 
 # used to internally impl things
-once_cell = "1.17.1" # polyfill until std::lazy::OnceCell stabilizes
+once_cell = "1.17.2" # polyfill until std::lazy::OnceCell stabilizes
 seq-macro = "0.3" # impls loops in macros
 uuid = { version = "1.3.3", features = [ "v4" ] } # PgLwLock and shmem
 enum-map = "2.5.0"


### PR DESCRIPTION
This is pgrx v0.9.1.  It's a minor point release.

## What's Changed

* Add --configure-flag option for cargo pgrx init by @ewencp in https://github.com/tcdi/pgrx/pull/1154

`cargo pgrx init` can now accept configure flags to pass to each Postgres version it builds.  This can be helpful for properly configuring other `contrib/` packages that are otherwise installed.

* do some cleanups around `PgHeapTuple` to make it easier to use by @eeeebbbbrrrr in https://github.com/tcdi/pgrx/pull/1153

This adds the ability to construct an empty `PgHeapTuple` from the underlying type Oid.  It also marks one of its constructor functions as `unsafe`.  The latter might be considered a breaking API change, but it's such a minor thing that it's not worth a full semver bump.


**Full Changelog**: https://github.com/tcdi/pgrx/compare/v0.9.0...v0.9.1