### PR TITLE
doc: fix link broken

### DIFF
--- a/articles/README.md
+++ b/articles/README.md
@@ -4,14 +4,14 @@ Articles about `pgrx`!
 
 By our team:
 
-* [Install pgrx extensions in PostgreSQL](https://tcdioss.tcdi.com/blog/install-pgrx-extensions) by [Ryan Lambert](https://github.com/rustprooflabs)
-* [SPI changes in pgrx 0.7.0](https://tcdioss.tcdi.com/blog/pgrx-0-7-0-spi-changes) by [Ryan Lambert](https://github.com/rustprooflabs)
-* [Pgrx: Year in Review 2022](https://tcdioss.tcdi.com/blog/pgrx-year-in-review-2022) by [Ryan Lambert](https://github.com/rustprooflabs)
+* [Install pgrx extensions in PostgreSQL](https://tcdioss.tcdi.com/blog/install-pgx-extensions) by [Ryan Lambert](https://github.com/rustprooflabs)
+* [SPI changes in pgrx 0.7.0](https://tcdioss.tcdi.com/blog/pgx-0-7-0-spi-changes) by [Ryan Lambert](https://github.com/rustprooflabs)
+* [Pgrx: Year in Review 2022](https://tcdioss.tcdi.com/blog/pgx-year-in-review-2022) by [Ryan Lambert](https://github.com/rustprooflabs)
 * "Forging SQL from Rust" ([archive](forging-sql-from-rust.md)) by [Ana Hobden (a `pgrx` maintainer)](https://github.com/Hoverbear/)
 
 By others (chronological order):
 
-* ["PgDD extension moves to Pgrx"](https://blog.rustprooflabs.com/2021/10/pgdd-extension-using-pgrx-rust) by [Ryan Lambert](https://github.com/rustprooflabs) ([RustProof Labs](https://www.rustprooflabs.com/))
+* ["PgDD extension moves to Pgrx"](https://blog.rustprooflabs.com/2021/10/pgdd-extension-using-pgx-rust) by [Ryan Lambert](https://github.com/rustprooflabs) ([RustProof Labs](https://www.rustprooflabs.com/))
 * ["A Rust PostgreSQL Extension for CAS Numbers"](https://depth-first.com/articles/2021/09/07/a-rust-postgresql-extension-for-cas-numbers/) by [Richard L. Apodaca](https://github.com/rapodaca/) ([Metamolecular](https://metamolecular.com/))
 * ["Postgres Extensions in Rust"](https://depth-first.com/articles/2021/08/25/postgres-extensions-in-rust/) by [Richard L. Apodaca](https://github.com/rapodaca/) ([Metamolecular](https://metamolecular.com/))
 * ["Building PostgreSQL Extensions with Rust"](https://tech.marksblogg.com/postgresql-extension-rust.html) by [Mark Litwintschik](https://github.com/marklit)


### PR DESCRIPTION
some articles link changed by mistake.
they should not change from gpx -> pgrx.

this PR this the link broken and make it happy

Signed-off-by: yihong0618 [zouzou0208@gmail.com](mailto:zouzou0208@gmail.com)