### PR TITLE
`PgVarlena` now knows how to be used by `#[derive(PostgresEq/Ord/Hash)]`

### DIFF
--- a/pgrx-examples/operators/src/lib.rs
+++ b/pgrx-examples/operators/src/lib.rs
@@ -11,6 +11,7 @@ use pgrx::prelude::*;
 use pgrx::{opname, pg_operator};
 use serde::{Deserialize, Serialize};
 mod derived;
+mod pgvarlena;
 
 pgrx::pg_module_magic!();
 
@@ -23,4 +24,16 @@ pub struct MyType {
 #[opname(=)]
 fn my_eq(left: MyType, right: MyType) -> bool {
     left == right
+}
+
+#[cfg(test)]
+pub mod pg_test {
+    pub fn setup(_options: Vec<&str>) {
+        // perform one-off initialization when the pg_test framework starts
+    }
+
+    pub fn postgresql_conf_options() -> Vec<&'static str> {
+        // return any postgresql.conf settings that are required for your tests
+        vec![]
+    }
 }

--- a/pgrx-examples/operators/src/pgvarlena.rs
+++ b/pgrx-examples/operators/src/pgvarlena.rs
@@ -49,6 +49,7 @@ pub struct PgVarlenaThing {
 }
 
 impl PgVarlenaThing {
+    #[allow(dead_code)]
     pub fn new(a: u64, b: u64, c: i32, d: [u8; 5]) -> Self {
         Self { a, b, c, d }
     }
@@ -56,13 +57,7 @@ impl PgVarlenaThing {
 
 impl Display for PgVarlenaThing {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.a.to_string())?;
-        f.write_char(';')?;
-        f.write_str(&self.b.to_string())?;
-        f.write_char(';')?;
-        f.write_str(&self.c.to_string())?;
-        f.write_char(';')?;
-        f.write_str(&format!("{:?}", self.d))
+        write!(f, "{};{};{};{:?}", self.a, self.b, self.c, self.d)
     }
 }
 

--- a/pgrx-examples/operators/src/pgvarlena.rs
+++ b/pgrx-examples/operators/src/pgvarlena.rs
@@ -1,0 +1,135 @@
+/*
+Portions Copyright 2019-2021 ZomboDB, LLC.
+Portions Copyright 2021-2022 Technology Concepts & Design, Inc. <support@tcdi.com>
+
+All rights reserved.
+
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
+use pgrx::prelude::*;
+use pgrx::StringInfo;
+use serde::{Deserialize, Serialize};
+use std::ffi::CStr;
+use std::fmt::{Display, Formatter, Write};
+
+/// standard Rust equality/comparison derives
+#[derive(Eq, PartialEq, Ord, Hash, PartialOrd)]
+
+/// Support using this struct as a Postgres type, which the easy way requires Serde
+#[derive(PostgresType, Serialize, Deserialize)]
+
+/// automatically generate =, <> SQL operator functions
+#[derive(PostgresEq)]
+
+/// automatically generate <, >, <=, >=, and a "_cmp" SQL functions
+/// When "PostgresEq" is also derived, pgrx also creates an "opclass" (and family)
+/// so that the type can be used in indexes `USING btree`
+#[derive(PostgresOrd)]
+
+/// automatically generate a "_hash" function, and the necessary "opclass" (and family)
+/// so the type can also be used in indexes `USING hash`
+#[derive(PostgresHash)]
+
+/// Necessary derives for generally working with [`PgVarlena`]
+#[derive(Copy, Clone)]
+
+/// For unit tests
+#[derive(Debug)]
+
+/// we want this to look like a C struct
+#[repr(C)]
+
+/// Indicate to `#[derive(PostgresType)]` that we'll write our own input and output function
+#[pgvarlena_inoutfuncs]
+pub struct PgVarlenaThing {
+    a: u64,
+    b: u64,
+    c: i32,
+    d: [u8; 5],
+}
+
+impl PgVarlenaThing {
+    pub fn new(a: u64, b: u64, c: i32, d: [u8; 5]) -> Self {
+        Self { a, b, c, d }
+    }
+}
+
+impl Display for PgVarlenaThing {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.a.to_string())?;
+        f.write_char(';')?;
+        f.write_str(&self.b.to_string())?;
+        f.write_char(';')?;
+        f.write_str(&self.c.to_string())?;
+        f.write_char(';')?;
+        f.write_str(&format!("{:?}", self.d))
+    }
+}
+
+// implement function to parse string representation of this type and a function to convert it
+// to a string
+impl PgVarlenaInOutFuncs for PgVarlenaThing {
+    fn input(input: &CStr) -> PgVarlena<Self>
+    where
+        Self: Copy + Sized,
+    {
+        let s = input.to_str().unwrap();
+        let mut result: PgVarlena<PgVarlenaThing> = PgVarlena::new();
+
+        // parsing a string in this format:  1;2;3;[1,2,3,4,5]
+
+        let mut parts = s.split(';');
+        result.a = parts.next().unwrap().parse().unwrap();
+        result.b = parts.next().unwrap().parse().unwrap();
+        result.c = parts.next().unwrap().parse().unwrap();
+
+        let d = parts.next().unwrap();
+        let d = d.trim_start_matches('[');
+        let d = d.trim_end_matches(']');
+        let d = d.split(',').map(|e| e.parse().unwrap()).collect::<Vec<u8>>();
+        result.d = [d[0], d[1], d[2], d[3], d[4]];
+        result
+    }
+
+    fn output(&self, buffer: &mut StringInfo) {
+        buffer.write_fmt(format_args!("{}", self)).unwrap()
+    }
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    use crate::pgvarlena::PgVarlenaThing;
+    use pgrx::prelude::*;
+    use std::error::Error;
+
+    #[pg_test]
+    fn test_varlena_thing() -> Result<(), Box<dyn Error>> {
+        let thing = Spi::get_one::<PgVarlena<PgVarlenaThing>>(
+            "SELECT '1;2;3;[1,2,3,4,5]'::pgvarlenathing",
+        )?
+        .unwrap();
+
+        assert_eq!(thing.as_ref(), &PgVarlenaThing::new(1, 2, 3, [1, 2, 3, 4, 5]));
+
+        let lt = Spi::get_one::<bool>(
+            "SELECT '1;2;3;[1,2,3,4,5]'::pgvarlenathing < '2;2;3;[1,2,3,4,5]'::pgvarlenathing",
+        )?
+        .unwrap();
+        assert_eq!(lt, true);
+
+        let gt = Spi::get_one::<bool>(
+            "SELECT '2;2;3;[1,2,3,4,5]'::pgvarlenathing > '1;2;3;[1,2,3,4,5]'::pgvarlenathing",
+        )?
+        .unwrap();
+        assert_eq!(gt, true);
+
+        let eq = Spi::get_one::<bool>(
+            "SELECT '1;2;3;[1,2,3,4,5]'::pgvarlenathing = '1;2;3;[1,2,3,4,5]'::pgvarlenathing",
+        )?
+        .unwrap();
+        assert_eq!(eq, true);
+
+        Ok(())
+    }
+}

--- a/pgrx-macros/src/operators.rs
+++ b/pgrx-macros/src/operators.rs
@@ -8,27 +8,40 @@ Use of this source code is governed by the MIT license that can be found in the 
 */
 use pgrx_sql_entity_graph::{PostgresHash, PostgresOrd};
 
