### PR TITLE
Implement PGRXSharedMemory for Deque

### DIFF
--- a/pgrx/src/shmem.rs
+++ b/pgrx/src/shmem.rs
@@ -259,6 +259,7 @@ where
 {
 }
 unsafe impl<T, const N: usize> PGRXSharedMemory for heapless::Vec<T, N> {}
+unsafe impl<T, const N: usize> PGRXSharedMemory for heapless::Deque<T, N> {}
 unsafe impl<K: Eq + Hash, V: Default, S, const N: usize> PGRXSharedMemory
     for heapless::IndexMap<K, V, S, N>
 {


### PR DESCRIPTION
Having a double ended queue allows for more efficient FIFO workloads when using shared memory

## Sample session:
```console
shmem=# select * from deque_count();
deque_count
-------------
          0

shmem=# select deque_push_front('{"value1": 2, "value2": 2}');
deque_push_front
------------------

shmem=# select deque_push_front('{"value1": 1, "value2": 1}');
deque_push_front
------------------

shmem=# select deque_push_back('{"value1": 3, "value2": 3}');
deque_push_back
-----------------

shmem=# select deque_push_back('{"value1": 4, "value2": 4}');
deque_push_back
-----------------

shmem=# select * from deque_select();
     deque_select
-------------------------
{"value1":1,"value2":1}
{"value1":2,"value2":2}
{"value1":3,"value2":3}
{"value1":4,"value2":4}
(4 rows)

shmem=# select deque_pop_front();
     deque_pop_front
-------------------------
{"value1":1,"value2":1}

shmem=# select deque_pop_back();
     deque_pop_back
-------------------------
{"value1":4,"value2":4}
```
