### PR TITLE
Prepare 0.9.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,7 +307,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-pgrx"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "atty",
  "cargo_metadata",
@@ -1520,7 +1520,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "atomic-traits",
  "bitflags 2.3.3",
@@ -1543,7 +1543,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-macros"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "pgrx-sql-entity-graph",
  "proc-macro2",
@@ -1554,7 +1554,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-config"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "cargo_toml",
  "dirs",
@@ -1570,7 +1570,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-sys"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "bindgen",
  "eyre",
@@ -1590,7 +1590,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-sql-entity-graph"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "atty",
  "convert_case",
@@ -1606,7 +1606,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-tests"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "clap-cargo",
  "eyre",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,7 +114,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -207,7 +207,7 @@ version = "0.66.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
 dependencies = [
- "bitflags 2.3.2",
+ "bitflags 2.3.3",
  "cexpr",
  "clang-sys",
  "lazy_static",
@@ -218,7 +218,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -244,9 +244,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbe3c979c178231552ecba20214a8272df4e09f232a87aef4320cf06539aded"
+checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
 name = "bitvec"
@@ -336,7 +336,7 @@ dependencies = [
  "serde",
  "serde-xml-rs",
  "serde_derive",
- "syn 2.0.18",
+ "syn 2.0.22",
  "tempfile",
  "tracing",
  "tracing-error",
@@ -413,9 +413,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.5"
+version = "4.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2686c4115cb0810d9a984776e197823d08ec94f176549a89a9efded477c456dc"
+checksum = "bba77a07e4489fb41bd90e8d4201c3eb246b3c2c9ea2ba0bddd6c1d1df87db7d"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -435,9 +435,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.5"
+version = "4.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e53afce1efce6ed1f633cf0e57612fe51db54a1ee4fd8f8503d078fe02d69ae"
+checksum = "2c9b4a88bb4bc35d3d6f65a21b0f0bafe9c894fa00978de242c555ec28bea1c0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -457,7 +457,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -721,6 +721,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1"
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -869,7 +875,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -954,6 +960,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+
+[[package]]
 name = "heapless"
 version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -977,15 +989,6 @@ name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
@@ -1028,7 +1031,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
@@ -1098,9 +1111,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.146"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "libflate"
@@ -1323,11 +1336,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi 0.3.1",
  "libc",
 ]
 
@@ -1389,7 +1402,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -1487,9 +1500,9 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16833386b02953ca926d19f64af613b9bf742c48dcd5e09b32fbfc9740bf84e2"
+checksum = "f73935e4d55e2abf7f130186537b19e7a4abc886a0252380b59248af473a3fc9"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -1502,7 +1515,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
 dependencies = [
  "fixedbitset",
- "indexmap",
+ "indexmap 1.9.3",
 ]
 
 [[package]]
@@ -1510,7 +1523,7 @@ name = "pgrx"
 version = "0.9.6"
 dependencies = [
  "atomic-traits",
- "bitflags 2.3.2",
+ "bitflags 2.3.3",
  "bitvec",
  "enum-map",
  "heapless",
@@ -1631,18 +1644,18 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928c6535de93548188ef63bb7c4036bd415cd8f36ad25af44b9789b2ee72a48c"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
 dependencies = [
  "phf_shared",
 ]
 
 [[package]]
 name = "phf_shared"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1fb5f6f826b772a8d4c0394209441e7d37cbbb967ae9c7e0e8134365c9ee676"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
 dependencies = [
  "siphasher",
 ]
@@ -1672,7 +1685,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bd9647b268a3d3e14ff09c23201133a62589c658db02bb7388c7246aafe0590"
 dependencies = [
  "base64",
- "indexmap",
+ "indexmap 1.9.3",
  "line-wrap",
  "quick-xml",
  "serde",
@@ -1730,19 +1743,19 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b0377b720bde721213a46cda1289b2f34abf0a436907cad91578c20de0454d"
+checksum = "9825a04601d60621feed79c4e6b56d65db77cdca55cef43b46b0de1096d1c282"
 dependencies = [
  "proc-macro2",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.60"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]
@@ -1758,9 +1771,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
 ]
@@ -2146,14 +2159,14 @@ checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.97"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdf3bf93142acad5821c99197022e170842cdbc1c30482b98750c688c640842a"
+checksum = "46266871c240a00b8f503b877622fe33430b3c7d963bdc0f2adc511e54a1eae3"
 dependencies = [
  "itoa",
  "ryu",
@@ -2162,9 +2175,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93107647184f6027e3b7dcb2e11034cf95ffa1e3a682c67951963ac69c1c007d"
+checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
 dependencies = [
  "serde",
 ]
@@ -2357,9 +2370,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.18"
+version = "2.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+checksum = "2efbeae7acf4eabd6bcdcbd11c92f45231ddda7539edc7806bd1a04a03b24616"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2451,7 +2464,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -2508,11 +2521,12 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.2"
+version = "1.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
+checksum = "374442f06ee49c3a28a8fc9f01a2596fed7559c6b99b31279c3261778e77d84f"
 dependencies = [
  "autocfg",
+ "backtrace",
  "bytes",
  "libc",
  "mio",
@@ -2561,9 +2575,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6135d499e69981f9ff0ef2167955a5333c35e36f6937d382974566b3d5b94ec"
+checksum = "1ebafdf5ad1220cb59e7d17cf4d2c72015297b75b19a10472f99b89225089240"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -2573,20 +2587,20 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.19.10"
+version = "0.19.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
+checksum = "266f016b7f039eec8a1a80dfe6156b633d208b9fccca5e4db1d6775b0c4e34a7"
 dependencies = [
- "indexmap",
+ "indexmap 2.0.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -2607,13 +2621,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8803eee176538f94ae9a14b55b2804eb7e1441f8210b1c31290b3bccdccff73b"
+checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -2771,9 +2785,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.3.4"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa2982af2eec27de306107c027578ff7f423d65f7250e40ce0fea8f45248b81"
+checksum = "d023da39d1fde5a8a3fe1f3e01ca9632ada0a63e9797de55a879d6e2236277be"
 dependencies = [
  "getrandom",
 ]
@@ -2849,7 +2863,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
  "wasm-bindgen-shared",
 ]
 
@@ -2871,7 +2885,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2958,9 +2972,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
 dependencies = [
  "windows_aarch64_gnullvm 0.48.0",
  "windows_aarch64_msvc 0.48.0",

--- a/cargo-pgrx/Cargo.toml
+++ b/cargo-pgrx/Cargo.toml
@@ -17,17 +17,17 @@ edition = "2021"
 atty = "0.2.14"
 cargo_metadata = "0.15.4"
 cargo_toml = "0.15.3"
-clap = { version = "4.3.5", features = [ "env", "suggestions", "cargo", "derive", "wrap_help" ] }
+clap = { version = "4.3.9", features = [ "env", "suggestions", "cargo", "derive", "wrap_help" ] }
 clap-cargo = { version = "0.10.0", features = [ "cargo_metadata" ] }
 semver = "1.0.17"
 owo-colors = { version = "3.5.0", features = [ "supports-colors" ] }
 env_proxy = "0.4.1"
-num_cpus = "1.15.0"
+num_cpus = "1.16.0"
 pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.9.6" }
 pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.9.6" }
-prettyplease = "0.2.8"
-proc-macro2 = { version = "1.0.60", features = [ "span-locations" ] }
-quote = "1.0.28"
+prettyplease = "0.2.9"
+proc-macro2 = { version = "1.0.63", features = [ "span-locations" ] }
+quote = "1.0.29"
 rayon = "1.7.0"
 regex = "1.8.4"
 ureq = "2.7.1"

--- a/cargo-pgrx/Cargo.toml
+++ b/cargo-pgrx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pgrx"
-version = "0.9.6"
+version = "0.9.7"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Cargo subcommand for 'pgrx' to make Postgres extension development easy"
@@ -23,8 +23,8 @@ semver = "1.0.17"
 owo-colors = { version = "3.5.0", features = [ "supports-colors" ] }
 env_proxy = "0.4.1"
 num_cpus = "1.16.0"
-pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.9.6" }
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.9.6" }
+pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.9.7" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.9.7" }
 prettyplease = "0.2.9"
 proc-macro2 = { version = "1.0.63", features = [ "span-locations" ] }
 quote = "1.0.29"

--- a/cargo-pgrx/src/templates/cargo_toml
+++ b/cargo-pgrx/src/templates/cargo_toml
@@ -16,10 +16,10 @@ pg15 = ["pgrx/pg15", "pgrx-tests/pg15" ]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.9.6"
+pgrx = "=0.9.7"
 
 [dev-dependencies]
-pgrx-tests = "=0.9.6"
+pgrx-tests = "=0.9.7"
 
 [profile.dev]
 panic = "unwind"

--- a/nix/templates/default/Cargo.toml
+++ b/nix/templates/default/Cargo.toml
@@ -16,10 +16,10 @@ pg15 = ["pgrx/pg15", "pgrx-tests/pg15" ]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.9.6"
+pgrx = "=0.9.7"
 
 [dev-dependencies]
-pgrx-tests = "=0.9.6"
+pgrx-tests = "=0.9.7"
 tempfile = "3.2.0"
 once_cell = "1.7.2"
 

--- a/pgrx-macros/Cargo.toml
+++ b/pgrx-macros/Cargo.toml
@@ -22,8 +22,8 @@ no-schema-generation = ["pgrx-sql-entity-graph/no-schema-generation"]
 
 [dependencies]
 pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.9.6" }
-proc-macro2 = "1.0.60"
-quote = "1.0.28"
+proc-macro2 = "1.0.63"
+quote = "1.0.29"
 syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsing" ] }
 
 [dev-dependencies]

--- a/pgrx-macros/Cargo.toml
+++ b/pgrx-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx-macros"
-version = "0.9.6"
+version = "0.9.7"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Proc Macros for 'pgrx'"
@@ -21,7 +21,7 @@ rustc-args = ["--cfg", "docsrs"]
 no-schema-generation = ["pgrx-sql-entity-graph/no-schema-generation"]
 
 [dependencies]
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.9.6" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.9.7" }
 proc-macro2 = "1.0.63"
 quote = "1.0.29"
 syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsing" ] }

--- a/pgrx-pg-config/Cargo.toml
+++ b/pgrx-pg-config/Cargo.toml
@@ -20,6 +20,6 @@ owo-colors = "3.5.0"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_derive = "1.0"
 serde_json = "1.0"
-toml = "0.7.4"
+toml = "0.7.5"
 url = "2.4.0"
 cargo_toml = "0.15.3"

--- a/pgrx-pg-config/Cargo.toml
+++ b/pgrx-pg-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx-pg-config"
-version = "0.9.6"
+version = "0.9.7"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "A Postgres pg_config wrapper for 'pgrx'"

--- a/pgrx-pg-sys/Cargo.toml
+++ b/pgrx-pg-sys/Cargo.toml
@@ -39,8 +39,8 @@ libc = "0.2"
 [build-dependencies]
 bindgen = { version = "0.66.1", default-features = false, features = ["runtime"] }
 pgrx-pg-config= { path = "../pgrx-pg-config/", version = "=0.9.6" }
-proc-macro2 = "1.0.60"
-quote = "1.0.28"
+proc-macro2 = "1.0.63"
+quote = "1.0.29"
 syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsing" ] }
 eyre = "0.6.8"
 shlex = "1.1.0" # shell lexing, also used by many of our deps

--- a/pgrx-pg-sys/Cargo.toml
+++ b/pgrx-pg-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx-pg-sys"
-version = "0.9.6"
+version = "0.9.7"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Generated Rust bindings for Postgres internals, for use with 'pgrx'"
@@ -29,8 +29,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 memoffset = "0.9.0"
-pgrx-macros = { path = "../pgrx-macros/", version = "=0.9.6" }
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph/", version = "=0.9.6" }
+pgrx-macros = { path = "../pgrx-macros/", version = "=0.9.7" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph/", version = "=0.9.7" }
 serde = { version = "1.0", features = [ "derive" ] } # impls on pub types
 # polyfill until #![feature(strict_provenance)] stabilizes
 sptr = "0.3"
@@ -38,7 +38,7 @@ libc = "0.2"
 
 [build-dependencies]
 bindgen = { version = "0.66.1", default-features = false, features = ["runtime"] }
-pgrx-pg-config= { path = "../pgrx-pg-config/", version = "=0.9.6" }
+pgrx-pg-config= { path = "../pgrx-pg-config/", version = "=0.9.7" }
 proc-macro2 = "1.0.63"
 quote = "1.0.29"
 syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsing" ] }

--- a/pgrx-sql-entity-graph/Cargo.toml
+++ b/pgrx-sql-entity-graph/Cargo.toml
@@ -18,8 +18,8 @@ no-schema-generation = []
 convert_case = "0.6.0"
 eyre = "0.6.8"
 petgraph = "0.6.3"
-proc-macro2 = { version = "1.0.60", features = [ "span-locations" ] }
-quote = "1.0.28"
+proc-macro2 = { version = "1.0.63", features = [ "span-locations" ] }
+quote = "1.0.29"
 syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsing" ] }
 unescape = "0.1.0"
 

--- a/pgrx-sql-entity-graph/Cargo.toml
+++ b/pgrx-sql-entity-graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx-sql-entity-graph"
-version = "0.9.6"
+version = "0.9.7"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Sql Entity Graph for `pgrx`"

--- a/pgrx-tests/Cargo.toml
+++ b/pgrx-tests/Cargo.toml
@@ -36,7 +36,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 clap-cargo = "0.10.0"
 owo-colors = "3.5.0"
 once_cell = "1.18.0"
-libc = "0.2.146"
+libc = "0.2.147"
 pgrx-macros = { path = "../pgrx-macros", version = "=0.9.6" }
 pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.9.6" }
 postgres = "0.19.5"

--- a/pgrx-tests/Cargo.toml
+++ b/pgrx-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx-tests"
-version = "0.9.6"
+version = "0.9.7"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "Test framework for 'pgrx'-based Postgres extensions"
@@ -37,8 +37,8 @@ clap-cargo = "0.10.0"
 owo-colors = "3.5.0"
 once_cell = "1.18.0"
 libc = "0.2.147"
-pgrx-macros = { path = "../pgrx-macros", version = "=0.9.6" }
-pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.9.6" }
+pgrx-macros = { path = "../pgrx-macros", version = "=0.9.7" }
+pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.9.7" }
 postgres = "0.19.5"
 regex = "1.8.4"
 serde = "1.0"
@@ -53,4 +53,4 @@ eyre = "0.6.8"  # testing functions that return `eyre::Result`
 [dependencies.pgrx]
 path = "../pgrx"
 default-features = false
-version = "=0.9.6"
+version = "=0.9.7"

--- a/pgrx-tests/src/tests/array_tests.rs
+++ b/pgrx-tests/src/tests/array_tests.rs
@@ -484,7 +484,7 @@ mod tests {
     }
 
     #[pg_test]
-    fn test_text_array() -> Result<(), Box<dyn std::error::Error>> {
+    fn test_text_array_as_vec_string() -> Result<(), Box<dyn std::error::Error>> {
         let a = Spi::get_one::<Array<String>>(
             "SELECT ARRAY[NULL, NULL, NULL, NULL, 'the fifth element']::text[]",
         )?
@@ -492,6 +492,42 @@ mod tests {
         .into_iter()
         .collect::<Vec<_>>();
         assert_eq!(a, vec![None, None, None, None, Some(String::from("the fifth element"))]);
+        Ok(())
+    }
+
+    #[pg_test]
+    fn test_text_array_iter() -> Result<(), Box<dyn std::error::Error>> {
+        let a = Spi::get_one::<Array<String>>(
+            "SELECT ARRAY[NULL, NULL, NULL, NULL, 'the fifth element']::text[]",
+        )?
+        .expect("spi result was NULL");
+
+        let mut iter = a.iter();
+
+        assert_eq!(iter.next(), Some(None));
+        assert_eq!(iter.next(), Some(None));
+        assert_eq!(iter.next(), Some(None));
+        assert_eq!(iter.next(), Some(None));
+        assert_eq!(iter.next(), Some(Some(String::from("the fifth element"))));
+        assert_eq!(iter.next(), None);
+
+        Ok(())
+    }
+
+    #[pg_test]
+    fn test_text_array_via_getter() -> Result<(), Box<dyn std::error::Error>> {
+        let a = Spi::get_one::<Array<String>>(
+            "SELECT ARRAY[NULL, NULL, NULL, NULL, 'the fifth element']::text[]",
+        )?
+        .expect("spi result was NULL");
+
+        assert_eq!(a.get(0), Some(None));
+        assert_eq!(a.get(1), Some(None));
+        assert_eq!(a.get(2), Some(None));
+        assert_eq!(a.get(3), Some(None));
+        assert_eq!(a.get(4), Some(Some(String::from("the fifth element"))));
+        assert_eq!(a.get(5), None);
+
         Ok(())
     }
 }

--- a/pgrx-tests/src/tests/array_tests.rs
+++ b/pgrx-tests/src/tests/array_tests.rs
@@ -482,4 +482,16 @@ mod tests {
         }
         Ok(())
     }
+
+    #[pg_test]
+    fn test_text_array() -> Result<(), Box<dyn std::error::Error>> {
+        let a = Spi::get_one::<Array<String>>(
+            "SELECT ARRAY[NULL, NULL, NULL, NULL, 'the fifth element']::text[]",
+        )?
+        .expect("spi result was NULL")
+        .into_iter()
+        .collect::<Vec<_>>();
+        assert_eq!(a, vec![None, None, None, None, Some(String::from("the fifth element"))]);
+        Ok(())
+    }
 }

--- a/pgrx-version-updater/Cargo.toml
+++ b/pgrx-version-updater/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 description = "Standalone tool to update PGRX Cargo.toml versions and dependencies in preparation for a release."
 
 [dependencies]
-clap = { version = "4.3.5", features = [ "env", "derive" ] }
+clap = { version = "4.3.9", features = [ "env", "derive" ] }
 owo-colors = "3.5.0"
-toml_edit = { version = "0.19.10" }
+toml_edit = { version = "0.19.11" }
 walkdir = "2"

--- a/pgrx/Cargo.toml
+++ b/pgrx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgrx"
-version = "0.9.6"
+version = "0.9.7"
 authors = ["ZomboDB, LLC <zombodb@gmail.com>"]
 license = "MIT"
 description = "pgrx:  A Rust framework for creating Postgres extensions"
@@ -33,9 +33,9 @@ no-default-features = true
 rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-pgrx-macros = { path = "../pgrx-macros", version = "=0.9.6" }
-pgrx-pg-sys = { path = "../pgrx-pg-sys", version = "=0.9.6" }
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.9.6" }
+pgrx-macros = { path = "../pgrx-macros", version = "=0.9.7" }
+pgrx-pg-sys = { path = "../pgrx-pg-sys", version = "=0.9.7" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.9.7" }
 
 # used to internally impl things
 once_cell = "1.18.0" # polyfill until std::lazy::OnceCell stabilizes

--- a/pgrx/Cargo.toml
+++ b/pgrx/Cargo.toml
@@ -40,7 +40,7 @@ pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.9.6" 
 # used to internally impl things
 once_cell = "1.18.0" # polyfill until std::lazy::OnceCell stabilizes
 seq-macro = "0.3" # impls loops in macros
-uuid = { version = "1.3.4", features = [ "v4" ] } # PgLwLock and shmem
+uuid = { version = "1.4.0", features = [ "v4" ] } # PgLwLock and shmem
 enum-map = "2.5.0"
 
 # error handling and logging
@@ -48,10 +48,10 @@ thiserror = "1.0"
 
 # exposed in public API
 atomic-traits = "0.3.0" # PgAtomic and shmem init
-bitflags = "2.3.2" # BackgroundWorker
+bitflags = "2.3.3" # BackgroundWorker
 bitvec = "1.0" # processing array nullbitmaps
 heapless = "0.7.16" # shmem and PgLwLock
-libc = "0.2.146" # FFI type compat
+libc = "0.2.147" # FFI type compat
 seahash = "4.1.0" # derive(PostgresHash)
 serde = { version = "1.0", features = [ "derive" ] } # impls on pub types
 serde_cbor = "0.11.2" # derive(PostgresType)


### PR DESCRIPTION
This is pgrx v0.9.7.  It fixes an important bug when working with arrays that have leading NULL elements.  Such arrays could lead to spurious Postgres errors or even crashes when iterating.

Please upgrade your pgrx projects as soon as you can, and making sure to update your crate dependencies and to `cargo install cargo-pgrx --locked`.

# What's Changed

PR #1180 - Arrays with leading NULL values are now properly advanced during iteration.

Big thanks to @workingjubilee for some late-night debugging!

**Full Changelog:** https://github.com/tcdi/pgrx/compare/v0.9.6...v0.9.7
--

NOTE:  This cherry-picks the individual commits from PR #1180, updates the version to 0.9.7, and upgrades dependencies.  It needs to go straight to `master`, after which I'll tag/publish the release and merge back into develop.

I'm avoiding releasing all of `develop` because it contains the 16beta1 support and that doesn't need to go out as part of this.