+use crate::{parse_postgres_type_args, PostgresTypeAttribute};
 use proc_macro2::Ident;
 use quote::{quote, ToTokens};
 use syn::DeriveInput;
 
+fn ident_and_type_path(ast: &DeriveInput) -> (&Ident, proc_macro2::TokenStream) {
+    let ident = &ast.ident;
+    let args = parse_postgres_type_args(&ast.attrs);
+    let type_path = if args.contains(&PostgresTypeAttribute::PgVarlenaInOutFuncs) {
+        quote! { ::pgrx::datum::PgVarlena<#ident> }
+    } else {
+        quote! { #ident }
+    };
+    (ident, type_path)
+}
+
 pub(crate) fn impl_postgres_eq(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
     let mut stream = proc_macro2::TokenStream::new();
-
-    stream.extend(eq(&ast.ident));
-    stream.extend(ne(&ast.ident));
+    let (ident, type_path) = ident_and_type_path(&ast);
+    stream.extend(eq(ident, &type_path));
+    stream.extend(ne(ident, &type_path));
 
     Ok(stream)
 }
 
 pub(crate) fn impl_postgres_ord(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
     let mut stream = proc_macro2::TokenStream::new();
+    let (ident, type_path) = ident_and_type_path(&ast);
 
-    stream.extend(lt(&ast.ident));
-    stream.extend(gt(&ast.ident));
-    stream.extend(le(&ast.ident));
-    stream.extend(ge(&ast.ident));
-    stream.extend(cmp(&ast.ident));
+    stream.extend(lt(ident, &type_path));
+    stream.extend(gt(ident, &type_path));
+    stream.extend(le(ident, &type_path));
+    stream.extend(ge(ident, &type_path));
+    stream.extend(cmp(ident, &type_path));
 
     let sql_graph_entity_item = PostgresOrd::from_derive_input(ast)?;
     sql_graph_entity_item.to_tokens(&mut stream);
@@ -38,8 +51,9 @@ pub(crate) fn impl_postgres_ord(ast: DeriveInput) -> syn::Result<proc_macro2::To
 
 pub(crate) fn impl_postgres_hash(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
     let mut stream = proc_macro2::TokenStream::new();
+    let (ident, type_path) = ident_and_type_path(&ast);
 
-    stream.extend(hash(&ast.ident));
+    stream.extend(hash(ident, &type_path));
 
     let sql_graph_entity_item = PostgresHash::from_derive_input(ast)?;
     sql_graph_entity_item.to_tokens(&mut stream);
@@ -47,7 +61,7 @@ pub(crate) fn impl_postgres_hash(ast: DeriveInput) -> syn::Result<proc_macro2::T
     Ok(stream)
 }
 
-pub fn eq(type_name: &Ident) -> proc_macro2::TokenStream {
+pub fn eq(type_name: &Ident, type_path: &proc_macro2::TokenStream) -> proc_macro2::TokenStream {
     let pg_name = Ident::new(&format!("{}_eq", type_name).to_lowercase(), type_name.span());
     quote! {
         #[allow(non_snake_case)]
@@ -58,13 +72,13 @@ pub fn eq(type_name: &Ident) -> proc_macro2::TokenStream {
         #[::pgrx::pgrx_macros::join(eqjoinsel)]
         #[::pgrx::pgrx_macros::merges]
         #[::pgrx::pgrx_macros::hashes]
-        fn #pg_name(left: #type_name, right: #type_name) -> bool {
+        fn #pg_name(left: #type_path, right: #type_path) -> bool {
             left == right
         }
     }
 }
 
-pub fn ne(type_name: &Ident) -> proc_macro2::TokenStream {
+pub fn ne(type_name: &Ident, type_path: &proc_macro2::TokenStream) -> proc_macro2::TokenStream {
     let pg_name = Ident::new(&format!("{}_ne", type_name).to_lowercase(), type_name.span());
     quote! {
         #[allow(non_snake_case)]
@@ -73,13 +87,13 @@ pub fn ne(type_name: &Ident) -> proc_macro2::TokenStream {
         #[::pgrx::pgrx_macros::negator(=)]
         #[::pgrx::pgrx_macros::restrict(neqsel)]
         #[::pgrx::pgrx_macros::join(neqjoinsel)]
-        fn #pg_name(left: #type_name, right: #type_name) -> bool {
+        fn #pg_name(left: #type_path, right: #type_path) -> bool {
             left != right
         }
     }
 }
 
-pub fn lt(type_name: &Ident) -> proc_macro2::TokenStream {
+pub fn lt(type_name: &Ident, type_path: &proc_macro2::TokenStream) -> proc_macro2::TokenStream {
     let pg_name = Ident::new(&format!("{}_lt", type_name).to_lowercase(), type_name.span());
     quote! {
         #[allow(non_snake_case)]
@@ -89,14 +103,14 @@ pub fn lt(type_name: &Ident) -> proc_macro2::TokenStream {
         #[::pgrx::pgrx_macros::commutator(>)]
         #[::pgrx::pgrx_macros::restrict(scalarltsel)]
         #[::pgrx::pgrx_macros::join(scalarltjoinsel)]
-        fn #pg_name(left: #type_name, right: #type_name) -> bool {
+        fn #pg_name(left: #type_path, right: #type_path) -> bool {
             left < right
         }
 
     }
 }
 
-pub fn gt(type_name: &Ident) -> proc_macro2::TokenStream {
+pub fn gt(type_name: &Ident, type_path: &proc_macro2::TokenStream) -> proc_macro2::TokenStream {
     let pg_name = Ident::new(&format!("{}_gt", type_name).to_lowercase(), type_name.span());
     quote! {
         #[allow(non_snake_case)]
@@ -106,13 +120,13 @@ pub fn gt(type_name: &Ident) -> proc_macro2::TokenStream {
         #[::pgrx::pgrx_macros::commutator(<)]
         #[::pgrx::pgrx_macros::restrict(scalargtsel)]
         #[::pgrx::pgrx_macros::join(scalargtjoinsel)]
-        fn #pg_name(left: #type_name, right: #type_name) -> bool {
+        fn #pg_name(left: #type_path, right: #type_path) -> bool {
             left > right
         }
     }
 }
 
-pub fn le(type_name: &Ident) -> proc_macro2::TokenStream {
+pub fn le(type_name: &Ident, type_path: &proc_macro2::TokenStream) -> proc_macro2::TokenStream {
     let pg_name = Ident::new(&format!("{}_le", type_name).to_lowercase(), type_name.span());
     quote! {
         #[allow(non_snake_case)]
@@ -122,13 +136,13 @@ pub fn le(type_name: &Ident) -> proc_macro2::TokenStream {
         #[::pgrx::pgrx_macros::commutator(>=)]
         #[::pgrx::pgrx_macros::restrict(scalarlesel)]
         #[::pgrx::pgrx_macros::join(scalarlejoinsel)]
-        fn #pg_name(left: #type_name, right: #type_name) -> bool {
+        fn #pg_name(left: #type_path, right: #type_path) -> bool {
             left <= right
         }
     }
 }
 
-pub fn ge(type_name: &Ident) -> proc_macro2::TokenStream {
+pub fn ge(type_name: &Ident, type_path: &proc_macro2::TokenStream) -> proc_macro2::TokenStream {
     let pg_name = Ident::new(&format!("{}_ge", type_name).to_lowercase(), type_name.span());
     quote! {
         #[allow(non_snake_case)]
@@ -138,29 +152,29 @@ pub fn ge(type_name: &Ident) -> proc_macro2::TokenStream {
         #[::pgrx::pgrx_macros::commutator(<=)]
         #[::pgrx::pgrx_macros::restrict(scalargesel)]
         #[::pgrx::pgrx_macros::join(scalargejoinsel)]
-        fn #pg_name(left: #type_name, right: #type_name) -> bool {
+        fn #pg_name(left: #type_path, right: #type_path) -> bool {
             left >= right
         }
     }
 }
 
-pub fn cmp(type_name: &Ident) -> proc_macro2::TokenStream {
+pub fn cmp(type_name: &Ident, type_path: &proc_macro2::TokenStream) -> proc_macro2::TokenStream {
     let pg_name = Ident::new(&format!("{}_cmp", type_name).to_lowercase(), type_name.span());
     quote! {
         #[allow(non_snake_case)]
         #[::pgrx::pgrx_macros::pg_extern(immutable, parallel_safe)]
-        fn #pg_name(left: #type_name, right: #type_name) -> i32 {
+        fn #pg_name(left: #type_path, right: #type_path) -> i32 {
             left.cmp(&right) as i32
         }
     }
 }
 
-pub fn hash(type_name: &Ident) -> proc_macro2::TokenStream {
+pub fn hash(type_name: &Ident, type_path: &proc_macro2::TokenStream) -> proc_macro2::TokenStream {
     let pg_name = Ident::new(&format!("{}_hash", type_name).to_lowercase(), type_name.span());
     quote! {
         #[allow(non_snake_case)]
         #[::pgrx::pgrx_macros::pg_extern(immutable, parallel_safe)]
-        fn #pg_name(value: #type_name) -> i32 {
+        fn #pg_name(value: #type_path) -> i32 {
             ::pgrx::misc::pgrx_seahash(&value) as i32
         }
     }

--- a/pgrx/src/datum/varlena.rs
+++ b/pgrx/src/datum/varlena.rs
@@ -19,6 +19,8 @@ use pgrx_sql_entity_graph::metadata::{
 };
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
+use std::cmp::Ordering;
+use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 
@@ -213,6 +215,47 @@ where
         if let Some(leaked) = self.leaked {
             unsafe { drop(Box::from_raw(leaked)) }
         }
+    }
+}
+
+impl<T> Eq for PgVarlena<T> where T: Eq + Copy + Sized {}
+impl<T> PartialEq for PgVarlena<T>
+where
+    T: PartialEq + Copy + Sized,
+{
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.as_ref() == other.as_ref()
+    }
+}
+
+impl<T> Ord for PgVarlena<T>
+where
+    T: Ord + Copy + Sized,
+{
+    #[inline]
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.as_ref().cmp(other.as_ref())
+    }
+}
+
+impl<T> PartialOrd for PgVarlena<T>
+where
+    T: Ord + Copy + Sized,
+{
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.as_ref().cmp(other.as_ref()))
+    }
+}
+
+impl<T> Hash for PgVarlena<T>
+where
+    T: Hash + Copy + Sized,
+{
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.as_ref().hash(state)
     }
 }
 

--- a/pgrx/src/stringinfo.rs
+++ b/pgrx/src/stringinfo.rs
@@ -46,6 +46,13 @@ impl<AllocatedBy: WhoAllocated> std::io::Write for StringInfo<AllocatedBy> {
     }
 }
 
+impl<AllocatedBy: WhoAllocated> std::fmt::Write for StringInfo<AllocatedBy> {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        self.push_str(s);
+        Ok(())
+    }
+}
+
 impl<AllocatedBy: WhoAllocated> Display for StringInfo<AllocatedBy> {
     /// Convert this [`StringInfo`] into a Rust string.  This uses [`String::from_utf8_lossy`] as
     /// it's fine for a Postgres [`StringInfo`] to contain null bytes and also not even be proper


### PR DESCRIPTION
The `PgVarlena` type was lacking some trait impls for doing proper comparisions of the `T` it wraps.  Additionally, the macros that implement the PostgresEq/Ord/Hash operators didn't know about `PgVarlena` and were emitting incorrect Rust wrappers.

Add a new example in `pgrx-examples/operators/src/pgverlena.rs` with a unit test.

As a drive-by, `impl std::fmt::Write for StringInfo` (in `stringinfo.rs`).