### PR TITLE
Update version to 0.9.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,7 +314,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-pgrx"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "atty",
  "cargo_metadata",
@@ -420,9 +420,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.2"
+version = "4.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "401a4694d2bf92537b6867d94de48c4842089645fdcdf6c71865b175d836e9c2"
+checksum = "ca8f255e4b8027970e78db75e78831229c9815fdbfa67eb1a1b777a62e24b4a0"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -442,9 +442,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.1"
+version = "4.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72394f3339a76daf211e57d4bcb374410f3965dcc606dd0e03738c7888766980"
+checksum = "acd4f3c17c83b0ba34ffbc4f8bbd74f079413f747f84a6f89292f138057e36ab"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1523,7 +1523,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "atomic-traits",
  "bitflags 2.3.1",
@@ -1546,7 +1546,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-macros"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "pgrx-sql-entity-graph",
  "proc-macro2",
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-config"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "cargo_toml",
  "dirs",
@@ -1573,7 +1573,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-sys"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "bindgen",
  "eyre",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-sql-entity-graph"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "atty",
  "convert_case",
@@ -1609,7 +1609,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-tests"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "clap-cargo",
  "eyre",

--- a/cargo-pgrx/Cargo.toml
+++ b/cargo-pgrx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pgrx"
-version = "0.9.4"
+version = "0.9.5"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Cargo subcommand for 'pgrx' to make Postgres extension development easy"
@@ -17,14 +17,14 @@ edition = "2021"
 atty = "0.2.14"
 cargo_metadata = "0.15.4"
 cargo_toml = "0.15.3"
-clap = { version = "4.3.2", features = [ "env", "suggestions", "cargo", "derive", "wrap_help" ] }
+clap = { version = "4.3.3", features = [ "env", "suggestions", "cargo", "derive", "wrap_help" ] }
 clap-cargo = { version = "0.10.0", features = [ "cargo_metadata" ] }
 semver = "1.0.17"
 owo-colors = { version = "3.5.0", features = [ "supports-colors" ] }
 env_proxy = "0.4.1"
 num_cpus = "1.15.0"
-pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.9.4" }
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.9.4" }
+pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.9.5" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.9.5" }
 prettyplease = "0.2.6"
 proc-macro2 = { version = "1.0.60", features = [ "span-locations" ] }
 quote = "1.0.28"

--- a/cargo-pgrx/src/templates/cargo_toml
+++ b/cargo-pgrx/src/templates/cargo_toml
@@ -16,10 +16,10 @@ pg15 = ["pgrx/pg15", "pgrx-tests/pg15" ]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.9.4"
+pgrx = "=0.9.5"
 
 [dev-dependencies]
-pgrx-tests = "=0.9.4"
+pgrx-tests = "=0.9.5"
 
 [profile.dev]
 panic = "unwind"

--- a/nix/templates/default/Cargo.toml
+++ b/nix/templates/default/Cargo.toml
@@ -16,10 +16,10 @@ pg15 = ["pgrx/pg15", "pgrx-tests/pg15" ]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.9.4"
+pgrx = "=0.9.5"
 
 [dev-dependencies]
-pgrx-tests = "=0.9.4"
+pgrx-tests = "=0.9.5"
 tempfile = "3.2.0"
 once_cell = "1.7.2"
 

--- a/pgrx-macros/Cargo.toml
+++ b/pgrx-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx-macros"
-version = "0.9.4"
+version = "0.9.5"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Proc Macros for 'pgrx'"
@@ -21,7 +21,7 @@ rustc-args = ["--cfg", "docsrs"]
 no-schema-generation = ["pgrx-sql-entity-graph/no-schema-generation"]
 
 [dependencies]
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.9.4" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.9.5" }
 proc-macro2 = "1.0.60"
 quote = "1.0.28"
 syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsing" ] }

--- a/pgrx-pg-config/Cargo.toml
+++ b/pgrx-pg-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx-pg-config"
-version = "0.9.4"
+version = "0.9.5"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "A Postgres pg_config wrapper for 'pgrx'"

