### PR TITLE
Update version to 0.9.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide 0.6.2",
- "object 0.30.3",
+ "object 0.30.4",
  "rustc-demangle",
 ]
 
@@ -314,7 +314,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-pgrx"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "atty",
  "cargo_metadata",
@@ -420,9 +420,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.1"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ed2379f8603fa2b7509891660e802b88c70a79a6427a70abb5968054de2c28"
+checksum = "401a4694d2bf92537b6867d94de48c4842089645fdcdf6c71865b175d836e9c2"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -457,9 +457,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.3.1"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e9ef9a08ee1c0e1f2e162121665ac45ac3783b0f897db7244ae75ad9a8f65b"
+checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -830,9 +830,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "fork"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf4b001d25ec51f755157ecffa208b342747ea9a4365df5438b12925c7f0056"
+checksum = "bf2ca97a59201425e7ee4d197c9c4fea282fe87a97d666a580bda889b95b8e88"
 dependencies = [
  "libc",
 ]
@@ -918,9 +918,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1105,9 +1105,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.145"
+version = "0.2.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc86cde3ff845662b8f4ef6cb50ea0e20c524eb3d29ae048287e06a1b3fa6a81"
+checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
 name = "libflate"
@@ -1172,9 +1172,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "lock_api"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1358,9 +1358,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.30.3"
+version = "0.30.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
+checksum = "03b4680b86d9cfafba8fc491dc9b6df26b68cf40e9e6cd73909194759a63c385"
 dependencies = [
  "memchr",
 ]
@@ -1468,15 +1468,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.2.16",
+ "redox_syscall 0.3.5",
  "smallvec",
- "windows-sys 0.45.0",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1523,7 +1523,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "atomic-traits",
  "bitflags 2.3.1",
@@ -1547,7 +1547,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-macros"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "pgrx-sql-entity-graph",
  "proc-macro2",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-config"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "cargo_toml",
  "dirs",
@@ -1574,7 +1574,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-sys"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "bindgen",
  "eyre",
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-sql-entity-graph"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "atty",
  "convert_case",
@@ -1610,7 +1610,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-tests"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "clap-cargo",
  "eyre",
@@ -2398,9 +2398,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02f1dc6930a439cc5d154221b5387d153f8183529b07c19aca24ea31e0a167e1"
+checksum = "c72130613601f6aad275f8bb9a1d4bf953df8e9c7891029f30e5fdc405ad07c4"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
@@ -2419,15 +2419,16 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.5.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
 dependencies = [
+ "autocfg",
  "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
  "rustix",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2965,35 +2966,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.0",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
+ "windows-targets",
 ]
 
 [[package]]

--- a/cargo-pgrx/Cargo.toml
+++ b/cargo-pgrx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pgrx"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Cargo subcommand for 'pgrx' to make Postgres extension development easy"
@@ -17,14 +17,14 @@ edition = "2021"
 atty = "0.2.14"
 cargo_metadata = "0.15.4"
 cargo_toml = "0.15.3"
-clap = { version = "4.3.1", features = [ "env", "suggestions", "cargo", "derive", "wrap_help" ] }
+clap = { version = "4.3.2", features = [ "env", "suggestions", "cargo", "derive", "wrap_help" ] }
 clap-cargo = { version = "0.10.0", features = [ "cargo_metadata" ] }
 semver = "1.0.17"
 owo-colors = { version = "3.5.0", features = [ "supports-colors" ] }
 env_proxy = "0.4.1"
 num_cpus = "1.15.0"
-pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.9.2" }
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.9.2" }
+pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.9.3" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.9.3" }
 prettyplease = "0.2.6"
 proc-macro2 = { version = "1.0.59", features = [ "span-locations" ] }
 quote = "1.0.28"
@@ -37,7 +37,7 @@ serde_derive = "1.0.163"
 serde-xml-rs = "0.6.0"
 syn = { version = "2.0.18", features = [ "extra-traits", "full", "fold", "parsing" ] }
 unescape = "0.1.0"
-fork = "0.1.21"
+fork = "0.1.22"
 libloading = "0.8.0"
 object = "0.31.1"
 once_cell = "1.18.0"
@@ -47,7 +47,7 @@ tracing = "0.1"
 tracing-error = "0.2.0"
 tracing-subscriber = { version = "0.3.17", features = [ "env-filter" ] }
 flate2 = { version = "1.0.26", default-features = false, features = ["rust_backend"] }
-tempfile = "3.5.0"
+tempfile = "3.6.0"
 nix = { version = "0.26", default-features = false, features = ["user"] }
 
 [features]

--- a/cargo-pgrx/src/templates/cargo_toml
+++ b/cargo-pgrx/src/templates/cargo_toml
@@ -16,10 +16,10 @@ pg15 = ["pgrx/pg15", "pgrx-tests/pg15" ]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.9.2"
+pgrx = "=0.9.3"
 
 [dev-dependencies]
-pgrx-tests = "=0.9.2"
+pgrx-tests = "=0.9.3"
 
 [profile.dev]
 panic = "unwind"

--- a/nix/templates/default/Cargo.toml
+++ b/nix/templates/default/Cargo.toml
@@ -16,10 +16,10 @@ pg15 = ["pgrx/pg15", "pgrx-tests/pg15" ]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.9.2"
+pgrx = "=0.9.3"
 
 [dev-dependencies]
-pgrx-tests = "=0.9.2"
+pgrx-tests = "=0.9.3"
 tempfile = "3.2.0"
 once_cell = "1.7.2"
 

