### PR TITLE
Underspecify rather than overspecify the serde/serde_json/serde_derive versions we require

### DIFF
--- a/cargo-pgrx/Cargo.toml
+++ b/cargo-pgrx/Cargo.toml
@@ -32,8 +32,8 @@ rayon = "1.7.0"
 regex = "1.8.4"
 ureq = "2.6.2"
 url = "2.4.0"
-serde = { version = "1.0.164", features = [ "derive" ] }
-serde_derive = "1.0.164"
+serde = { version = "1.0", features = [ "derive" ] }
+serde_derive = "1.0"
 serde-xml-rs = "0.6.0"
 syn = { version = "2.0.18", features = [ "extra-traits", "full", "fold", "parsing" ] }
 unescape = "0.1.0"

--- a/pgrx-examples/aggregate/Cargo.toml
+++ b/pgrx-examples/aggregate/Cargo.toml
@@ -18,7 +18,7 @@ bob = []
 
 [dependencies]
 pgrx = { path = "../../pgrx", default-features = false }
-serde = "1.0.164"
+serde = "1.0"
 
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }

--- a/pgrx-examples/arrays/Cargo.toml
+++ b/pgrx-examples/arrays/Cargo.toml
@@ -17,7 +17,7 @@ pg_test = []
 
 [dependencies]
 pgrx = { path = "../../pgrx", default-features = false }
-serde = "1.0.164"
+serde = "1.0"
 rand = "*"
 
 [dev-dependencies]

--- a/pgrx-examples/composite_type/Cargo.toml
+++ b/pgrx-examples/composite_type/Cargo.toml
@@ -17,7 +17,7 @@ pg_test = []
 
 [dependencies]
 pgrx = { path = "../../pgrx", default-features = false }
-serde = "1.0.164"
+serde = "1.0"
 
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }

--- a/pgrx-examples/custom_sql/Cargo.toml
+++ b/pgrx-examples/custom_sql/Cargo.toml
@@ -17,7 +17,7 @@ pg_test = []
 
 [dependencies]
 pgrx = { path = "../../pgrx", default-features = false }
-serde = "1.0.164"
+serde = "1.0"
 
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }

--- a/pgrx-examples/custom_types/Cargo.toml
+++ b/pgrx-examples/custom_types/Cargo.toml
@@ -19,7 +19,7 @@ no-schema-generation = [ "pgrx/no-schema-generation", "pgrx-tests/no-schema-gene
 [dependencies]
 pgrx = { path = "../../pgrx", default-features = false }
 maplit = "1.0.2"
-serde = "1.0.164"
+serde = "1.0"
 
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }

--- a/pgrx-examples/nostd/Cargo.toml
+++ b/pgrx-examples/nostd/Cargo.toml
@@ -17,7 +17,7 @@ pg_test = []
 
 [dependencies]
 pgrx = { path = "../../pgrx", default-features = false }
-serde = "1.0.164"
+serde = "1.0"
 
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }

--- a/pgrx-examples/operators/Cargo.toml
+++ b/pgrx-examples/operators/Cargo.toml
@@ -17,7 +17,7 @@ pg_test = []
 
 [dependencies]
 pgrx = { path = "../../pgrx", default-features = false }
-serde = "1.0.164"
+serde = "1.0"
 
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }

--- a/pgrx-examples/schemas/Cargo.toml
+++ b/pgrx-examples/schemas/Cargo.toml
@@ -17,7 +17,7 @@ pg_test = []
 
 [dependencies]
 pgrx = { path = "../../pgrx", default-features = false }
-serde = "1.0.164"
+serde = "1.0"
 
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }

--- a/pgrx-examples/shmem/Cargo.toml
+++ b/pgrx-examples/shmem/Cargo.toml
@@ -18,7 +18,7 @@ pg_test = []
 [dependencies]
 heapless = "0.7.16"
 pgrx = { path = "../../pgrx", default-features = false }
-serde = { version = "1.0.164", features = [ "derive" ] }
+serde = { version = "1.0", features = [ "derive" ] }
 
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }

--- a/pgrx-macros/Cargo.toml
+++ b/pgrx-macros/Cargo.toml
@@ -27,4 +27,4 @@ quote = "1.0.28"
 syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsing" ] }
 
 [dev-dependencies]
-serde = { version = "1.0.164", features = ["derive"] } # for Documentation examples
+serde = { version = "1.0", features = ["derive"] } # for Documentation examples

--- a/pgrx-pg-config/Cargo.toml
+++ b/pgrx-pg-config/Cargo.toml
@@ -17,9 +17,9 @@ dirs = "5.0.1"
 eyre = "0.6.8"
 pathsearch = "0.2.0"
 owo-colors = "3.5.0"
-serde = { version = "1.0.164", features = [ "derive" ] }
-serde_derive = "1.0.164"
-serde_json = "1.0.96"
+serde = { version = "1.0", features = [ "derive" ] }
+serde_derive = "1.0"
+serde_json = "1.0"
 toml = "0.7.4"
 url = "2.4.0"
 cargo_toml = "0.15.3"

--- a/pgrx-pg-sys/Cargo.toml
+++ b/pgrx-pg-sys/Cargo.toml
@@ -31,7 +31,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 memoffset = "0.9.0"
 pgrx-macros = { path = "../pgrx-macros/", version = "=0.9.4" }
 pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph/", version = "=0.9.4" }
-serde = { version = "1.0.164", features = [ "derive" ] } # impls on pub types
+serde = { version = "1.0", features = [ "derive" ] } # impls on pub types
 # polyfill until #![feature(strict_provenance)] stabilizes
 sptr = "0.3"
 libc = "0.2"

--- a/pgrx-tests/Cargo.toml
+++ b/pgrx-tests/Cargo.toml
@@ -41,8 +41,8 @@ pgrx-macros = { path = "../pgrx-macros", version = "=0.9.4" }
 pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.9.4" }
 postgres = "0.19.5"
 regex = "1.8.4"
-serde = "1.0.164"
-serde_json = "1.0.96"
+serde = "1.0"
+serde_json = "1.0"
 sysinfo = "0.29.2"
 eyre = "0.6.8"
 thiserror = "1.0"

--- a/pgrx/Cargo.toml
+++ b/pgrx/Cargo.toml
@@ -53,7 +53,7 @@ bitvec = "1.0" # processing array nullbitmaps
 heapless = "0.7.16" # shmem and PgLwLock
 libc = "0.2.146" # FFI type compat
 seahash = "4.1.0" # derive(PostgresHash)
-serde = { version = "1.0.164", features = [ "derive" ] } # impls on pub types
+serde = { version = "1.0", features = [ "derive" ] } # impls on pub types
 serde_cbor = "0.11.2" # derive(PostgresType)
-serde_json = "1.0.96" # everything JSON
+serde_json = "1.0" # everything JSON
 


### PR DESCRIPTION
Allows making some issues with plrust dependency handling much less of a problem in practice than they might otherwise be.