--- a/pgrx-pg-sys/Cargo.toml
+++ b/pgrx-pg-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx-pg-sys"
-version = "0.9.4"
+version = "0.9.5"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Generated Rust bindings for Postgres internals, for use with 'pgrx'"
@@ -29,8 +29,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 memoffset = "0.9.0"
-pgrx-macros = { path = "../pgrx-macros/", version = "=0.9.4" }
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph/", version = "=0.9.4" }
+pgrx-macros = { path = "../pgrx-macros/", version = "=0.9.5" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph/", version = "=0.9.5" }
 serde = { version = "1.0", features = [ "derive" ] } # impls on pub types
 # polyfill until #![feature(strict_provenance)] stabilizes
 sptr = "0.3"
@@ -38,7 +38,7 @@ libc = "0.2"
 
 [build-dependencies]
 bindgen = { version = "0.65.1", default-features = false, features = ["runtime"] }
-pgrx-pg-config= { path = "../pgrx-pg-config/", version = "=0.9.4" }
+pgrx-pg-config= { path = "../pgrx-pg-config/", version = "=0.9.5" }
 proc-macro2 = "1.0.60"
 quote = "1.0.28"
 syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsing" ] }

--- a/pgrx-sql-entity-graph/Cargo.toml
+++ b/pgrx-sql-entity-graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx-sql-entity-graph"
-version = "0.9.4"
+version = "0.9.5"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Sql Entity Graph for `pgrx`"

--- a/pgrx-tests/Cargo.toml
+++ b/pgrx-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx-tests"
-version = "0.9.4"
+version = "0.9.5"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Test framework for 'pgrx'-based Postgres extensions"
@@ -37,8 +37,8 @@ clap-cargo = "0.10.0"
 owo-colors = "3.5.0"
 once_cell = "1.18.0"
 libc = "0.2.146"
-pgrx-macros = { path = "../pgrx-macros", version = "=0.9.4" }
-pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.9.4" }
+pgrx-macros = { path = "../pgrx-macros", version = "=0.9.5" }
+pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.9.5" }
 postgres = "0.19.5"
 regex = "1.8.4"
 serde = "1.0"
@@ -53,4 +53,4 @@ eyre = "0.6.8"  # testing functions that return `eyre::Result`
 [dependencies.pgrx]
 path = "../pgrx"
 default-features = false
-version = "=0.9.4"
+version = "=0.9.5"

--- a/pgrx-version-updater/Cargo.toml
+++ b/pgrx-version-updater/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 description = "Standalone tool to update PGRX Cargo.toml versions and dependencies in preparation for a release."
 
 [dependencies]
-clap = { version = "4.3.2", features = [ "env", "derive" ] }
+clap = { version = "4.3.3", features = [ "env", "derive" ] }
 owo-colors = "3.5.0"
 toml_edit = { version = "0.19.10" }
 walkdir = "2"

--- a/pgrx/Cargo.toml
+++ b/pgrx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx"
-version = "0.9.4"
+version = "0.9.5"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "pgrx:  A Rust framework for creating Postgres extensions"
@@ -33,9 +33,9 @@ no-default-features = true
 rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-pgrx-macros = { path = "../pgrx-macros", version = "=0.9.4" }
-pgrx-pg-sys = { path = "../pgrx-pg-sys", version = "=0.9.4" }
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.9.4" }
+pgrx-macros = { path = "../pgrx-macros", version = "=0.9.5" }
+pgrx-pg-sys = { path = "../pgrx-pg-sys", version = "=0.9.5" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.9.5" }
 
 # used to internally impl things
 once_cell = "1.18.0" # polyfill until std::lazy::OnceCell stabilizes


### PR DESCRIPTION
This is pgrx v0.9.5.  It contains no code changes.  It simply under-specifies its dependency on `serde` in an effort to make `serde` easier to use by pgrx-based crates.

## What's Changed
* Underspecify rather than overspecify the serde/serde_json/serde_derive versions we require by @thomcc in https://github.com/tcdi/pgrx/pull/1167


**Full Changelog**: https://github.com/tcdi/pgrx/compare/v0.9.4...asdf