### PR TITLE
Update version to 0.9.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1541,7 +1541,6 @@ dependencies = [
  "serde_cbor",
  "serde_json",
  "thiserror",
- "time",
  "uuid",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,7 +314,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-pgrx"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "atty",
  "cargo_metadata",
@@ -1523,7 +1523,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "atomic-traits",
  "bitflags 2.3.1",
@@ -1547,7 +1547,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-macros"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "pgrx-sql-entity-graph",
  "proc-macro2",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-config"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "cargo_toml",
  "dirs",
@@ -1574,7 +1574,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-sys"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "bindgen",
  "eyre",
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-sql-entity-graph"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "atty",
  "convert_case",
@@ -1610,7 +1610,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-tests"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "clap-cargo",
  "eyre",
@@ -1757,9 +1757,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
+checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
 dependencies = [
  "unicode-ident",
 ]
@@ -2116,9 +2116,9 @@ checksum = "e6b44e8fc93a14e66336d230954dda83d18b4605ccace8fe09bc7514a71ad0bc"
 
 [[package]]
 name = "serde"
-version = "1.0.163"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
+checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
 dependencies = [
  "serde_derive",
 ]
@@ -2147,9 +2147,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.163"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
+checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2398,9 +2398,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.29.1"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c72130613601f6aad275f8bb9a1d4bf953df8e9c7891029f30e5fdc405ad07c4"
+checksum = "9557d0845b86eea8182f7b10dff120214fb6cd9fd937b6f4917714e546a38695"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
@@ -2473,9 +2473,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.21"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
+checksum = "ea9e1b3cf1243ae005d9e74085d4d542f3125458f3a81af210d901dcd7411efd"
 dependencies = [
  "itoa",
  "serde",

--- a/cargo-pgrx/Cargo.toml
+++ b/cargo-pgrx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pgrx"
-version = "0.9.3"
+version = "0.9.4"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Cargo subcommand for 'pgrx' to make Postgres extension development easy"
@@ -23,17 +23,17 @@ semver = "1.0.17"
 owo-colors = { version = "3.5.0", features = [ "supports-colors" ] }
 env_proxy = "0.4.1"
 num_cpus = "1.15.0"
-pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.9.3" }
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.9.3" }
+pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.9.4" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.9.4" }
 prettyplease = "0.2.6"
-proc-macro2 = { version = "1.0.59", features = [ "span-locations" ] }
+proc-macro2 = { version = "1.0.60", features = [ "span-locations" ] }
 quote = "1.0.28"
 rayon = "1.7.0"
 regex = "1.8.4"
 ureq = "2.6.2"
 url = "2.4.0"
-serde = { version = "1.0.163", features = [ "derive" ] }
-serde_derive = "1.0.163"
+serde = { version = "1.0.164", features = [ "derive" ] }
+serde_derive = "1.0.164"
 serde-xml-rs = "0.6.0"
 syn = { version = "2.0.18", features = [ "extra-traits", "full", "fold", "parsing" ] }
 unescape = "0.1.0"

--- a/cargo-pgrx/src/templates/cargo_toml
+++ b/cargo-pgrx/src/templates/cargo_toml
@@ -16,10 +16,10 @@ pg15 = ["pgrx/pg15", "pgrx-tests/pg15" ]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.9.3"
+pgrx = "=0.9.4"
 
 [dev-dependencies]
-pgrx-tests = "=0.9.3"
+pgrx-tests = "=0.9.4"
 
 [profile.dev]
 panic = "unwind"

--- a/nix/templates/default/Cargo.toml
+++ b/nix/templates/default/Cargo.toml
@@ -16,10 +16,10 @@ pg15 = ["pgrx/pg15", "pgrx-tests/pg15" ]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.9.3"
+pgrx = "=0.9.4"
 
 [dev-dependencies]
-pgrx-tests = "=0.9.3"
+pgrx-tests = "=0.9.4"
 tempfile = "3.2.0"
 once_cell = "1.7.2"
 

--- a/pgrx-examples/aggregate/Cargo.toml
+++ b/pgrx-examples/aggregate/Cargo.toml
@@ -18,7 +18,7 @@ bob = []
 
 [dependencies]
 pgrx = { path = "../../pgrx", default-features = false }
-serde = "1.0.163"
+serde = "1.0.164"
 
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }

--- a/pgrx-examples/arrays/Cargo.toml
+++ b/pgrx-examples/arrays/Cargo.toml
@@ -17,7 +17,7 @@ pg_test = []
 
 [dependencies]
 pgrx = { path = "../../pgrx", default-features = false }
-serde = "1.0.163"
+serde = "1.0.164"
 rand = "*"
 
 [dev-dependencies]

--- a/pgrx-examples/composite_type/Cargo.toml
+++ b/pgrx-examples/composite_type/Cargo.toml
@@ -17,7 +17,7 @@ pg_test = []
 
 [dependencies]
 pgrx = { path = "../../pgrx", default-features = false }