--- a/pgrx-macros/Cargo.toml
+++ b/pgrx-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx-macros"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Proc Macros for 'pgrx'"
@@ -21,7 +21,7 @@ rustc-args = ["--cfg", "docsrs"]
 no-schema-generation = ["pgrx-sql-entity-graph/no-schema-generation"]
 
 [dependencies]
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.9.2" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.9.3" }
 proc-macro2 = "1.0.59"
 quote = "1.0.28"
 syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsing" ] }

--- a/pgrx-pg-config/Cargo.toml
+++ b/pgrx-pg-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx-pg-config"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "A Postgres pg_config wrapper for 'pgrx'"

--- a/pgrx-pg-sys/Cargo.toml
+++ b/pgrx-pg-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx-pg-sys"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Generated Rust bindings for Postgres internals, for use with 'pgrx'"
@@ -29,8 +29,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 memoffset = "0.9.0"
-pgrx-macros = { path = "../pgrx-macros/", version = "=0.9.2" }
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph/", version = "=0.9.2" }
+pgrx-macros = { path = "../pgrx-macros/", version = "=0.9.3" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph/", version = "=0.9.3" }
 serde = { version = "1.0.163", features = [ "derive" ] } # impls on pub types
 # polyfill until #![feature(strict_provenance)] stabilizes
 sptr = "0.3"
@@ -38,7 +38,7 @@ libc = "0.2"
 
 [build-dependencies]
 bindgen = { version = "0.65.1", default-features = false, features = ["runtime"] }
-pgrx-pg-config= { path = "../pgrx-pg-config/", version = "=0.9.2" }
+pgrx-pg-config= { path = "../pgrx-pg-config/", version = "=0.9.3" }
 proc-macro2 = "1.0.59"
 quote = "1.0.28"
 syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsing" ] }

--- a/pgrx-sql-entity-graph/Cargo.toml
+++ b/pgrx-sql-entity-graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx-sql-entity-graph"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Sql Entity Graph for `pgrx`"

--- a/pgrx-tests/Cargo.toml
+++ b/pgrx-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx-tests"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Test framework for 'pgrx'-based Postgres extensions"
@@ -36,14 +36,14 @@ rustdoc-args = ["--cfg", "docsrs"]
 clap-cargo = "0.10.0"
 owo-colors = "3.5.0"
 once_cell = "1.18.0"
-libc = "0.2.145"
-pgrx-macros = { path = "../pgrx-macros", version = "=0.9.2" }
-pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.9.2" }
+libc = "0.2.146"
+pgrx-macros = { path = "../pgrx-macros", version = "=0.9.3" }
+pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.9.3" }
 postgres = "0.19.5"
 regex = "1.8.4"
 serde = "1.0.163"
 serde_json = "1.0.96"
-sysinfo = "0.29.0"
+sysinfo = "0.29.1"
 eyre = "0.6.8"
 thiserror = "1.0"
 
@@ -53,4 +53,4 @@ eyre = "0.6.8"  # testing functions that return `eyre::Result`
 [dependencies.pgrx]
 path = "../pgrx"
 default-features = false
-version = "=0.9.2"
+version = "=0.9.3"

--- a/pgrx-version-updater/Cargo.toml
+++ b/pgrx-version-updater/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 description = "Standalone tool to update PGRX Cargo.toml versions and dependencies in preparation for a release."
 
 [dependencies]
-clap = { version = "4.3.1", features = [ "env", "derive" ] }
+clap = { version = "4.3.2", features = [ "env", "derive" ] }
 owo-colors = "3.5.0"
 toml_edit = { version = "0.19.10" }
 walkdir = "2"

--- a/pgrx/Cargo.toml
+++ b/pgrx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "pgrx:  A Rust framework for creating Postgres extensions"
@@ -33,9 +33,9 @@ no-default-features = true
 rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-pgrx-macros = { path = "../pgrx-macros", version = "=0.9.2" }
-pgrx-pg-sys = { path = "../pgrx-pg-sys", version = "=0.9.2" }
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.9.2" }
+pgrx-macros = { path = "../pgrx-macros", version = "=0.9.3" }
+pgrx-pg-sys = { path = "../pgrx-pg-sys", version = "=0.9.3" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.9.3" }
 
 # used to internally impl things
 once_cell = "1.18.0" # polyfill until std::lazy::OnceCell stabilizes
@@ -51,7 +51,7 @@ atomic-traits = "0.3.0" # PgAtomic and shmem init
 bitflags = "2.3.1" # BackgroundWorker
 bitvec = "1.0" # processing array nullbitmaps
 heapless = "0.7.16" # shmem and PgLwLock
-libc = "0.2.145" # FFI type compat
+libc = "0.2.146" # FFI type compat
 seahash = "4.1.0" # derive(PostgresHash)
 serde = { version = "1.0.163", features = [ "derive" ] } # impls on pub types
 serde_cbor = "0.11.2" # derive(PostgresType)


### PR DESCRIPTION
pgrx v0.9.3 is a minor update that resolves some issues with the relatively new zero-copy array support.  There are no user-facing changes in this release.

As always, please install it with `cargo install cargo-pgrx --locked` and update your dependencies accordingly.

## What's Changed

* Teach `Array` how to work with Arrays of arbitrary fixed-sizes that are also pass-by-value by @eeeebbbbrrrr in https://github.com/tcdi/pgrx/pull/1161
* Simplify and fix some correctness issues with fixed-size byval arrays by @thomcc in https://github.com/tcdi/pgrx/pull/1162


**Full Changelog**: https://github.com/tcdi/pgrx/compare/v0.9.2...v0.9.3
