### PR TITLE
Array-walking is aligned

### DIFF
--- a/pgrx/src/datum/array.rs
+++ b/pgrx/src/datum/array.rs
@@ -119,15 +119,6 @@ impl<'a, T: FromDatum> Array<'a, T> {
             .map(|nonnull| NullKind::Bits(unsafe { &*nonnull.as_ptr() }))
             .unwrap_or(NullKind::Strict(nelems));
 
-        // The array-walking code assumes this is always the case, is it?
-        if let Layout { size: Size::Fixed(n), align, .. } = elem_layout {
-            let n: usize = n.into();
-            assert!(
-                n % (align.as_usize()) == 0,
-                "typlen does NOT include padding for fixed-width layouts!"
-            );
-        }
-
         // do a little two-step before jumping into the Cha-Cha Slide and figure out
         // which implementation is correct for the type of element in this Array.
         let slide_impl: ChaChaSlideImpl<T> = match elem_layout.pass {

--- a/pgrx/src/layout.rs
+++ b/pgrx/src/layout.rs
@@ -92,6 +92,13 @@ impl Align {
             Align::Double => TYPALIGN_DOUBLE,
         }) as _
     }
+
+    #[inline]
+    pub(crate) fn pad(self, size: usize) -> usize {
+        let size = size as usize;
+        let align = self.as_usize();
+        (size + (align - 1)) & !(align - 1)
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]


### PR DESCRIPTION
The alignment-handling code has been correct for some time.

Remove the questioning assert, extract the align-up pattern into a function on `layout::Align`, and precompute the fixed-size offset to use for fixed-size elements in arrays.