### PR TITLE
Fix bug with converting a `pg_sys::Datum` into a `pgrx::Date`

### DIFF
--- a/pgrx-tests/src/tests/datetime_tests.rs
+++ b/pgrx-tests/src/tests/datetime_tests.rs
@@ -573,4 +573,13 @@ mod tests {
         assert_eq!(result, Interval::new(6, 15, 42)?);
         Ok(())
     }
+
+    #[pg_test]
+    fn test_old_date() -> Result<(), Box<dyn std::error::Error>> {
+        let array = Spi::get_one::<Array<Date>>("SELECT ARRAY['1977-07-04']::date[]")?.unwrap();
+        let first = array.into_iter().next();
+        assert_eq!(first, Some(Some(Date::from_str("1977-07-04")?)));
+        Ok(())
+
+    }
 }

--- a/pgrx-tests/src/tests/datetime_tests.rs
+++ b/pgrx-tests/src/tests/datetime_tests.rs
@@ -580,6 +580,5 @@ mod tests {
         let first = array.into_iter().next();
         assert_eq!(first, Some(Some(Date::from_str("1977-07-04")?)));
         Ok(())
-
     }
 }

--- a/pgrx/src/datum/date.rs
+++ b/pgrx/src/datum/date.rs
@@ -63,7 +63,7 @@ impl TryFrom<pg_sys::Datum> for Date {
 
     #[inline]
     fn try_from(datum: pg_sys::Datum) -> Result<Self, Self::Error> {
-        pg_sys::DateADT::try_from(datum.value() as isize).map(|d| Date(d))
+        Ok(Date(datum.value() as pg_sys::DateADT))
     }
 }
 


### PR DESCRIPTION
The cast to `isize` was wrong.  It needs to be a cast to `pg_sys::DateADT` which is an `i32`.