-serde = "1.0.163"
+serde = "1.0.164"
 
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }

--- a/pgrx-examples/custom_sql/Cargo.toml
+++ b/pgrx-examples/custom_sql/Cargo.toml
@@ -17,7 +17,7 @@ pg_test = []
 
 [dependencies]
 pgrx = { path = "../../pgrx", default-features = false }
-serde = "1.0.163"
+serde = "1.0.164"
 
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }

--- a/pgrx-examples/custom_types/Cargo.toml
+++ b/pgrx-examples/custom_types/Cargo.toml
@@ -19,7 +19,7 @@ no-schema-generation = [ "pgrx/no-schema-generation", "pgrx-tests/no-schema-gene
 [dependencies]
 pgrx = { path = "../../pgrx", default-features = false }
 maplit = "1.0.2"
-serde = "1.0.163"
+serde = "1.0.164"
 
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }

--- a/pgrx-examples/nostd/Cargo.toml
+++ b/pgrx-examples/nostd/Cargo.toml
@@ -17,7 +17,7 @@ pg_test = []
 
 [dependencies]
 pgrx = { path = "../../pgrx", default-features = false }
-serde = "1.0.163"
+serde = "1.0.164"
 
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }

--- a/pgrx-examples/operators/Cargo.toml
+++ b/pgrx-examples/operators/Cargo.toml
@@ -17,7 +17,7 @@ pg_test = []
 
 [dependencies]
 pgrx = { path = "../../pgrx", default-features = false }
-serde = "1.0.163"
+serde = "1.0.164"
 
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }

--- a/pgrx-examples/schemas/Cargo.toml
+++ b/pgrx-examples/schemas/Cargo.toml
@@ -17,7 +17,7 @@ pg_test = []
 
 [dependencies]
 pgrx = { path = "../../pgrx", default-features = false }
-serde = "1.0.163"
+serde = "1.0.164"
 
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }

--- a/pgrx-examples/shmem/Cargo.toml
+++ b/pgrx-examples/shmem/Cargo.toml
@@ -18,7 +18,7 @@ pg_test = []
 [dependencies]
 heapless = "0.7.16"
 pgrx = { path = "../../pgrx", default-features = false }
-serde = { version = "1.0.163", features = [ "derive" ] }
+serde = { version = "1.0.164", features = [ "derive" ] }
 
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }

--- a/pgrx-macros/Cargo.toml
+++ b/pgrx-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx-macros"
-version = "0.9.3"
+version = "0.9.4"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Proc Macros for 'pgrx'"
@@ -21,10 +21,10 @@ rustc-args = ["--cfg", "docsrs"]
 no-schema-generation = ["pgrx-sql-entity-graph/no-schema-generation"]
 
 [dependencies]
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.9.3" }
-proc-macro2 = "1.0.59"
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.9.4" }
+proc-macro2 = "1.0.60"
 quote = "1.0.28"
 syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsing" ] }
 
 [dev-dependencies]
-serde = { version = "1.0.163", features = ["derive"] } # for Documentation examples
+serde = { version = "1.0.164", features = ["derive"] } # for Documentation examples

--- a/pgrx-pg-config/Cargo.toml
+++ b/pgrx-pg-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx-pg-config"
-version = "0.9.3"
+version = "0.9.4"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "A Postgres pg_config wrapper for 'pgrx'"
@@ -17,8 +17,8 @@ dirs = "5.0.1"
 eyre = "0.6.8"
 pathsearch = "0.2.0"
 owo-colors = "3.5.0"
-serde = { version = "1.0.163", features = [ "derive" ] }
-serde_derive = "1.0.163"
+serde = { version = "1.0.164", features = [ "derive" ] }
+serde_derive = "1.0.164"
 serde_json = "1.0.96"
 toml = "0.7.4"
 url = "2.4.0"

