### PR TITLE
Fix Arrays with leading nulls

### DIFF
--- a/pgrx-tests/src/tests/array_tests.rs
+++ b/pgrx-tests/src/tests/array_tests.rs
@@ -484,7 +484,7 @@ mod tests {
     }
 
     #[pg_test]
-    fn test_text_array() -> Result<(), Box<dyn std::error::Error>> {
+    fn test_text_array_as_vec_string() -> Result<(), Box<dyn std::error::Error>> {
         let a = Spi::get_one::<Array<String>>(
             "SELECT ARRAY[NULL, NULL, NULL, NULL, 'the fifth element']::text[]",
         )?
@@ -492,6 +492,42 @@ mod tests {
         .into_iter()
         .collect::<Vec<_>>();
         assert_eq!(a, vec![None, None, None, None, Some(String::from("the fifth element"))]);
+        Ok(())
+    }
+
+    #[pg_test]
+    fn test_text_array_iter() -> Result<(), Box<dyn std::error::Error>> {
+        let a = Spi::get_one::<Array<String>>(
+            "SELECT ARRAY[NULL, NULL, NULL, NULL, 'the fifth element']::text[]",
+        )?
+        .expect("spi result was NULL");
+
+        let mut iter = a.iter();
+
+        assert_eq!(iter.next(), Some(None));
+        assert_eq!(iter.next(), Some(None));
+        assert_eq!(iter.next(), Some(None));
+        assert_eq!(iter.next(), Some(None));
+        assert_eq!(iter.next(), Some(Some(String::from("the fifth element"))));
+        assert_eq!(iter.next(), None);
+
+        Ok(())
+    }
+
+    #[pg_test]
+    fn test_text_array_via_getter() -> Result<(), Box<dyn std::error::Error>> {
+        let a = Spi::get_one::<Array<String>>(
+            "SELECT ARRAY[NULL, NULL, NULL, NULL, 'the fifth element']::text[]",
+        )?
+        .expect("spi result was NULL");
+
+        assert_eq!(a.get(0), Some(None));
+        assert_eq!(a.get(1), Some(None));
+        assert_eq!(a.get(2), Some(None));
+        assert_eq!(a.get(3), Some(None));
+        assert_eq!(a.get(4), Some(Some(String::from("the fifth element"))));
+        assert_eq!(a.get(5), None);
+
         Ok(())
     }
 }

--- a/pgrx-tests/src/tests/array_tests.rs
+++ b/pgrx-tests/src/tests/array_tests.rs
@@ -482,4 +482,16 @@ mod tests {
         }
         Ok(())
     }
+
+    #[pg_test]
+    fn test_text_array() -> Result<(), Box<dyn std::error::Error>> {
+        let a = Spi::get_one::<Array<String>>(
+            "SELECT ARRAY[NULL, NULL, NULL, NULL, 'the fifth element']::text[]",
+        )?
+        .expect("spi result was NULL")
+        .into_iter()
+        .collect::<Vec<_>>();
+        assert_eq!(a, vec![None, None, None, None, Some(String::from("the fifth element"))]);
+        Ok(())
+    }
 }


### PR DESCRIPTION
This test fails with some form of:

```
compression method lz4 not supported
Postgres location: toast_compression.c:187
```

A classic off-by-one error caused this:
If element 0 was null, and 1 was non-null, data started with 1,
but iteration would advance before unpacking.
This allowed moving to uninit data, or just skipping elements.