### PR TITLE
fcinfo: fix incorrect length set in unsafe code

### DIFF
--- a/pgrx/src/fcinfo.rs
+++ b/pgrx/src/fcinfo.rs
@@ -285,8 +285,7 @@ mod pg_12_13_14_15 {
         let fcinfo = unsafe { fcinfo.as_mut() }.unwrap();
         unsafe {
             let nargs = fcinfo.nargs;
-            let len = std::mem::size_of::<pg_sys::NullableDatum>() * nargs as usize;
-            fcinfo.args.as_slice(len)[num].clone()
+            fcinfo.args.as_slice(nargs as usize)[num].clone()
         }
     }
 


### PR DESCRIPTION
according to `std::slice::from_raw_parts`, the len argument is the number of elements, not the number of bytes.