--- a/pgrx-pg-sys/Cargo.toml
+++ b/pgrx-pg-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx-pg-sys"
-version = "0.9.3"
+version = "0.9.4"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Generated Rust bindings for Postgres internals, for use with 'pgrx'"
@@ -29,17 +29,17 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 memoffset = "0.9.0"
-pgrx-macros = { path = "../pgrx-macros/", version = "=0.9.3" }
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph/", version = "=0.9.3" }
-serde = { version = "1.0.163", features = [ "derive" ] } # impls on pub types
+pgrx-macros = { path = "../pgrx-macros/", version = "=0.9.4" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph/", version = "=0.9.4" }
+serde = { version = "1.0.164", features = [ "derive" ] } # impls on pub types
 # polyfill until #![feature(strict_provenance)] stabilizes
 sptr = "0.3"
 libc = "0.2"
 
 [build-dependencies]
 bindgen = { version = "0.65.1", default-features = false, features = ["runtime"] }
-pgrx-pg-config= { path = "../pgrx-pg-config/", version = "=0.9.3" }
-proc-macro2 = "1.0.59"
+pgrx-pg-config= { path = "../pgrx-pg-config/", version = "=0.9.4" }
+proc-macro2 = "1.0.60"
 quote = "1.0.28"
 syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsing" ] }
 eyre = "0.6.8"

--- a/pgrx-sql-entity-graph/Cargo.toml
+++ b/pgrx-sql-entity-graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx-sql-entity-graph"
-version = "0.9.3"
+version = "0.9.4"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Sql Entity Graph for `pgrx`"
@@ -18,7 +18,7 @@ no-schema-generation = []
 convert_case = "0.6.0"
 eyre = "0.6.8"
 petgraph = "0.6.3"
-proc-macro2 = { version = "1.0.59", features = [ "span-locations" ] }
+proc-macro2 = { version = "1.0.60", features = [ "span-locations" ] }
 quote = "1.0.28"
 syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsing" ] }
 unescape = "0.1.0"

--- a/pgrx-tests/Cargo.toml
+++ b/pgrx-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx-tests"
-version = "0.9.3"
+version = "0.9.4"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Test framework for 'pgrx'-based Postgres extensions"
@@ -37,13 +37,13 @@ clap-cargo = "0.10.0"
 owo-colors = "3.5.0"
 once_cell = "1.18.0"
 libc = "0.2.146"
-pgrx-macros = { path = "../pgrx-macros", version = "=0.9.3" }
-pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.9.3" }
+pgrx-macros = { path = "../pgrx-macros", version = "=0.9.4" }
+pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.9.4" }
 postgres = "0.19.5"
 regex = "1.8.4"
-serde = "1.0.163"
+serde = "1.0.164"
 serde_json = "1.0.96"
-sysinfo = "0.29.1"
+sysinfo = "0.29.2"
 eyre = "0.6.8"
 thiserror = "1.0"
 
@@ -53,4 +53,4 @@ eyre = "0.6.8"  # testing functions that return `eyre::Result`
 [dependencies.pgrx]
 path = "../pgrx"
 default-features = false
-version = "=0.9.3"
+version = "=0.9.4"

--- a/pgrx/Cargo.toml
+++ b/pgrx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx"
-version = "0.9.3"
+version = "0.9.4"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "pgrx:  A Rust framework for creating Postgres extensions"
@@ -33,9 +33,9 @@ no-default-features = true
 rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-pgrx-macros = { path = "../pgrx-macros", version = "=0.9.3" }
-pgrx-pg-sys = { path = "../pgrx-pg-sys", version = "=0.9.3" }
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.9.3" }
+pgrx-macros = { path = "../pgrx-macros", version = "=0.9.4" }
+pgrx-pg-sys = { path = "../pgrx-pg-sys", version = "=0.9.4" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.9.4" }
 
 # used to internally impl things
 once_cell = "1.18.0" # polyfill until std::lazy::OnceCell stabilizes
@@ -53,8 +53,8 @@ bitvec = "1.0" # processing array nullbitmaps
 heapless = "0.7.16" # shmem and PgLwLock
 libc = "0.2.146" # FFI type compat
 seahash = "4.1.0" # derive(PostgresHash)
-serde = { version = "1.0.163", features = [ "derive" ] } # impls on pub types
+serde = { version = "1.0.164", features = [ "derive" ] } # impls on pub types
 serde_cbor = "0.11.2" # derive(PostgresType)
 serde_json = "1.0.96" # everything JSON
-time = { version = "0.3.21", features = ["formatting", "parsing", "alloc", "macros"], optional = true }
+time = { version = "0.3.22", features = ["formatting", "parsing", "alloc", "macros"], optional = true }
 

--- a/pgrx/Cargo.toml
+++ b/pgrx/Cargo.toml
@@ -56,5 +56,4 @@ seahash = "4.1.0" # derive(PostgresHash)
 serde = { version = "1.0.164", features = [ "derive" ] } # impls on pub types
 serde_cbor = "0.11.2" # derive(PostgresType)
 serde_json = "1.0.96" # everything JSON
-time = { version = "0.3.22", features = ["formatting", "parsing", "alloc", "macros"], optional = true }
 


### PR DESCRIPTION
Welcome to pgrx v0.9.4.  It is a minor bugfix release resolving an issue returning a `TableIterator` with only 1 field.

As always, please update with `cargo install cargo-pgrx --locked` and update your crate dependencies.

## What's Changed
* Properly Support `RETURNS TABLE (T)` (returning a table with 1 field) by @eeeebbbbrrrr in https://github.com/tcdi/pgrx/pull/1164.  This closes Issue #1031 and #1091 
* Remove `pgrx/Cargo.toml` dependency on the `time` crate [579f29f](https://github.com/tcdi/pgrx/pull/1165/commits/579f29f7dde604de441f2887b4f02cbd782a8d40)


**Full Changelog**: https://github.com/tcdi/pgrx/compare/v0.9.3...asdf